### PR TITLE
docs(development): write down how a release is cut

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -111,6 +111,28 @@ bash scripts/ci_gate.sh                    # core (fmt + test-all)
 ZWASM_CI_EXTENDED=1 bash scripts/ci_gate.sh  # + lint/DCE/AOT/zone checks (Unix)
 ```
 
+## Cutting a release
+
+Releases are cut by hand, by a maintainer, and never by automation acting on
+its own (ADR-0156). Three manual steps; the rest is the `release` workflow.
+
+1. **Bump `.version` in `build.zig.zon`.** SemVer against the previous tag —
+   `git log v<previous>..main --no-merges` is the input to that call.
+2. **Add the CHANGELOG section** for the new version, dated.
+3. **Push the tag.** `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds
+and packages all four targets in ReleaseSafe (macOS aarch64, Linux
+x86_64/aarch64, Windows x86_64), then creates the GitHub Release with the
+archives and `SHA256SUMS`. Nothing else in this repository needs touching.
+
+**One step is outside this repository and is not automated: the Homebrew
+formula.** `zwasm/homebrew-tap`'s `Formula/zwasm.rb` pins the release URL
+and its sha256, so until it is updated `brew install zwasm/tap/zwasm` still
+installs the previous version — while the README points readers at exactly
+that command. Update the formula as part of the release, not after someone
+reports it.
+
 ## Git hooks (recommended)
 
 The repo ships its hooks in `.githooks/` (fast static checks at commit,


### PR DESCRIPTION
`docs/development.md` had no release section. The three in-repo steps
(bump `build.zig.zon`, add the CHANGELOG section, push the `v*` tag) were
recorded only in agent scaffolding, and the tag-triggered
`release.yml` behaviour was not stated anywhere a contributor reads.

The gap that mattered is the fourth step. Updating `Formula/zwasm.rb` in
`zwasm/homebrew-tap` is not automated — `release.yml` contains no tap,
formula or homebrew reference, and `scripts/` has no release helper. The
formula pins a release URL and sha256, so between a tag and a formula
update `brew install zwasm/tap/zwasm` installs the previous version, which
is the command the README hands to every reader.

Also states plainly that releases are maintainer-only (ADR-0156), so the
manual steps read as a deliberate boundary rather than missing automation.

Docs only; no behaviour change.
