### PR TITLE
test(realworld): add the forced-interp differential lane

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -2251,8 +2251,9 @@ entries:
       and an unreached fixture now fail it, not just a mismatch — ADR-0210's rule); the misleading run
       stage was removed in the same change.
       ---
-      **OPEN, found while closing the above (2026-08-16): the paired lane is NOT the interpreter, so
-      `test-all` has no forced-interp result-check over the realworld corpus.** `diff_runner.zig`'s
+      **Forced-interp-gap reason DISCHARGED 2026-08-21 (issue #215).** As found while closing the above
+      (2026-08-16): the paired lane is NOT the interpreter, so
+      `test-all` had no forced-interp result-check over the realworld corpus. `diff_runner.zig`'s
       non-`--jit` lane calls `cli_run.runWasmCaptured` with default `Limits`, i.e. `engine = .auto`
       (`src/cli/run.zig:52`), and `.auto` calls `instantiateJit` FIRST and reaches the interp only where
       the JIT cannot instantiate (`src/api/instance.zig:945`). `run_realworld_run` (`cli_run.runWasm`) is
@@ -2264,8 +2265,14 @@ entries:
       fixture-dependent because it is whatever `.auto` picked. DISCHARGE: either pin the lane's engine
       (`Limits{ .engine = .interp }`, which costs the interp's wall-clock on every fixture — 9.76s for
       `emcc_fannkuch` alone) or state the lane as `.auto` everywhere and stop calling it interp. Not
-      closed here: this PR only corrected the prose (README / handover / build.zig comment) so nothing
-      claims an interp result-check that does not exist.
+      closed by the 2026-08-16 change: that PR only corrected the prose (README / handover / build.zig
+      comment) so nothing claimed an interp result-check that did not exist.
+      CLOSED by the `--interp` lane (issue #215): a fourth diff_runner lane pins the engine per fixture
+      and byte-diffs vs wasmtime — 52 of 56 gated in `test-all`, the 4 slowest enumerated as accounted
+      SKIP-INTERP-SLOW (re-measured 2026-08-21 x86_64-linux Debug: 35.7s `c_large_memory` / 21.0s
+      `rust_fib_compute` / 13.3s `go_json_marshal` / 11.7s `go_sort_benchmark`; the corpus total is
+      116.0s, the gated subset 34.3s). `zig build test-realworld-diff-interp` (`--interp-all`) covers
+      all 56 in one command.
       ---
       **OPEN, scoped not closed (2026-08-16): a wasmtime-less host makes this lane contribute nothing,
       silently.** `diff_runner` returns before the per-fixture loop when `resolveWasmtime` finds nothing,

--- a/build.zig
+++ b/build.zig
@@ -1117,20 +1117,39 @@ pub fn build(b: *std.Build) void {
 
     // `zig build test-realworld-diff-jit` — D-283 the real JIT-correctness net,
     // and the lane `test-all` depends on (NOT `test-realworld-diff`, which is the
-    // same runner minus `--jit`; depending on both would run the interp lane
-    // twice). Same wasmtime differential PLUS a `--jit` lane that runs each
+    // same runner minus the engine lanes; depending on both would run the shared
+    // lane twice). Same wasmtime differential PLUS a `--jit` lane that runs each
     // fixture via the WASI-aware `--engine jit` path (runWasmJitCaptured) +
     // byte-diffs stdout vs wasmtime. Superseded the run_runner_jit run-stage,
     // which ran with a null WASI host and so reported false traps.
     // Measured cost over the shared-lane-only step: +29s (19.3 → 48.3) on
     // x86_64-linux — a rounding error against the ~10 min core gate, which is
     // why this sits in the core gate rather than behind ZWASM_CI_EXTENDED.
+    // `--interp` (issue #215) adds the forced-interp lane to the same
+    // invocation: 52 of 56 fixtures byte-diffed vs wasmtime under
+    // `Limits{ .engine = .interp }`, the 4 slowest enumerated as accounted
+    // SKIP-INTERP-SLOW (81.7s of the corpus's 116.0s forced-interp total,
+    // x86_64-linux Debug 2026-08-21 — the lane's own +34s stays in the JIT
+    // lane's cost class). Full-corpus coverage: `test-realworld-diff-interp`.
     const run_realworld_diff_jit = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff_jit.addArg(b.pathFromRoot("test/realworld/wasm"));
     run_realworld_diff_jit.addArg("--jit");
+    run_realworld_diff_jit.addArg("--interp");
     run_realworld_diff_jit.has_side_effects = true;
-    const test_realworld_diff_jit_step = b.step("test-realworld-diff-jit", "Realworld differential incl. the gating WASI-aware JIT lane (D-283)");
+    const test_realworld_diff_jit_step = b.step("test-realworld-diff-jit", "Realworld differential incl. the gating WASI-aware JIT and forced-interp lanes (D-283, #215)");
     test_realworld_diff_jit_step.dependOn(&run_realworld_diff_jit.step);
+
+    // `zig build test-realworld-diff-interp` — the forced-interp differential
+    // over the FULL corpus (`--interp-all`: the enumerated-slow fixtures run
+    // too, under a 240s per-fixture deadline). Manual entry point, NOT in
+    // `test-all` — the 4 enumerated fixtures alone are ~82s on x86_64-linux
+    // Debug. One command re-derives interp-vs-wasmtime for all 56.
+    const run_realworld_diff_interp = b.addRunArtifact(realworld_diff_runner_exe);
+    run_realworld_diff_interp.addArg(b.pathFromRoot("test/realworld/wasm"));
+    run_realworld_diff_interp.addArg("--interp-all");
+    run_realworld_diff_interp.has_side_effects = true;
+    const test_realworld_diff_interp_step = b.step("test-realworld-diff-interp", "Full-corpus forced-interp differential incl. the enumerated-slow fixtures (manual; not in test-all)");
+    test_realworld_diff_interp_step.dependOn(&run_realworld_diff_interp.step);
 
     // `zig build test-api-zig-facade` — Phase 10 / §10.J / J.6.
     // Walks the realworld corpus driving each fixture through the
@@ -1461,13 +1480,13 @@ pub fn build(b: *std.Build) void {
     // fixtures") — they are SKIP, not FAIL, so the runner
     // exits zero. Hosts without `wasmtime` on PATH degrade to
     // SKIP-WASMTIME-FAIL gracefully and do not break the gate.
-    // The `--jit` variant, NOT `run_realworld_diff`: same runner, same default-
-    // engine lane, plus the gating JIT lane — so one dependency, no double run
-    // of the shared lane. Note what that shared lane is NOT: it calls
+    // The `--jit --interp` variant, NOT `run_realworld_diff`: same runner, same
+    // default-engine lane, plus the gating JIT and forced-interp lanes — so one
+    // dependency, no double run of the shared lane. The shared lane itself calls
     // `runWasmCaptured` with default `Limits`, i.e. `.auto`, which tries the JIT
-    // first and reaches the interp only where the JIT cannot instantiate. It is
-    // not an interp result-check, and `test-all` currently has none over the
-    // realworld corpus.
+    // first and reaches the interp only where the JIT cannot instantiate; the
+    // `--interp` lane (issue #215) is what pins the engine and result-checks the
+    // corpus on the interpreter (52 of 56 — 4 enumerated accounted skips).
     test_all_step.dependOn(&run_realworld_diff_jit.step);
     test_all_step.dependOn(&run_wast_2_0.step);
     // §10 / 10.T-2b: wasm-3.0 assertion runner skeleton — enumerates

--- a/test/realworld/README.md
+++ b/test/realworld/README.md
@@ -11,21 +11,26 @@ runners exercise the corpus from different angles:
 | `runner.zig`          | `zig build test-realworld`          | parse + validate + lower (no execute)                                     |
 | `run_runner.zig`      | `zig build test-realworld-run`      | parse + execute via `cli_run.runWasm`; reports exit code per fixture      |
 | `diff_runner.zig`     | `zig build test-realworld-diff`     | wasmtime stdout vs `cli_run.runWasmCaptured` byte compare; gate at 30+       |
-| `diff_runner.zig --jit` | `zig build test-realworld-diff-jit` | the above PLUS wasmtime vs `--engine jit` byte compare; gates on mismatch, on a skip, and on any fixture the lane failed to account for |
+| `diff_runner.zig --jit --interp` | `zig build test-realworld-diff-jit` | the above PLUS wasmtime vs `--engine jit`, and wasmtime vs forced-interp (52 of 56; 4 enumerated slow skips) — each engine lane gates on mismatch, on a skip, and on any fixture it failed to account for |
+| `diff_runner.zig --interp-all` | `zig build test-realworld-diff-interp` | the forced-interp differential over the FULL corpus, enumerated-slow fixtures included (manual; ~2 min) |
 | `run_runner_jit.zig`  | `zig build test-realworld-run-jit`  | JIT **compilation** of every fixture (`compileWasm`) — no execution        |
 
 `test-all` depends on `test-realworld-diff-jit`, not on `test-realworld-diff`:
-same runner, same shared lane, plus the gating JIT lane — one dependency, no
-double run of the shared lane.
+same runner, same shared lane, plus the gating JIT and forced-interp lanes —
+one dependency, no double run of the shared lane.
 
 **Careful about which engine each runner uses.** `runWasm` / `runWasmCaptured`
 take default `Limits`, i.e. `engine = .auto`, and `.auto` tries the JIT first
 and reaches the interp only where the JIT cannot instantiate. So neither
-`run_runner.zig` nor `diff_runner.zig`'s shared lane is an interp check —
-measured 2026-08-16, 7 of the 56 fixtures provably do not take the interp under
-the default (the interp needs >3s where the default finishes; `emcc_fannkuch`
-is 9.76s vs 0.12s). Only `--engine interp` forces it, and nothing in `test-all`
-does. `test/realworld` therefore has no interp result-check today.
+`run_runner.zig` nor `diff_runner.zig`'s shared lane is an interp check.
+The `--interp` lane (issue #215) is what pins the engine
+(`Limits{ .engine = .interp }`) and byte-diffs the result against wasmtime.
+Its gating subset excludes 4 fixtures whose forced-interp wall-clock is ≥10s
+(`c_large_memory` 35.7s / `rust_fib_compute` 21.0s / `go_json_marshal` 13.3s /
+`go_sort_benchmark` 11.7s — x86_64-linux Debug, 2026-08-21); they are printed
+as `SKIP-INTERP-SLOW`, counted in the lane's identity, and covered by the
+manual `test-realworld-diff-interp` step, so no exclusion is silent
+(ADR-0210) and full-corpus interp coverage is one command away.
 
 **Which runners answer "does JIT-emitted code compute the right answer?"** —
 `diff_runner.zig --jit` (56 fixtures vs wasmtime), and in `test-all` also
@@ -33,7 +38,8 @@ does. `test/realworld` therefore has no interp result-check today.
 `run_aot_diff` (56 of its 63 vs the `.cwasm` lane). They differ by oracle:
 an independent runtime, a checked-in expectation, and zwasm itself.
 `run_runner_jit.zig` answers none of them — it only says the backend encoded
-every fixture.
+every fixture. The same question for the **interpreter** is answered by the
+`--interp` lane above (52 vs wasmtime in `test-all`, 56 via the manual step).
 
 ## Argv convention
 

--- a/test/realworld/diff_runner.zig
+++ b/test/realworld/diff_runner.zig
@@ -30,17 +30,30 @@
 //! The `--jit` lane (D-283) re-runs the same corpus through the
 //! WASI-aware `--engine jit` path and byte-diffs against the same
 //! wasmtime reference — the realworld JIT-correctness net. It is
-//! the lane `test-all` runs, and it gates on every way the JIT can
+//! a lane `test-all` runs, and it gates on every way the JIT can
 //! fail to answer for a fixture the oracle ran: MISMATCH-JIT,
 //! SKIP-JIT-*, and — as a structural guard — a fixture that never
 //! reached the lane (see the gate at the bottom of `main`).
 //! Counting only mismatches would let a lane that verified nothing
 //! report success.
 //!
+//! The `--interp` lane (issue #215) is the same differential with the
+//! engine PINNED to the interpreter (`Limits{ .engine = .interp }`, the
+//! D-496 selection surface). It exists because both default-`Limits`
+//! realworld runners resolve `.auto`, which prefers the JIT — so without
+//! it no lane in `test-all` executes the realworld corpus on the interp
+//! and checks the result. It gates like the JIT lane (mismatch, skip,
+//! and shortfall all fatal; identity printed and checked), with one more
+//! bucket: fixtures whose forced-interp wall-clock dominates the corpus
+//! are enumerated out as SKIP-INTERP-SLOW — printed and counted, never
+//! silent (ADR-0210) — and stay covered by the manual `--interp-all`
+//! variant.
+//!
 //! Usage:
-//!   zig build test-realworld-diff      # interp lane only
-//!   zig build test-realworld-diff-jit  # + the gating JIT lane (test-all)
-//!   diff_runner_exe <corpus-dir> [--jit|--aot|--wasmer]
+//!   zig build test-realworld-diff         # shared (.auto) lane only
+//!   zig build test-realworld-diff-jit     # + the gating JIT + forced-interp lanes (test-all)
+//!   zig build test-realworld-diff-interp  # forced-interp over the FULL corpus (manual)
+//!   diff_runner_exe <corpus-dir> [--jit|--aot|--wasmer|--interp|--interp-all]
 
 const std = @import("std");
 
@@ -85,6 +98,35 @@ fn resetPreopenScratch(io: std.Io, cwd: std.Io.Dir) !void {
 /// differential. Tune up once a subprocess-based (timeout-able) lane lands.
 const aot_size_cap: usize = 64 * 1024;
 
+/// Fixtures enumerated OUT of the gating `--interp` lane. Cutline: forced-
+/// interp wall-clock >= 10s (x86_64-linux Debug, main @ 053f0c942,
+/// 2026-08-21) — together 81.7s of the corpus's 116.0s total, versus +34s
+/// for the 52 fixtures the gating lane keeps (the cost class the JIT lane's
+/// +29s established for `test-all`). Each is printed as SKIP-INTERP-SLOW and
+/// counted in the lane's identity (ADR-0210: an exclusion is enumerated and
+/// accounted, never silent); `--interp-all` (the manual
+/// `test-realworld-diff-interp` step) runs them too, so full-corpus interp
+/// coverage stays one command away. A row whose fixture vanishes from the
+/// corpus fails the lane (stale-entry check in the gate) rather than rotting.
+const InterpSlowSkip = struct { name: []const u8, measured: []const u8 };
+const interp_slow_skips = [_]InterpSlowSkip{
+    .{ .name = "c_large_memory.wasm", .measured = "35.7s" },
+    .{ .name = "rust_fib_compute.wasm", .measured = "21.0s" },
+    .{ .name = "go_json_marshal.wasm", .measured = "13.3s" },
+    .{ .name = "go_sort_benchmark.wasm", .measured = "11.7s" },
+};
+
+/// Per-fixture deadline for the gating `--interp` lane, via the cooperative
+/// interrupt the interp dispatch loop polls (ADR-0179 #3a-4) — the interp
+/// runs in-process, so like the JIT lane a hang would otherwise wedge
+/// `test-all` to CI's cap instead of failing loudly. Slowest gated fixture
+/// measured 9.5s (`emcc_fannkuch`, x86_64-linux Debug, 2026-08-21), so 60s is
+/// ~6x headroom for a slower host while still turning a hang into a fatal
+/// SKIP-INTERP-TRAP. `--interp-all` raises it to 240s: the enumerated
+/// fixtures it re-admits measure up to 35.7s.
+const interp_deadline_ms: u64 = 60_000;
+const interp_all_deadline_ms: u64 = 240_000;
+
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
     const gpa = init.gpa;
@@ -116,9 +158,17 @@ pub fn main(init: std.process.Init) !void {
     //             net: GATING, wired into `test-all`, and the realworld gate
     //             whose oracle is an independent runtime rather than a
     //             checked-in expectation or zwasm itself.
+    //   --interp  run via the captured path with the engine pinned to the
+    //             interpreter (`Limits{ .engine = .interp }`) + byte-diff vs
+    //             wasmtime (issue #215). GATING, wired into `test-all`
+    //             alongside `--jit`; the `interp_slow_skips` fixtures are
+    //             enumerated skips. `--interp-all` is the same lane with the
+    //             skip table ignored and a larger deadline (manual step).
     var aot_lane = false;
     var wasmer_lane = false;
     var jit_lane = false;
+    var interp_lane = false;
+    var interp_all = false;
     while (arg_it.next()) |a| {
         if (std.mem.eql(u8, a, "--aot")) {
             aot_lane = true;
@@ -126,6 +176,11 @@ pub fn main(init: std.process.Init) !void {
             wasmer_lane = true;
         } else if (std.mem.eql(u8, a, "--jit")) {
             jit_lane = true;
+        } else if (std.mem.eql(u8, a, "--interp")) {
+            interp_lane = true;
+        } else if (std.mem.eql(u8, a, "--interp-all")) {
+            interp_lane = true;
+            interp_all = true;
         }
     }
 
@@ -215,6 +270,26 @@ pub fn main(init: std.process.Init) !void {
     var jit_oracle_failed: u32 = 0;
     var jit_pre_oracle: u32 = 0;
 
+    // Forced-interp lane (issue #215). Same bucketing discipline as the JIT
+    // lane, with two differences: the identity has one extra bucket (the
+    // enumerated slow skips), and oracle-unspawnable gets its OWN counter
+    // instead of reusing `skipped_wasmtime_fail` — an enumerated fixture whose
+    // oracle also fails to spawn must land in exactly one interp bucket, and
+    // the shared counter cannot know about the enumeration.
+    var interp_matched: u32 = 0;
+    var interp_mismatched: u32 = 0;
+    var interp_skipped: u32 = 0;
+    var interp_skipped_empty: u32 = 0;
+    var interp_eligible: u32 = 0;
+    var interp_oracle_failed: u32 = 0;
+    var interp_unspawnable: u32 = 0;
+    var interp_pre_oracle: u32 = 0;
+    var interp_enum_skipped: u32 = 0;
+    // Which `interp_slow_skips` rows matched a real corpus file this walk —
+    // the gate fails on a row that matched none (stale entry), so the table
+    // cannot silently outlive a renamed or deleted fixture.
+    var interp_enum_seen = [_]bool{false} ** interp_slow_skips.len;
+
     var it = dir.iterate();
     while (try it.next(io)) |entry| {
         if (entry.kind != .file) continue;
@@ -228,9 +303,33 @@ pub fn main(init: std.process.Init) !void {
             try stdout.print("SKIP-V2-READ  {s}\n", .{entry.name});
             skipped_v2 += 1;
             jit_pre_oracle += 1;
+            interp_pre_oracle += 1;
             continue;
         };
         defer gpa.free(bytes);
+
+        // Enumerated slow-skip check for the gating `--interp` lane — BEFORE
+        // the oracle spawn on purpose: the exclusion is a corpus-level property
+        // of the fixture, so it must not also land in an oracle-side bucket (a
+        // fixture in two buckets breaks the identity on exactly the host where
+        // it matters, e.g. wasmtime-unusable, where every spawn fails).
+        const interp_enum_measured: ?[]const u8 = blk: {
+            if (!interp_lane or interp_all) break :blk null;
+            for (interp_slow_skips, 0..) |row, i| {
+                if (std.mem.eql(u8, row.name, entry.name)) {
+                    interp_enum_seen[i] = true;
+                    break :blk row.measured;
+                }
+            }
+            break :blk null;
+        };
+        if (interp_enum_measured) |measured| {
+            try stdout.print(
+                "  SKIP-INTERP-SLOW  {s} (enumerated: forced-interp {s} measured; excluded from the gating lane, covered by --interp-all)\n",
+                .{ entry.name, measured },
+            );
+            interp_enum_skipped += 1;
+        }
 
         const needs_preopen = fixtureNeedsPreopen(entry.name);
         // `try`, not a categorised skip: being unable to create a directory
@@ -257,6 +356,7 @@ pub fn main(init: std.process.Init) !void {
         }) catch |err| {
             try stdout.print("SKIP-WASMTIME-FAIL  {s}: {s}\n", .{ entry.name, @errorName(err) });
             skipped_wasmtime_fail += 1;
+            if (interp_lane and interp_enum_measured == null) interp_unspawnable += 1;
             continue;
         };
         defer gpa.free(wt_result.stdout);
@@ -281,27 +381,37 @@ pub fn main(init: std.process.Init) !void {
             jit_oracle_failed += 1;
         }
 
+        // Same owed-a-verdict rule as the JIT lane, minus the enumerated
+        // fixtures — those are already in their own bucket above.
+        const interp_owed = interp_lane and wt_exit == 0 and interp_enum_measured == null;
+        if (interp_owed) interp_eligible += 1;
+        if (interp_lane and wt_exit != 0 and interp_enum_measured == null) {
+            try stdout.print("  ORACLE-FAILED-INTERP  {s} (wasmtime exit={d} — outside the differential's scope)\n", .{ entry.name, wt_exit });
+            interp_oracle_failed += 1;
+        }
+
         // Mirror wasmtime's default of `argv[0] = <wasm filename>`
         // so guests like `c_hello_wasi` that print argv[0] produce
         // identical bytes.
         const v2_argv: [1][]const u8 = .{entry.name};
 
-        // The AOT and JIT lanes run BEFORE the interp, not after. Neither reads
-        // an interp result — only `bytes` and the wasmtime reference — and every
-        // exit from the interp block below (its error `catch`, SKIP-V2-TRAP,
-        // SKIP-EMPTY) is a `continue` that would otherwise deny these lanes a
-        // fixture the oracle DID run. That mattered once the JIT lane started
-        // gating on its denominator: an interp-side skip, which the interp lane
-        // itself tolerates, failed the JIT gate with the wrong explanation.
+        // The AOT, JIT, and forced-interp lanes run BEFORE the shared (.auto)
+        // lane, not after. None reads a shared-lane result — only `bytes` and
+        // the wasmtime reference — and every exit from the shared block below
+        // (its error `catch`, SKIP-V2-TRAP, SKIP-EMPTY) is a `continue` that
+        // would otherwise deny these lanes a fixture the oracle DID run. That
+        // mattered once the JIT lane started gating on its denominator: a
+        // shared-lane skip, which that lane itself tolerates, failed the JIT
+        // gate with the wrong explanation.
         // The wasmer lane genuinely needs `v2_stdout`, so it stays below.
         //
-        // BISECT NOTE: this puts up to two in-process native executions ahead of
-        // the shared lane's run of the same fixture. D-489 investigated exactly
-        // that class — tinygo_json diverged under the diff runner but not
-        // standalone, an in-process ripple (`zig build d489-repro`). Measured
-        // green on x86_64-linux across all three lanes after the move, but if a
-        // shared-lane MISMATCH ever appears on another host, suspect this
-        // ordering before the engines.
+        // BISECT NOTE: this puts up to three in-process executions (two native,
+        // one interpreted) ahead of the shared lane's run of the same fixture.
+        // D-489 investigated exactly that class — tinygo_json diverged under
+        // the diff runner but not standalone, an in-process ripple (`zig build
+        // d489-repro`). Measured green on x86_64-linux across all lanes after
+        // the move, but if a shared-lane MISMATCH ever appears on another
+        // host, suspect this ordering before the engines.
         //
         // Flush per fixture so incremental output shows progress.
         if (aot_lane) {
@@ -329,6 +439,18 @@ pub fn main(init: std.process.Init) !void {
                 .mismatch => jit_mismatched += 1,
                 .skip => jit_skipped += 1,
                 .skip_empty => jit_skipped_empty += 1,
+            }
+            try stdout.flush();
+        }
+
+        if (interp_owed) {
+            if (needs_preopen) try resetPreopenScratch(io, cwd);
+            const deadline_ms: u64 = if (interp_all) interp_all_deadline_ms else interp_deadline_ms;
+            switch (try interpCompare(gpa, io, bytes, entry.name, &v2_argv, needs_preopen, wt_stdout, wt_exit, deadline_ms, stdout)) {
+                .match => interp_matched += 1,
+                .mismatch => interp_mismatched += 1,
+                .skip => interp_skipped += 1,
+                .skip_empty => interp_skipped_empty += 1,
             }
             try stdout.flush();
         }
@@ -428,6 +550,21 @@ pub fn main(init: std.process.Init) !void {
             .{ total, jit_eligible, jit_oracle_failed, skipped_wasmtime_fail, jit_pre_oracle, if (jit_denominator == total) "CLOSED" else "OPEN" },
         );
     }
+    if (interp_lane) {
+        try stdout.print(
+            "diff_runner [interp]: {d}/{d} matched vs wasmtime, {d} mismatched, {d} skipped (interp-unsupported / trap), " ++
+                "{d} skipped-empty, {d} unaccounted — GATING (fatal on mismatch, skip, or shortfall)\n",
+            .{ interp_matched, interp_eligible, interp_mismatched, interp_skipped, interp_skipped_empty, interp_eligible -| (interp_matched + interp_mismatched + interp_skipped + interp_skipped_empty) },
+        );
+        // Same rule-4 print as the JIT lane, one bucket wider: the enumerated
+        // slow skips are part of the corpus-level denominator, so a fixture
+        // enumerated out is visibly NOT part of the `{d}/{d}` coverage ratio.
+        const interp_denominator = interp_eligible + interp_enum_skipped + interp_oracle_failed + interp_unspawnable + interp_pre_oracle;
+        try stdout.print(
+            "diff_runner [interp] RECONCILE: total {d} = eligible {d} + enumerated-slow {d} + oracle-failed {d} + oracle-unspawnable {d} + dropped-before-oracle {d} → {s}\n",
+            .{ total, interp_eligible, interp_enum_skipped, interp_oracle_failed, interp_unspawnable, interp_pre_oracle, if (interp_denominator == total) "CLOSED" else "OPEN" },
+        );
+    }
     // Flush the summary unconditionally: the green path (no mismatch, matched
     // >= 30) returns at the bottom WITHOUT hitting any of the branch-local
     // flushes below, so the summary line would otherwise be lost in the
@@ -489,6 +626,62 @@ pub fn main(init: std.process.Init) !void {
                 // runs at most once per eligible fixture), but a gate that panics
                 // on an impossible state is worse than one that still reports.
                 .{ accounted, jit_eligible, jit_eligible -| accounted },
+            );
+            try stdout.flush();
+            std.process.exit(1);
+        }
+    }
+    // Forced-interp lane gates (issue #215) — the JIT lane's arms, plus the
+    // stale-entry check on the enumerated-skip table. Vacuous on wasmtime-less
+    // and wasmtime-unusable hosts for the same reason the JIT gates are:
+    // `interp_eligible` stays 0 there, and the enumerated bucket is counted
+    // before the oracle spawn so the identity still closes.
+    if (interp_lane) {
+        const interp_accounted = interp_matched + interp_mismatched + interp_skipped + interp_skipped_empty;
+        if (interp_mismatched != 0) {
+            try stdout.print("error: interp lane byte-mismatched vs wasmtime on {d} fixture(s)\n", .{interp_mismatched});
+            try stdout.flush();
+            std.process.exit(1);
+        }
+        if (interp_skipped != 0) {
+            try stdout.print(
+                "error: interp lane could not complete {d} of {d} fixture(s) the oracle answered for; a skip is " ++
+                    "an unverified fixture, not a pass (fix the interp gap or enumerate the exclusion deliberately)\n",
+                .{ interp_skipped, interp_eligible },
+            );
+            try stdout.flush();
+            std.process.exit(1);
+        }
+        // Only the gating config consults the table, so only it can vouch for
+        // the rows; `--interp-all` never matches entries against the corpus.
+        if (!interp_all) {
+            for (interp_slow_skips, interp_enum_seen) |row, seen| {
+                if (!seen) {
+                    try stdout.print(
+                        "error: interp lane enumerated-skip entry '{s}' matched no fixture in the corpus — " ++
+                            "stale entry; remove the row or restore the fixture\n",
+                        .{row.name},
+                    );
+                    try stdout.flush();
+                    std.process.exit(1);
+                }
+            }
+        }
+        const interp_denominator = interp_eligible + interp_enum_skipped + interp_oracle_failed + interp_unspawnable + interp_pre_oracle;
+        if (interp_denominator != total) {
+            try stdout.print(
+                "error: interp lane accounting OPEN — {d} of {d} fixture(s) fall in no bucket; the matched " ++
+                    "ratio is against the eligible set and cannot be read as corpus coverage\n",
+                .{ total -| interp_denominator, total },
+            );
+            try stdout.flush();
+            std.process.exit(1);
+        }
+        if (interp_accounted != interp_eligible) {
+            try stdout.print(
+                "error: interp lane accounted for {d} of {d} fixture(s) the oracle answered for — {d} left the " ++
+                    "corpus without an interp verdict; a `continue` was added above the lane in the loop\n",
+                .{ interp_accounted, interp_eligible, interp_eligible -| interp_accounted },
             );
             try stdout.flush();
             std.process.exit(1);
@@ -699,6 +892,56 @@ fn jitCompare(
     }
     if (std.mem.eql(u8, wt_stdout, jit_stdout.items)) return .match;
     try out.print("  MISMATCH-JIT  {s} (wasmtime={d} bytes, jit={d} bytes)\n", .{ name, wt_stdout.len, jit_stdout.items.len });
+    return .mismatch;
+}
+
+/// Outcome of the forced-interp lane for one fixture — mirrors `JitOutcome`.
+const InterpOutcome = enum { match, mismatch, skip, skip_empty };
+
+/// Run `bytes` through the captured-run path with the engine PINNED to the
+/// interpreter (`Limits{ .engine = .interp }`, the D-496 selection surface —
+/// same forcing as CLI `--engine interp`) and byte-compare vs `wt_stdout`.
+/// This is the lane that makes "the realworld corpus runs on the interp and
+/// the result is checked" true (issue #215): both default-`Limits` realworld
+/// runners resolve `.auto`, which prefers the JIT, so before this lane an
+/// interp-only miscompile in code these fixtures exercise could pass every
+/// realworld gate. Skip semantics mirror the JIT lane, and as there a skip is
+/// fatal in the caller's gate. `deadline_ms` arms the cooperative interrupt
+/// the interp dispatch loop polls (ADR-0179 #3a-4): the guest runs in-process,
+/// so a hang becomes a fatal SKIP-INTERP-TRAP instead of wedging `test-all`.
+fn interpCompare(
+    gpa: std.mem.Allocator,
+    io: std.Io,
+    bytes: []const u8,
+    name: []const u8,
+    argv: []const []const u8,
+    needs_preopen: bool,
+    wt_stdout: []const u8,
+    wt_exit: u8,
+    deadline_ms: u64,
+    out: anytype,
+) !InterpOutcome {
+    var interp_stdout: std.ArrayList(u8) = .empty;
+    defer interp_stdout.deinit(gpa);
+    const preopens: []const cli_run.PreopenDir = if (needs_preopen)
+        &.{.{ .host_path = preopen_scratch, .guest_path = "." }}
+    else
+        &.{};
+    const limits: cli_run.Limits = .{ .engine = .interp, .timeout_ms = deadline_ms };
+    const interp_exit: u8 = cli_run.runWasmCapturedOpts(gpa, io, bytes, argv, &interp_stdout, null, preopens, &.{}, &.{}, null, limits) catch |err| {
+        try out.print("  SKIP-INTERP-RUN  {s}: {s}\n", .{ name, @errorName(err) });
+        return .skip;
+    };
+    if (interp_exit != 0 and wt_exit == 0) {
+        try out.print("  SKIP-INTERP-TRAP  {s} (interp exit={d}, wasmtime exit=0 — interp could not complete)\n", .{ name, interp_exit });
+        return .skip;
+    }
+    if (wt_stdout.len == 0 and interp_stdout.items.len == 0) {
+        try out.print("  SKIP-INTERP-EMPTY  {s}\n", .{name});
+        return .skip_empty;
+    }
+    if (std.mem.eql(u8, wt_stdout, interp_stdout.items)) return .match;
+    try out.print("  MISMATCH-INTERP  {s} (wasmtime={d} bytes, interp={d} bytes)\n", .{ name, wt_stdout.len, interp_stdout.items.len });
     return .mismatch;
 }
 

--- a/test/realworld/diff_runner.zig
+++ b/test/realworld/diff_runner.zig
@@ -299,20 +299,15 @@ pub fn main(init: std.process.Init) !void {
         const fixture_path = try std.fmt.allocPrint(gpa, "{s}/{s}", .{ corpus_dir, entry.name });
         defer gpa.free(fixture_path);
 
-        const bytes = dir.readFileAlloc(io, entry.name, gpa, .limited(64 << 20)) catch {
-            try stdout.print("SKIP-V2-READ  {s}\n", .{entry.name});
-            skipped_v2 += 1;
-            jit_pre_oracle += 1;
-            interp_pre_oracle += 1;
-            continue;
-        };
-        defer gpa.free(bytes);
-
         // Enumerated slow-skip check for the gating `--interp` lane — BEFORE
-        // the oracle spawn on purpose: the exclusion is a corpus-level property
-        // of the fixture, so it must not also land in an oracle-side bucket (a
-        // fixture in two buckets breaks the identity on exactly the host where
-        // it matters, e.g. wasmtime-unusable, where every spawn fails).
+        // the read and the oracle spawn on purpose. The exclusion is a
+        // corpus-level property of the fixture NAME, so it must land in
+        // exactly one interp bucket whatever else fails for the fixture:
+        // matched after the read, the stale-entry gate would misreport an
+        // unreadable-but-present enumerated fixture as "no such fixture";
+        // counted after an oracle-side skip, the same fixture would land in
+        // two buckets and break the identity on exactly the host where it
+        // matters (e.g. wasmtime-unusable, where every spawn fails).
         const interp_enum_measured: ?[]const u8 = blk: {
             if (!interp_lane or interp_all) break :blk null;
             for (interp_slow_skips, 0..) |row, i| {
@@ -330,6 +325,16 @@ pub fn main(init: std.process.Init) !void {
             );
             interp_enum_skipped += 1;
         }
+
+        const bytes = dir.readFileAlloc(io, entry.name, gpa, .limited(64 << 20)) catch {
+            try stdout.print("SKIP-V2-READ  {s}\n", .{entry.name});
+            skipped_v2 += 1;
+            jit_pre_oracle += 1;
+            // Exactly-one-bucket: an enumerated fixture is already accounted.
+            if (interp_lane and interp_enum_measured == null) interp_pre_oracle += 1;
+            continue;
+        };
+        defer gpa.free(bytes);
 
         const needs_preopen = fixtureNeedsPreopen(entry.name);
         // `try`, not a categorised skip: being unable to create a directory

--- a/test/realworld/diff_runner.zig
+++ b/test/realworld/diff_runner.zig
@@ -120,12 +120,15 @@ const interp_slow_skips = [_]InterpSlowSkip{
 /// interrupt the interp dispatch loop polls (ADR-0179 #3a-4) — the interp
 /// runs in-process, so like the JIT lane a hang would otherwise wedge
 /// `test-all` to CI's cap instead of failing loudly. Slowest gated fixture
-/// measured 9.5s (`emcc_fannkuch`, x86_64-linux Debug, 2026-08-21), so 60s is
-/// ~6x headroom for a slower host while still turning a hang into a fatal
-/// SKIP-INTERP-TRAP. `--interp-all` raises it to 240s: the enumerated
-/// fixtures it re-admits measure up to 35.7s.
-const interp_deadline_ms: u64 = 60_000;
-const interp_all_deadline_ms: u64 = 240_000;
+/// measured 9.5s (`emcc_fannkuch`, x86_64-linux Debug, 2026-08-21); 120s is
+/// ~12x headroom, sized to the JIT lane's precedent (60s ≈ 18x its 3.4s
+/// slowest) rather than to the one host measured — the deadline costs
+/// nothing on the green path, and what it must not do is turn a slow CI
+/// leg into a fatal SKIP-INTERP-TRAP that reads as an interp bug. A real
+/// hang still fails loudly, 120s per hung fixture. `--interp-all` uses
+/// 480s (~13x): the enumerated fixtures it re-admits measure up to 35.7s.
+const interp_deadline_ms: u64 = 120_000;
+const interp_all_deadline_ms: u64 = 480_000;
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;


### PR DESCRIPTION
Adds the forced-interp result-checking lane over the realworld corpus.

## Measurement first (per the issue)

Forced-interp wall-clock, all 56 fixtures, main @ 053f0c942 (x86_64-linux
Debug, 2026-08-21): total 116.0s, and four fixtures carry 81.7s of it —
`c_large_memory` 35.7s, `rust_fib_compute` 21.0s, `go_json_marshal` 13.3s,
`go_sort_benchmark` 11.7s; next-slowest 9.5s. The issue's 2026-08-16 numbers
are stale (tail is 3.6x the ~9.8s max recorded there). All 56 match wasmtime
byte-for-byte under forced interp today.

## Design: subset + enumerated accounted skips

`diff_runner --interp` pins the engine (`Limits{ .engine = .interp }`) and
byte-diffs vs wasmtime, gating like the JIT lane (mismatch / skip / shortfall
fatal; RECONCILE identity printed and checked). The 4 outliers are
SKIP-INTERP-SLOW — printed, counted in the identity, stale-entry-guarded —
and `zig build test-realworld-diff-interp` (`--interp-all`) re-derives all 56
in one command. Rejected: full corpus in test-all (+116s on every PR for 4
fixtures' 82s). Untaken: self-differential vs committed expected files —
orthogonal, would keep the lane alive on wasmtime-less hosts (relevant to
issue #213).

## Placement (maintainer call per ADR-0212 D1)

In test-all via the existing test-realworld-diff-jit invocation. The gated
52 fixtures' forced-interp wall-clock sums to 34.3s — the cost class the JIT
lane's accepted +29s established (the step, shared+JIT+interp run-only, is
80.8s on this host). If too heavy: drop `--interp` from that step and keep
the manual step as the entry point — one-line change.

## Verified red, not just green

- interp-only miscompile (i32.add interp handler locally patched to `+% 1`):
  2 MISMATCH-INTERP + 50 fatal SKIP-INTERP-TRAP, exit 1, JIT lane still 56/56
  CLOSED — also proves the engine pin (an `.auto` lane would not notice an
  interp-handler patch).
- `c_large_memory.wasm` hidden from the corpus: stale-entry error, exit 1.
- interp-lane-only fixture drop injected in the loop: interp RECONCILE OPEN
  (51+4=55≠56), exit 1, JIT lane still CLOSED.
- Green: interp 52/52 matched + 4 enumerated skips, identity CLOSED; the
  manual full step 56/56 matched CLOSED (2m15s); one full `zig build
  test-all` pass green (3m56s, x86_64-linux Debug).

D-283's "no forced-interp result-check" reason is marked discharged (minimal
edit; comments in the new lane mirror the JIT lane's accounting comments).

Fixes #215
