### PR TITLE
fix(jit): a block reached only by `br` keeps its result vreg live past `.end`

### DIFF
--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -742,3 +742,128 @@ every one of them. Two things a literal-`.r10` grep also misses:
 never reads that subtree (`find … -maxdepth 2`, 37 of 469 x86_64 files) —
 nor would it fire here, since it checks that a handler *uses* the
 spill-aware helpers, never *where* it calls them.
+
+## Recipe 21 — differential probe of a real-world guest by re-exporting its internals
+
+**Trigger.** A toolchain-built `.wasm` (AssemblyScript / TinyGo / Rust /
+emcc) aborts under `--engine jit` but completes under `--engine interp`,
+and the module is far too big to read. Works for both "engine diverges"
+and "guest detects its own corruption" shapes.
+
+### 21a — is it a host-call boundary at all?
+
+```bash
+for e in interp jit; do ZWASM_DEBUG=mem.cksum zig-out/bin/zwasm run --engine $e F.wasm; done
+```
+
+Read the **import names**, not just the checksums. If the JIT's first
+`[dbg mem.cksum]` line names a *different* import than the interp's first
+line, the guest already took a different branch **before any host call** —
+so it is a plain miscompile, not host-boundary memory corruption. (This
+inverted the AssemblyScript-TLSF hypothesis in one command: interp's first
+line was `interp 2` = `random_get`; the JIT's was `jit fd_write`, which is
+the abort message itself.)
+
+### 21b — which guest function diverges
+
+```bash
+for e in interp jit; do ZWASM_DEBUG=jit.callcount zig-out/bin/zwasm run --engine $e F.wasm; done
+```
+
+Diff the **sets** of called indices, not the counts — interp bumps at the
+call site, the JIT in the prologue, so magnitudes are not comparable.
+Indices present on one engine only bracket the divergent branch. Pair with
+a call graph so an index maps to a role:
+
+```bash
+wasm-tools print F.wasm > /tmp/f.wat   # then: for each `(func (;N;)`, collect its `call K`
+```
+
+The function that calls both `fd_write` and `proc_exit` is the guest's
+`abort`; its callers carry the assertion's file:line as `i32.const`
+literals, which names the failing source line in the guest's own runtime.
+
+### 21c — drive an internal function directly
+
+`zwasm run` has `--invoke <name>[=a,b,...]`, so add probe exports to a
+scratch copy of the guest and call them:
+
+```bash
+wasm-tools print F.wasm > probe.wat   # append probe funcs, then:
+wasm-tools parse probe.wat -o probe.wasm
+```
+
+```wat
+;; run the guest's own initializer, then read one word of its heap
+(func $p_peek (export "p_peek") (param i32) (result i32)
+  call 22          ;; the guest's initializeRoot
+  global.get 1     ;; its root pointer
+  local.get 0 i32.add i32.load)
+;; …and a prefix hash, for binary search
+(func $p_cksum (export "p_cksum") (param i32) (result i32) ...)
+```
+
+Binary-search `p_cksum=N` interp-vs-jit for the **first differing byte** —
+~11 round trips instead of a full word sweep. In the TLSF case this landed
+on a single word (`slMap[7]`: interp `0x4000`, JIT `0x4001`).
+
+### 21d — prove which instruction writes the bad value
+
+Replace the suspect `i32.store` with `drop drop` in the scratch copy,
+keeping the address/value computation intact. If the divergence vanishes,
+that store's *value operand* is wrong; if it survives, look elsewhere.
+
+### 21e — WARNING: probes inside the suspect function hide regalloc bugs
+
+Inserting `global.set` / `global.get` captures **into** the function under
+test changes its register pressure and made this bug disappear (every
+captured value read correct, and the final store became correct too).
+That is itself the diagnosis — a Heisenbug under added pressure means
+**regalloc / liveness**, not arithmetic. Probe from *outside* the function,
+then go to `ZWASM_DEBUG=jit.dump` + Recipe 2 for the real answer.
+
+### 21f — shrink to hand-written `.wat`
+
+Once the wat pattern is known, retype it by hand and sweep variants
+(with/without the `br`, `br` vs `br_if`, `block` vs `loop`, an extra
+operand below the block). The AssemblyScript TLSF abort reduced to:
+
+```wat
+(module (func (export "f") (param $p i32) (result i32)
+  block (result i32) i32.const 7 br 0 end   ;; fall-through is DEAD
+  i32.const 1 local.get $p i32.shl i32.or))
+```
+
+`f(3)`: interp 15, JIT 9. The 54-byte body disassembles to `mov ebx,0x7` /
+`jmp` / `mov ebx,0x1` — one physical register for two live operands.
+
+## Recipe 22 — liveness's operand-stack sim must mirror emit's `pushed_vregs`
+
+**Symptom.** The JIT reads a stale value for an operand that a `block` /
+`if` produced, and `ZWASM_DEBUG=regverify` reports **no** overlap: the
+allocation is consistent with the liveness it was given, and the liveness
+is what is wrong.
+
+**Check.** `src/ir/analysis/liveness.zig` simulates the operand stack
+independently of `codegen/{arm64,x86_64}/op_control.zig`. Every place the
+emit adjusts `pushed_vregs`, liveness must make the *same* adjustment to
+`sim_stack` / `sim_len`, or the two models drift by a slot and every vreg
+after that point is mis-scoped. When auditing a control op, diff the two
+files side by side — the emit is authoritative, because it decides which
+register a value is actually read from.
+
+Concrete drift found this way: `emitEndIntra` splits a block's `.end` into
+three shapes ((a) live fall-through, (b) dead fall-through, (c) stack
+emptied below `entry + arity`), while liveness's `.end` had only shape (a)/(b)
+behind an **absolute** `sim_len >= result_arity` guard. A block whose only
+exit is `br` hits shape (c): the `br` handler drains `sim_stack` to the
+block's entry depth, the guard fails, and the captured merge vreg is never
+restored — it dies at the branch and the next push inherits its register.
+With one operand already on the stack the absolute guard is worse than
+useless: it passes, reaches *below* the block's base, and overwrites the
+enclosing frame's vreg.
+
+**Grep-able tell.** In liveness, any guard of the form
+`sim_len >= <arity>` that should be `sim_len >= entry_depth + <arity>`, and
+any `Frame` field the emit's `Label` has but liveness pins to a constant
+(`param_arity = 0` was pinned for block/loop frames).

--- a/.claude/skills/debug_jit_auto/SKILL.md
+++ b/.claude/skills/debug_jit_auto/SKILL.md
@@ -101,6 +101,8 @@ to the heading.
 | 18 | **lldb VALUE-trace inside JIT code (`scripts/jit_value_trace.sh`)** | Mac/ubuntu | **Miscompile = wrong output, NO crash** — read regs/mem at a JIT instruction |
 | 19 | **Attribute a spec-lane fail before reading any codegen** | any | **FIRST step on every `ZWASM_SPEC_ENGINE=jit` fail** — the detail line names the func, not the module |
 | 20 | **Operand-stack-pressure sweep** | any | JIT-only wrong result/trap where each op passes in isolation → spilled operand |
+| 21 | **Differential probe by re-exporting a guest's internals** | any | **A toolchain-built `.wasm` aborts under `--engine jit` only** — too big to read |
+| 22 | **liveness sim vs emit `pushed_vregs` drift** | any | Stale block/if result AND `regverify` reports no overlap |
 
 
 ## When to invoke each recipe (decision tree)
@@ -113,6 +115,16 @@ Fail came from a spec-assert runner lane (ZWASM_SPEC_ENGINE=jit)?
     (`zwasm run --engine jit/--engine interp`) for a precise trap kind.
     Only then enter the tree below. (D-590: a `table.get` regalloc bug
     spent a cycle inside `invokeMulti` for want of this step.)
+
+A whole toolchain-built guest (AssemblyScript / TinyGo / Rust / emcc)
+aborts or misbehaves under `--engine jit` but not `--engine interp`?
+└── Recipe 21 FIRST — 21a settles in ONE command whether a host-call
+    boundary is involved at all (compare WHICH import each engine reaches
+    first under `ZWASM_DEBUG=mem.cksum`, not just the checksums), then 21b/21c
+    localize to a guest function and a single heap word without reading the
+    module. 21f ends at a hand-written `.wat`. If a probe inserted INTO the
+    suspect function makes the bug vanish (21e), it is regalloc/liveness —
+    continue at Recipe 22, then Recipe 2 on the `jit.dump` bytes.
 
 Host = Mac / ubuntunote?
 ├── JIT-only wrong result / wrong trap, but each op passes in isolation?

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -2236,6 +2236,65 @@ test "jitTableGrow: D-497 guest funcref table.grow + call_indirect grown slot (A
     try testing.expectEqual(@as(u32, 42), try entry.callI32NoArgs(compiled.module, 1, &owned.rt));
 }
 
+test "runI32Export: a block whose result arrives only via `br` keeps that vreg live past .end" {
+    if (builtin.os.tag == .windows) return skip.phaseEnd(.win64);
+    // (module (func (export "test") (result i32)
+    //   (block (result i32) (i32.const 7) (br 0))   ;; the br is the ONLY exit
+    //   (i32.const 1) (i32.const 3) i32.shl
+    //   i32.or))
+    //
+    // The br drains liveness's sim stack to the block's entry depth, so the
+    // block's `.end` sees fewer operands than `result_arity` and never puts the
+    // captured merge vreg back. The vreg then dies at the br while emit still
+    // carries it on `pushed_vregs` — regalloc hands its register to the
+    // `i32.const 1` that follows and the `i32.or` reads 1 instead of 7.
+    //
+    // Expected 7 | (1 << 3) = 15; the pre-fix JIT returned 9 (= 1 | 8).
+    // Provenance: AssemblyScript's `~lib/rt/tlsf.ts` insertBlock, whose
+    // `slMap[fl] |= 1 << sl` has exactly this shape. The spurious bit 0 in the
+    // free-list bitmap made the next searchBlock fail, and every allocating AS
+    // guest aborted at `~lib/rt/tlsf.ts(499:16)` under --engine jit.
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, // type 0: ()->i32
+        0x03, 0x02, 0x01, 0x00, // 1 func, type 0
+        0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00, // export "test"
+        0x0a, 0x11, 0x01, 0x0f, 0x00, // code
+        0x02, 0x7f, 0x41, 0x07, 0x0c, 0x00, 0x0b, // block(i32) i32.const 7; br 0; end
+        0x41, 0x01, 0x41, 0x03, 0x74, 0x72, 0x0b, // i32.const 1; i32.const 3; shl; or; end
+    };
+    try testing.expectEqual(@as(u32, 15), try runI32Export(testing.allocator, &bytes, "test"));
+}
+
+test "runI32Export: a br-only block's .end leaves the operand below its entry depth alone" {
+    if (builtin.os.tag == .windows) return skip.phaseEnd(.win64);
+    // (module (func (export "test") (result i32)
+    //   (i32.const 32)
+    //   (block (result i32) (i32.const 5) (br 0))
+    //   (i32.const 1) (i32.const 1) i32.shl
+    //   i32.or
+    //   i32.or))
+    //
+    // Same drain as above, but with an operand already on the stack when the
+    // block opens. The `.end` merge-restore must be indexed from the block's
+    // entry depth: an absolute `sim_len >= result_arity` test still passes here
+    // (one operand is left) and reaches BELOW the block, overwriting the
+    // enclosing frame's `i32.const 32` vreg with the merge vreg.
+    //
+    // Expected 32 | 5 | (1 << 1) = 39; the pre-fix JIT returned 7 (= 5 | 2).
+    const bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, // type 0: ()->i32
+        0x03, 0x02, 0x01, 0x00, // 1 func, type 0
+        0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00, // export "test"
+        0x0a, 0x14, 0x01, 0x12, 0x00, // code
+        0x41, 0x20, // i32.const 32
+        0x02, 0x7f, 0x41, 0x05, 0x0c, 0x00, 0x0b, // block(i32) i32.const 5; br 0; end
+        0x41, 0x01, 0x41, 0x01, 0x74, 0x72, 0x72, 0x0b, // i32.const 1; i32.const 1; shl; or; or; end
+    };
+    try testing.expectEqual(@as(u32, 39), try runI32Export(testing.allocator, &bytes, "test"));
+}
+
 // Trap-KIND execution tests (ADR-0164 A / D-292: unreachable=5, oob_memory=6,
 // div_by_zero=7, int_overflow=8) live in the sibling `runner_trap_test.zig`
 // (split to keep this file under the 2000-line hard cap; mirrors runner_gc_test).

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -275,10 +275,37 @@ pub fn compute(
                     // jumps over `.end`'s home MOV, leaving it stale
                     // (c_sha256 dropped the final `\n`). Mirrors the
                     // if/else handling above.
-                    if (sim_len >= @as(usize, fr.result_arity)) {
-                        const base = sim_len - @as(usize, fr.result_arity);
-                        var i: u32 = 0;
-                        while (i < fr.result_arity) : (i += 1) {
+                    //
+                    // The case split mirrors `emitEndIntra`. `entry` is the
+                    // block's own operand-stack base (entry depth minus the
+                    // params it consumed), so the merge vregs are homed at
+                    // `entry .. entry + result_arity`.
+                    const arity: usize = fr.result_arity;
+                    const entry: usize = @as(usize, fr.entry_depth) -| @as(usize, fr.param_arity);
+                    if (sim_len < entry + arity) {
+                        // The block's only exit is a `br`: its handler drained
+                        // the body back to the innermost entry depth, so no
+                        // fall-through operand is left to home. The merge
+                        // vregs ARE the block's result — emit's `pushed_vregs`
+                        // still carries them, so put them back and keep them
+                        // live to this `.end`. Without this they die at the
+                        // branch and regalloc hands their register to the next
+                        // push, which then aliases the block's result
+                        // (AssemblyScript `~lib/rt/tlsf.ts` insertBlock's
+                        // `slMap[fl] |= 1 << sl` read 1 instead of 0).
+                        if (sim_len > entry) sim_len = entry;
+                        while (sim_len < entry) : (sim_len += 1) sim_stack[sim_len] = fr.merge_vregs[0];
+                        var i: usize = 0;
+                        while (i < arity) : (i += 1) {
+                            if (sim_len == max_simulated_stack) return Error.OperandStackUnderflow;
+                            ranges.items[fr.merge_vregs[i]].last_use_pc = pc;
+                            sim_stack[sim_len] = fr.merge_vregs[i];
+                            sim_len += 1;
+                        }
+                    } else {
+                        const base = sim_len - arity;
+                        var i: usize = 0;
+                        while (i < arity) : (i += 1) {
                             ranges.items[sim_stack[base + i]].last_use_pc = pc;
                             ranges.items[fr.merge_vregs[i]].last_use_pc = pc;
                             sim_stack[base + i] = fr.merge_vregs[i];
@@ -333,9 +360,15 @@ pub fn compute(
             // handled by emit's captureOrEmitBlockMergeMov).
             const result_arity_u: u32 = instr.extra & 0xFF;
             if (result_arity_u > 8) return Error.UnsupportedOp;
+            // The block's own params are already on the operand stack at
+            // `entry_depth`, so `.end` needs them to find the block's base
+            // (mirrors emit's `entry_stack_depth - param_arity`). The mask
+            // bounds this to 0..255; `param_vregs` stays unused for
+            // block/loop frames (only if-frames re-push params at `.else`).
+            const block_param_arity_u: u32 = (instr.extra >> 8) & 0xFF;
             block_stack[block_stack_len] = .{
                 .entry_depth = @intCast(sim_len),
-                .param_arity = 0,
+                .param_arity = @intCast(block_param_arity_u),
                 .result_arity = @intCast(result_arity_u),
                 .is_if = false,
                 // D-330: a `loop` is a backward-branch target (no


### PR DESCRIPTION
AssemblyScript output aborts under `--engine jit` only:

```
abort:  in ~lib/rt/tlsf.ts(499:16)
```

Four of the twelve `test/wasi/wasip1_official/assemblyscript/` fixtures hit
it, and `.auto` prefers the JIT, so this is the default path.

## Root cause

Not WASI and not a host-call boundary — the guest diverges before its first
host call. `src/ir/analysis/liveness.zig` restores a block's captured merge
vregs at `.end` only while the sim stack still holds `result_arity`
operands. When the block's only exit is a `br` the stack has already been
drained to the block's entry depth, so the merge vreg dies at the branch
while `emitEndIntra` still carries it on `pushed_vregs`. The two models
drift by a slot, and regalloc gives the block's result register to the next
push.

Minimal repro — `f(3)` is 15 on interp, 9 on the JIT:

```wat
(module (func (export "f") (param $p i32) (result i32)
  block (result i32) i32.const 7 br 0 end
  i32.const 1 local.get $p i32.shl i32.or))
```

x86_64 body: `mov ebx,0x7` / `jmp` / `mov ebx,0x1` — one register for two
live operands. AssemblyScript's `slMap[fl] |= 1 << sl` is exactly this
shape, so the TLSF free-list bitmap got a spurious bit and the next
`searchBlock` failed.

## Result

`test-wasi-p1-official` jit 54/72 -> 58/72, equal to interp. The remaining
14 are the p1 behaviour gaps tracked in #204. `test-all` green.
