### PR TITLE
docs(handover): #183 and #186 landed, and the branch has a PR now

### DIFF
--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -18,19 +18,18 @@ issues / releases / ruleset intact). **Phase 4's repo side is done too** —
 `zwasm/tap/zwasm` (#181). Left to the user: phase 4 item 10 (verify from a
 clean `brew` state) and **phase 5** (cljw pin + wind-down).
 
-## In flight (2026-08-16)
+## In flight (2026-08-18)
 
-- **#186** (jit: trap on a null table funcptr instead of executing it) and
-  **#183** (ADR-0208 — gate WASI preview1 on the official testsuite): both
-  CI-green and mergeable, **awaiting maintainer review since 2026-08-14**.
-  Do not refresh them against `main` until the review lands.
+- **#200** (`develop/wasi-p1-official-impl`) — ADR-0208's D1/D2/D3: the
+  vendored `wasm32-wasip1` corpus (144 files) + `test/wasi/official_runner.zig`
+  + an **advisory** CI step. Draft, 3-OS green.
+- **Landed 2026-08-18**: #183 (ADR-0208 itself — Accepted), #186 (D-586 — the
+  JIT traps on a null table funcptr instead of executing it), #194 / #195 /
+  #196 (records).
 - **Landed 2026-08-16**: #190 (D-592 retracted — the build-cache mechanism it
   claimed does not hold; the real defect was `run_oob_trap` never re-running),
   #192 (the JIT realworld differential had no caller — now in `test-all` with
   denominator accounting), #191 / #193 (records).
-- `develop/wasi-p1-official-impl` carries #183's implementation — 147 files
-  (vendored corpus + runner + advisory gate), pushed, **no PR**; it lands with
-  the ADR once the review answers.
 - **Next dispatchable — the wasmtime differential is double fail-open.**
   `test/realworld/diff_runner.zig` has a `matched < 30` denominator gate that is
   bypassed on any host without a working wasmtime: two early returns precede it
@@ -89,11 +88,13 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
   spec lane is opt-in (`ZWASM_SPEC_ENGINE=jit`) and is NOT in CI, so that row
   is not currently re-derivable for both engines.
 - **WASI 0.1**: syscall SURFACE complete (46/46, ADR-0161). Behaviour against
-  the official wasi-testsuite was measured 2026-08-14 at **58/72 interp,
-  54/72 jit** (x86_64-linux; wasmtime 47.0.3 scores 72/72 through the same
-  harness) — nothing gated that until now. ADR-0208 (#183) proposes the gate
-  (D-582 infra, D-583 the 14 behaviour gaps). **0.2/CM** default-ON; **0.3
-  FULL on all 3 OSes** (official 45/45, 0 skip). Sandbox triad cross-engine.
+  the official wasi-testsuite measures **58/72 interp, 54/72 jit** on
+  x86_64-linux (2026-08-18, through #200's runner; wasmtime 47.0.3 scores
+  72/72 through the same harness) — **nothing gates that**, and the step #200
+  adds is advisory too. ADR-0208 is Accepted and decides the gate: D-582 the
+  corpus + runner infra, D-583 the 14 interp gaps that keep the step advisory
+  rather than blocking. **0.2/CM** default-ON; **0.3 FULL on all 3 OSes**
+  (official 45/45, 0 skip). Sandbox triad cross-engine.
 - **Surfaces**: C-API · Zig-API · lean CLI · memory-safety sound · dogfooded
   into cljw. Realworld 56/0 vs wasmtime under `--engine jit`, gating in
   `test-all` since 2026-08-16 (`test-realworld-diff-jit`) **on hosts where

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -20,16 +20,10 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
 
 ## In flight (2026-08-18)
 
-- **#200** (`develop/wasi-p1-official-impl`) — ADR-0208's D1/D2/D3: the
-  vendored `wasm32-wasip1` corpus (144 files) + `test/wasi/official_runner.zig`
-  + an **advisory** CI step. Draft, 3-OS green.
-- **Recently landed**: #183 + #197 (ADR-0208 — filed, then flipped to
-  Accepted), #186 + #198 (D-586 — the JIT traps on a null table funcptr
-  instead of executing it), #190 (D-592 retracted — the build-cache mechanism
-  it claimed does not hold; the real defect was `run_oob_trap` never
-  re-running), #192 (the JIT realworld differential had no caller — now in
-  `test-all` with denominator accounting), #191 / #193 / #194 / #195 / #196
-  (records). Dates and order: `git log` — they are not restated here.
+- **WASI preview1 conformance** (`develop/wasi-p1-official-impl`) — ADR-0208's
+  D1/D2/D3: the vendored `wasm32-wasip1` corpus,
+  `test/wasi/official_runner.zig`, and an **advisory** CI step. Delete this
+  entry when it lands; what already landed is `git log`, not a list here.
 - **Next dispatchable — the wasmtime differential is double fail-open.**
   `test/realworld/diff_runner.zig` has a `matched < 30` denominator gate that is
   bypassed on any host without a working wasmtime: two early returns precede it
@@ -89,12 +83,13 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
   is not currently re-derivable for both engines.
 - **WASI 0.1**: syscall SURFACE complete (46/46, ADR-0161). Behaviour against
   the official wasi-testsuite measures **58/72 interp, 54/72 jit** on
-  x86_64-linux (2026-08-18, through #200's runner; wasmtime 47.0.3 scores
-  72/72 through the same harness) — **nothing gates that**, and the step #200
-  adds is advisory too. ADR-0208 is Accepted and decides the gate: D-582 the
-  corpus + runner infra, D-583 the 14 interp gaps that keep the step advisory
-  rather than blocking. **0.2/CM** default-ON; **0.3 FULL on all 3 OSes**
-  (official 45/45, 0 skip). Sandbox triad cross-engine.
+  x86_64-linux (2026-08-18, through the runner on that branch; wasmtime scores
+  72/72 through the same harness — read locally at 47.0.3, while CI pins
+  45.0.0, so it is not re-derivable there: D-283) — **nothing gates that**, and
+  the CI step the branch adds is advisory too. ADR-0208 is Accepted and decides
+  the gate: D-582 the corpus + runner infra, D-583 the 14 interp gaps that keep
+  the step advisory rather than blocking. **0.2/CM** default-ON; **0.3 FULL on
+  all 3 OSes** (official 45/45, 0 skip). Sandbox triad cross-engine.
 - **Surfaces**: C-API · Zig-API · lean CLI · memory-safety sound · dogfooded
   into cljw. Realworld 56/0 vs wasmtime under `--engine jit`, gating in
   `test-all` since 2026-08-16 (`test-realworld-diff-jit`) **on hosts where

--- a/.dev/handover.md
+++ b/.dev/handover.md
@@ -23,13 +23,13 @@ clean `brew` state) and **phase 5** (cljw pin + wind-down).
 - **#200** (`develop/wasi-p1-official-impl`) — ADR-0208's D1/D2/D3: the
   vendored `wasm32-wasip1` corpus (144 files) + `test/wasi/official_runner.zig`
   + an **advisory** CI step. Draft, 3-OS green.
-- **Landed 2026-08-18**: #183 (ADR-0208 itself — Accepted), #186 (D-586 — the
-  JIT traps on a null table funcptr instead of executing it), #194 / #195 /
-  #196 (records).
-- **Landed 2026-08-16**: #190 (D-592 retracted — the build-cache mechanism it
-  claimed does not hold; the real defect was `run_oob_trap` never re-running),
-  #192 (the JIT realworld differential had no caller — now in `test-all` with
-  denominator accounting), #191 / #193 (records).
+- **Recently landed**: #183 + #197 (ADR-0208 — filed, then flipped to
+  Accepted), #186 + #198 (D-586 — the JIT traps on a null table funcptr
+  instead of executing it), #190 (D-592 retracted — the build-cache mechanism
+  it claimed does not hold; the real defect was `run_oob_trap` never
+  re-running), #192 (the JIT realworld differential had no caller — now in
+  `test-all` with denominator accounting), #191 / #193 / #194 / #195 / #196
+  (records). Dates and order: `git log` — they are not restated here.
 - **Next dispatchable — the wasmtime differential is double fail-open.**
   `test/realworld/diff_runner.zig` has a `matched < 30` denominator gate that is
   bypassed on any host without a working wasmtime: two early returns precede it


### PR DESCRIPTION
`.dev/handover.md` is the canonical fresh-session entry point, so a stale
line here is paid by every session that reads it. Three claims had gone
false:

- **#183 / #186 "both CI-green and mergeable, awaiting maintainer review
  since 2026-08-14"** — both merged 2026-08-18 (`85ea28f8a`, `e1e6925ab`).
- **"`develop/wasi-p1-official-impl` ... pushed, no PR"** — it is #200, and
  the file count was 147 against a measured 144.
- **"ADR-0208 (#183) *proposes* the gate"** — the ADR is Accepted. What is
  still open is the implementation, not the decision.

The first two are false on `main` today, independently of #200. The third is
worded to stay true after #200 lands — the CI step it adds is advisory, so
"nothing gates that" holds before and after — so no follow-up edit is owed.

#200 leaves `.dev/handover.md` untouched so the two do not contend for it.
