### PR TITLE
feat(wasi): check preview1 rights at the calls their witx doc comments name

### DIFF
--- a/.dev/decisions/0215_wasi_p1_rights_model.md
+++ b/.dev/decisions/0215_wasi_p1_rights_model.md
@@ -188,7 +188,6 @@ lives in [`.dev/wasi_p1_rights.md`](../wasi_p1_rights.md).
 
 ## Revision history
 
-| Date       | SHA          | Note                                                     |
-|------------|--------------|----------------------------------------------------------|
-| 2026-08-23 | `2a3b86c61`  | Initial proposed version.                                 |
-| 2026-08-23 | `<backfill>` | Maintainer sign-off; P2/P3 consequence pointed at #254.   |
+| Date       | SHA          | Note                                                              |
+|------------|--------------|-------------------------------------------------------------------|
+| 2026-08-24 | `5058d517f`  | Initial version, maintainer sign-off and the #254 reference — the branch was squashed, so all three reached `main` in one commit. |

--- a/.dev/wasi_p1_rights.md
+++ b/.dev/wasi_p1_rights.md
@@ -11,12 +11,9 @@ they operate on.
 
 > **Implementation status.** The model lands in three changes and this file
 > describes all of it, so parts of it lead the code. Advertising the table and
-> deriving rights onto opened fds: **landed**. Reading a right at each call —
-> the `zwasm entry point` column below, and "Where the check sits" — **not
-> yet**: nothing consults `rights_base` today except `fd_fdstat_set_rights`,
-> so `fd_fdstat_get` reports a capability set no call enforces. Folding `..`
-> (`path.normalize`): **not yet**. Each section that runs ahead of the code
-> repeats the fact where it appears.
+> deriving rights onto opened fds: **landed**. Reading a right at each call:
+> **landed**. Folding `..` (`path.normalize`): **not yet**. Each section that
+> runs ahead of the code repeats the fact where it appears.
 
 ## Sources
 
@@ -75,9 +72,6 @@ Ungated by design, because witx assigns them no bit: `fd_close`,
 `proc_*`, `sched_yield`.
 
 ### Where the check sits
-
-**Not yet implemented** — no entry point reads `rights_base` yet; this is
-where the check goes and why it goes there.
 
 The rights check runs **after** the fd-type dispatch, never before. The fd's
 type decides whether the operation exists at all — `spipe` for a stream,

--- a/src/api/component_tests.zig
+++ b/src/api/component_tests.zig
@@ -940,7 +940,7 @@ test "D2 (EXIT): a WASI-P2 fs component writes a file via get-directories+open-a
     // Read the written file back through the still-open preopen dir.
     var pmem: [128]u8 = @splat(0);
     @memcpy(pmem[0..7], "out.txt");
-    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 7, 0, wasi_p1.RIGHTS_FD_READ, 0, 0, 96));
+    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 7, 0, wasi_p1.RIGHTS_FD_READ | wasi_p1.RIGHTS_FD_SEEK, 0, 0, 96));
     const rfd = std.mem.readInt(u32, pmem[96..100], .little);
     std.mem.writeInt(u32, pmem[16..20], 32, .little);
     std.mem.writeInt(u32, pmem[20..24], 6, .little);
@@ -1136,7 +1136,7 @@ test "D2: WASI-P2 descriptor.open-at creates+writes a file under a dir descripto
     // Re-open "f.txt" (the file descriptor was dropped) and read it back.
     var pmem: [128]u8 = @splat(0);
     @memcpy(pmem[0..5], "f.txt");
-    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 5, 0, wasi_p1.RIGHTS_FD_READ, 0, 0, 96));
+    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 5, 0, wasi_p1.RIGHTS_FD_READ | wasi_p1.RIGHTS_FD_SEEK, 0, 0, 96));
     const rfd = std.mem.readInt(u32, pmem[96..100], .little);
     std.mem.writeInt(u32, pmem[16..20], 32, .little);
     std.mem.writeInt(u32, pmem[20..24], 6, .little);
@@ -1186,7 +1186,7 @@ test "D2: WASI-P2 descriptor.write writes a file via the descriptor resource (fd
     // Re-open the file (the descriptor was dropped → its fd closed) and read it back.
     @memset(pmem[0..128], 0);
     @memcpy(pmem[0..8], "out.txt\x00");
-    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 7, 0, wasi_p1.RIGHTS_FD_READ, 0, 0, 96));
+    try testing.expectEqual(wasi_p1.Errno.success, wasi_fd.pathOpen(&host, &pmem, dirfd, 0, 0, 7, 0, wasi_p1.RIGHTS_FD_READ | wasi_p1.RIGHTS_FD_SEEK, 0, 0, 96));
     const rfd = std.mem.readInt(u32, pmem[96..100], .little);
     std.mem.writeInt(u32, pmem[16..20], 32, .little); // iovec: buf=32, len=8
     std.mem.writeInt(u32, pmem[20..24], 8, .little);

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -123,7 +123,18 @@ pub fn fdWrite(
 /// trampoline, where `list<u8>` is a flat `(ptr, len)` rather than a ciovec.
 pub fn writeSlice(host: *Host, fd: p1.Fd, bytes: []const u8) p1.Errno {
     const slot = host.translateFd(fd) orelse return .badf;
-    if (slot.kind == .closed) return .badf;
+    // The fd's TYPE decides whether the operation exists at all; only then does
+    // the capability decide whether THIS fd may perform it. Keeping that order
+    // is what preserves `isdir` / `notsup` / `spipe` as the answers a guest
+    // gets from a stream or a directory — measured against wasmtime 47, which
+    // reports the type error for every one of these.
+    switch (slot.kind) {
+        .stdout, .stderr, .file => {},
+        .stdin => return .notsup,
+        .dir => return .isdir,
+        .closed => return .badf,
+    }
+    if (!slot.has(p1.RIGHTS_FD_WRITE)) return .notcapable;
 
     // stdout/stderr route to a capture buffer (or are dropped); a file fd
     // writes to the host file at its cursor via std.Io.File (D-243 cycle 2).
@@ -131,13 +142,11 @@ pub fn writeSlice(host: *Host, fd: p1.Fd, bytes: []const u8) p1.Errno {
     const buffer: ?*std.ArrayList(u8) = switch (slot.kind) {
         .stdout => host.stdout_buffer,
         .stderr => host.stderr_buffer,
-        .stdin => return .notsup,
-        .dir => return .isdir,
         .file => fblk: {
             file_opt = .{ .handle = slot.host_handle orelse return .badf, .flags = .{ .nonblocking = false } };
             break :fblk null;
         },
-        .closed => return .badf,
+        .stdin, .dir, .closed => unreachable, // rejected above
     };
     const io_opt = host.io;
     if (file_opt != null and io_opt == null) return .nosys;
@@ -218,12 +227,13 @@ pub fn fdRead(
 ) p1.Errno {
     const slot = host.translateFd(fd) orelse return .badf;
     switch (slot.kind) {
-        .stdin => {},
+        .stdin, .file => {},
         .stdout, .stderr => return .notsup,
         .dir => return .isdir,
-        .file => return fdReadFile(host, mem, slot, iovec_ptr, iovec_count, nread_ptr),
         .closed => return .badf,
     }
+    if (!slot.has(p1.RIGHTS_FD_READ)) return .notcapable;
+    if (slot.kind == .file) return fdReadFile(host, mem, slot, iovec_ptr, iovec_count, nread_ptr);
 
     var total: u32 = 0;
     var i: u32 = 0;
@@ -340,6 +350,13 @@ pub fn fdSeek(
         .closed => return .badf,
         .file => {},
     }
+    // witx: FD_TELL covers the offset-preserving form (`cur` + 0); anything
+    // that can move the cursor needs FD_SEEK. FD_SEEK "implies FD_TELL", so it
+    // satisfies the offset-preserving form on its own.
+    const preserves_offset = whence == @intFromEnum(p1.Whence.cur) and offset == 0;
+    const may_seek = slot.has(p1.RIGHTS_FD_SEEK) or
+        (preserves_offset and slot.has(p1.RIGHTS_FD_TELL));
+    if (!may_seek) return .notcapable;
     const handle = slot.host_handle orelse return .badf;
     const io = host.io orelse return .nosys;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -368,6 +385,8 @@ pub fn fdTell(host: *Host, mem: []u8, fd: p1.Fd, pos_ptr: u32) p1.Errno {
         .closed => return .badf,
         .file => {},
     }
+    // FD_SEEK "implies rights::fd_tell" (witx), so either bit answers for it.
+    if (!slot.has(p1.RIGHTS_FD_TELL) and !slot.has(p1.RIGHTS_FD_SEEK)) return .notcapable;
     return writeU64LE(mem, pos_ptr, slot.pos);
 }
 
@@ -384,6 +403,7 @@ pub fn fdSync(host: *Host, fd: p1.Fd) p1.Errno {
         .stdin, .stdout, .stderr => return .success,
         .closed => return .badf,
         .file, .dir => {
+            if (!slot.has(p1.RIGHTS_FD_SYNC)) return .notcapable;
             const io = host.io orelse return .nosys;
             const handle = slot.host_handle orelse return .badf;
             const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -404,6 +424,7 @@ pub fn fdDatasync(host: *Host, fd: p1.Fd) p1.Errno {
         .stdin, .stdout, .stderr => return .success,
         .closed => return .badf,
         .file, .dir => {
+            if (!slot.has(p1.RIGHTS_FD_DATASYNC)) return .notcapable;
             const io = host.io orelse return .nosys;
             const handle = slot.host_handle orelse return .badf;
             const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -428,7 +449,7 @@ pub fn fdAdvise(host: *Host, fd: p1.Fd, offset: u64, len: u64, advice: u8) p1.Er
         // Advisory information applies to file data; a directory has none
         // (official filesystem-advise.wasm asserts bad-descriptor).
         .closed, .dir => .badf,
-        .file => .success,
+        .file => if (slot.has(p1.RIGHTS_FD_ADVISE)) .success else .notcapable,
     };
 }
 
@@ -456,6 +477,9 @@ pub fn fdPread(
         .dir => return .isdir,
         .closed => return .badf,
     }
+    // witx: FD_READ "includes the right to invoke fd_pread" only when FD_SEEK
+    // is also held — positional IO is a seek plus a read.
+    if (!slot.has(p1.RIGHTS_FD_READ | p1.RIGHTS_FD_SEEK)) return .notcapable;
     const handle = slot.host_handle orelse return .badf;
     const io = host.io orelse return .nosys;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -497,6 +521,7 @@ pub fn fdPwrite(
         .dir => return .isdir,
         .closed => return .badf,
     }
+    if (!slot.has(p1.RIGHTS_FD_WRITE | p1.RIGHTS_FD_SEEK)) return .notcapable;
     const handle = slot.host_handle orelse return .badf;
     const io = host.io orelse return .nosys;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -609,6 +634,10 @@ pub fn fdFdstatGet(
 pub fn fdFdstatSetFlags(host: *Host, fd: p1.Fd, flags: p1.Fdflags) p1.Errno {
     const slot = host.translateFd(fd) orelse return .badf;
     if (slot.kind == .closed) return .badf;
+    switch (slot.kind) {
+        .stdin, .stdout, .stderr => {},
+        .file, .dir, .closed => if (!slot.has(p1.RIGHTS_FD_FDSTAT_SET_FLAGS)) return .notcapable,
+    }
     const allowed: p1.Fdflags = p1.FDFLAGS_APPEND | p1.FDFLAGS_DSYNC |
         p1.FDFLAGS_NONBLOCK | p1.FDFLAGS_RSYNC | p1.FDFLAGS_SYNC;
     slot.fs_flags = flags & allowed;
@@ -701,6 +730,7 @@ pub fn fdFilestatSetTimes(host: *Host, fd: p1.Fd, atim: u64, mtim: u64, fst_flag
         .closed => return .badf,
         .file, .dir => {},
     }
+    if (!slot.has(p1.RIGHTS_FD_FILESTAT_SET_TIMES)) return .notcapable;
     const io = host.io orelse return .nosys;
     const handle = slot.host_handle orelse return .badf;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -731,6 +761,7 @@ pub fn fdFilestatSetSize(host: *Host, fd: p1.Fd, size: u64) p1.Errno {
         .closed => return .badf,
         .file => {},
     }
+    if (!slot.has(p1.RIGHTS_FD_FILESTAT_SET_SIZE)) return .notcapable;
     const io = host.io orelse return .nosys;
     const handle = slot.host_handle orelse return .badf;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -750,6 +781,7 @@ pub fn fdAllocate(host: *Host, fd: p1.Fd, offset: u64, len: u64) p1.Errno {
         .closed => return .badf,
         .file => {},
     }
+    if (!slot.has(p1.RIGHTS_FD_ALLOCATE)) return .notcapable;
     const io = host.io orelse return .nosys;
     const handle = slot.host_handle orelse return .badf;
     const file: std.Io.File = .{ .handle = handle, .flags = .{ .nonblocking = false } };
@@ -836,6 +868,7 @@ pub fn fdReaddir(host: *Host, mem: []u8, fd: p1.Fd, buf_ptr: u32, buf_len: u32, 
         .closed => return .badf,
         .stdin, .stdout, .stderr, .file => return .notdir,
     }
+    if (!slot.has(p1.RIGHTS_FD_READDIR)) return .notcapable;
     const io = host.io orelse return .nosys;
     const handle = slot.host_handle orelse return .badf;
     const dir: std.Io.Dir = .{ .handle = handle };
@@ -912,6 +945,12 @@ pub fn pathOpen(
     // Resolve dirfd.
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
     if (dir_slot.kind != .dir) return .notdir;
+    // witx: PATH_OPEN gates the call; PATH_CREATE_FILE and
+    // PATH_FILESTAT_SET_SIZE gate the `creat` and `trunc` open-flags.
+    var needed: p1.Rights = p1.RIGHTS_PATH_OPEN;
+    if ((oflags & p1.OFLAGS_CREAT) != 0) needed |= p1.RIGHTS_PATH_CREATE_FILE;
+    if ((oflags & p1.OFLAGS_TRUNC) != 0) needed |= p1.RIGHTS_PATH_FILESTAT_SET_SIZE;
+    if (!dir_slot.has(needed)) return .notcapable;
     const dir_handle = dir_slot.host_handle orelse return .notdir;
 
     // Filesystem syscalls require an io context; tests / production
@@ -1046,6 +1085,12 @@ fn kindToFiletype(kind: std.Io.File.Kind) p1.Filetype {
 pub fn fdFilestatGet(host: *Host, mem: []u8, fd: p1.Fd, filestat_ptr: u32) p1.Errno {
     const slot = host.translateFd(fd) orelse return .badf;
     if (slot.kind == .closed) return .badf;
+    switch (slot.kind) {
+        // A stdio stream's filestat is synthetic, not a capability the guest
+        // holds over a filesystem object; wasmtime answers it too.
+        .stdin, .stdout, .stderr => {},
+        .file, .dir, .closed => if (!slot.has(p1.RIGHTS_FD_FILESTAT_GET)) return .notcapable,
+    }
     const dst = sliceMem(mem, filestat_ptr, @sizeOf(p1.Filestat)) orelse return .fault;
 
     const fs: p1.Filestat = switch (slot.kind) {
@@ -1094,6 +1139,7 @@ pub fn pathUnlinkFile(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_
     if (pathHasParentEscape(path)) return .notcapable;
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
     if (dir_slot.kind != .dir) return .notdir;
+    if (!dir_slot.has(p1.RIGHTS_PATH_UNLINK_FILE)) return .notcapable;
     const dir_handle = dir_slot.host_handle orelse return .notdir;
     const io = host.io orelse return .nosys;
     const dir: std.Io.Dir = .{ .handle = dir_handle };
@@ -1328,7 +1374,7 @@ test "fdSync / fdDatasync: real file fd succeeds; stdio noop; closed badf" {
 
     var mem: [64]u8 = @splat(0);
     @memcpy(mem[16..28], "synced.txt\x00\x00"[0..12]);
-    const oe = pathOpen(&h, &mem, dirfd, 0, 16, 10, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE, 0, 0, 32);
+    const oe = pathOpen(&h, &mem, dirfd, 0, 16, 10, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE | p1.RIGHTS_FD_SYNC | p1.RIGHTS_FD_DATASYNC, 0, 0, 32);
     try testing.expectEqual(p1.Errno.success, oe);
     const fd = std.mem.readInt(u32, mem[32..36], .little);
 
@@ -1356,7 +1402,8 @@ test "fdPwrite / fdPread: positional round-trip at an offset (no cursor move)" {
 
     var mem: [128]u8 = @splat(0);
     @memcpy(mem[0..8], "pos.txt\x00");
-    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 7, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE | p1.RIGHTS_FD_READ, 0, 0, 96);
+    // Positional IO is a seek plus a read/write, so it needs FD_SEEK too.
+    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 7, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE | p1.RIGHTS_FD_READ | p1.RIGHTS_FD_SEEK, 0, 0, 96);
     try testing.expectEqual(p1.Errno.success, oe);
     const fd = std.mem.readInt(u32, mem[96..100], .little);
 
@@ -1405,10 +1452,10 @@ test "fdRenumber: moves an fd onto another; source becomes badf" {
 
     var mem: [128]u8 = @splat(0);
     @memcpy(mem[100..101], "x");
-    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 100, 1, 0, p1.RIGHTS_FD_READ, 0, 0, 108));
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 100, 1, 0, p1.RIGHTS_FD_READ | p1.RIGHTS_FD_FILESTAT_GET, 0, 0, 108));
     const fd_x = std.mem.readInt(u32, mem[108..112], .little);
     @memcpy(mem[100..101], "y");
-    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 100, 1, 0, p1.RIGHTS_FD_READ, 0, 0, 108));
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 100, 1, 0, p1.RIGHTS_FD_READ | p1.RIGHTS_FD_FILESTAT_GET, 0, 0, 108));
     const fd_y = std.mem.readInt(u32, mem[108..112], .little);
 
     // Renumber x onto y: fd_y now holds x's 5-byte file; fd_x is closed.
@@ -1528,7 +1575,8 @@ test "fdFilestatSetSize / fdAllocate: truncate-extend exact, allocate grows-only
 
     var mem: [128]u8 = @splat(0);
     @memcpy(mem[0..8], "sz.txt\x00\x00"[0..8]);
-    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 6, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE, 0, 0, 96);
+    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 6, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE |
+        p1.RIGHTS_FD_FILESTAT_SET_SIZE | p1.RIGHTS_FD_ALLOCATE | p1.RIGHTS_FD_FILESTAT_GET, 0, 0, 96);
     try testing.expectEqual(p1.Errno.success, oe);
     const fd = std.mem.readInt(u32, mem[96..100], .little);
 
@@ -1571,7 +1619,8 @@ test "fdFilestatSetTimes: set mtim and read it back via fdFilestatGet" {
 
     var mem: [128]u8 = @splat(0);
     @memcpy(mem[0..8], "tim.txt\x00");
-    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 7, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE, 0, 0, 96);
+    const oe = pathOpen(&h, &mem, dirfd, 0, 0, 7, p1.OFLAGS_CREAT, p1.RIGHTS_FD_WRITE |
+        p1.RIGHTS_FD_FILESTAT_SET_TIMES | p1.RIGHTS_FD_FILESTAT_GET, 0, 0, 96);
     try testing.expectEqual(p1.Errno.success, oe);
     const fd = std.mem.readInt(u32, mem[96..100], .little);
 
@@ -1752,7 +1801,7 @@ test "fd_seek + fd_tell move + report the file cursor (set/cur/end whence)" {
 
     var mem: [128]u8 = @splat(0);
     @memcpy(mem[16..24], "seek.txt");
-    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 16, 8, 0, p1.RIGHTS_FD_READ, 0, 0, 100));
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 16, 8, 0, p1.RIGHTS_FD_READ | p1.RIGHTS_FD_SEEK | p1.RIGHTS_FD_TELL, 0, 0, 100));
     const fd = std.mem.readInt(u32, mem[100..104], .little);
     const slot = h.translateFd(fd).?;
     defer {
@@ -1914,7 +1963,6 @@ test "fdWrite: max_capture_bytes bounds a capture buffer and reports nospc" {
 // ============================================================
 // Rights: derivation + enforcement
 // ============================================================
-
 test "deriveRights: a derived fd cannot exceed the parent's inheriting set" {
     const parent: host_mod.OpenFd = .{
         .kind = .dir,
@@ -1990,4 +2038,166 @@ test "path_open: a write right on a directory target is isdir" {
     const read_only = pathOpen(&h, &mem, dirfd, 0, 0, 5, write_dir, p1.RIGHTS_FD_READ, 0, 0, 32);
     try testing.expectEqual(read_only, with_write);
     try testing.expect(with_write != .isdir);
+}
+
+/// Push a `.file` slot carrying exactly `rights` and return its guest fd. No
+/// host handle: every test below asserts the rights check fires BEFORE the
+/// handle is touched, so a `badf` here would mean the gate ran too late.
+fn pushRightsOnlyFile(h: *Host, rights: p1.Rights) !p1.Fd {
+    try h.fd_table.append(h.alloc, .{ .kind = .file, .rights_base = rights });
+    return @intCast(h.fd_table.items.len - 1);
+}
+
+test "rights gate: a call the fd cannot make is notcapable, not badf" {
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    var mem: [64]u8 = @splat(0);
+
+    const no_read = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_WRITE);
+    try testing.expectEqual(p1.Errno.notcapable, fdRead(&h, &mem, no_read, 0, 1, 32));
+
+    const no_write = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_READ);
+    try testing.expectEqual(p1.Errno.notcapable, fdWrite(&h, &mem, no_write, 0, 1, 32));
+
+    const bare = try pushRightsOnlyFile(&h, 0);
+    try testing.expectEqual(p1.Errno.notcapable, fdSync(&h, bare));
+    try testing.expectEqual(p1.Errno.notcapable, fdDatasync(&h, bare));
+    try testing.expectEqual(p1.Errno.notcapable, fdAdvise(&h, bare, 0, 0, 0));
+    try testing.expectEqual(p1.Errno.notcapable, fdAllocate(&h, bare, 0, 1));
+    try testing.expectEqual(p1.Errno.notcapable, fdFilestatGet(&h, &mem, bare, 0));
+    try testing.expectEqual(p1.Errno.notcapable, fdFilestatSetSize(&h, bare, 0));
+    try testing.expectEqual(p1.Errno.notcapable, fdFilestatSetTimes(&h, bare, 0, 0, 0));
+    try testing.expectEqual(p1.Errno.notcapable, fdFdstatSetFlags(&h, bare, 0));
+
+    // fd_readdir needs a directory to reach its rights check at all.
+    try h.fd_table.append(h.alloc, .{ .kind = .dir });
+    const bare_dir: p1.Fd = @intCast(h.fd_table.items.len - 1);
+    try testing.expectEqual(p1.Errno.notcapable, fdReaddir(&h, &mem, bare_dir, 0, 8, 0, 32));
+
+    // Positional IO is a seek plus a read/write, so it needs both bits.
+    const read_only = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_READ);
+    try testing.expectEqual(p1.Errno.notcapable, fdPread(&h, &mem, read_only, 0, 1, 0, 32));
+    const write_only = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_WRITE);
+    try testing.expectEqual(p1.Errno.notcapable, fdPwrite(&h, &mem, write_only, 0, 1, 0, 32));
+
+    // A closed or out-of-range fd is still badf — the rights check must not
+    // shadow the identity check.
+    try testing.expectEqual(p1.Errno.badf, fdRead(&h, &mem, 99, 0, 1, 32));
+}
+
+test "rights gate: fd_seek implies fd_tell, and only fd_seek moves the cursor" {
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    var mem: [64]u8 = @splat(0);
+
+    // FD_TELL alone: the offset-preserving form clears the gate (it reaches
+    // the missing handle and reports badf); a real seek does not.
+    const tell_only = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_TELL);
+    try testing.expectEqual(p1.Errno.badf, fdSeek(&h, &mem, tell_only, 0, @intFromEnum(p1.Whence.cur), 32));
+    try testing.expectEqual(p1.Errno.notcapable, fdSeek(&h, &mem, tell_only, 1, @intFromEnum(p1.Whence.set), 32));
+
+    // FD_SEEK alone: witx says it implies FD_TELL, so both forms clear.
+    const seek_only = try pushRightsOnlyFile(&h, p1.RIGHTS_FD_SEEK);
+    try testing.expectEqual(p1.Errno.badf, fdSeek(&h, &mem, seek_only, 0, @intFromEnum(p1.Whence.cur), 32));
+    try testing.expectEqual(p1.Errno.success, fdTell(&h, &mem, seek_only, 32));
+
+    // Neither bit: both forms are notcapable.
+    const bare = try pushRightsOnlyFile(&h, 0);
+    try testing.expectEqual(p1.Errno.notcapable, fdSeek(&h, &mem, bare, 0, @intFromEnum(p1.Whence.cur), 32));
+    try testing.expectEqual(p1.Errno.notcapable, fdTell(&h, &mem, bare, 32));
+}
+
+test "rights gate: path_open's oflags each need their own right" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    h.io = testing.io;
+    const dirfd = try h.addPreopen(tmp.dir.handle, "/sandbox");
+
+    var mem: [64]u8 = @splat(0);
+    @memcpy(mem[0..4], "file");
+
+    // Drop PATH_CREATE_FILE: a plain open still works, OFLAGS_CREAT does not.
+    h.fd_table.items[dirfd].rights_base = p1.RIGHTS_DIRECTORY_BASE & ~p1.RIGHTS_PATH_CREATE_FILE;
+    try testing.expectEqual(p1.Errno.notcapable, pathOpen(&h, &mem, dirfd, 0, 0, 4, p1.OFLAGS_CREAT, 0, 0, 0, 32));
+
+    // Restore it, create the file, then drop PATH_FILESTAT_SET_SIZE and watch
+    // OFLAGS_TRUNC lose its right (official `truncation_rights`).
+    h.fd_table.items[dirfd].rights_base = p1.RIGHTS_DIRECTORY_BASE;
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 0, 4, p1.OFLAGS_CREAT, 0, 0, 0, 32));
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 0, 4, p1.OFLAGS_TRUNC, 0, 0, 0, 32));
+    h.fd_table.items[dirfd].rights_base = p1.RIGHTS_DIRECTORY_BASE & ~p1.RIGHTS_PATH_FILESTAT_SET_SIZE;
+    try testing.expectEqual(p1.Errno.notcapable, pathOpen(&h, &mem, dirfd, 0, 0, 4, p1.OFLAGS_TRUNC, 0, 0, 0, 32));
+
+    // And PATH_OPEN itself gates the call outright.
+    h.fd_table.items[dirfd].rights_base = 0;
+    try testing.expectEqual(p1.Errno.notcapable, pathOpen(&h, &mem, dirfd, 0, 0, 4, 0, 0, 0, 0, 32));
+}
+
+test "rights gate: a file under a component-opened subdirectory is still writable" {
+    // The WASI 0.2/0.3 `open-at` trampolines have no rights model, so they ask
+    // `path_open` for whatever `rightsForRightlessOpen` allows. If a directory
+    // open narrowed the INHERITING ceiling as well as its own base, this write
+    // would be `notcapable` — the fd under it would never have been granted
+    // FD_WRITE in the first place.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    h.io = testing.io;
+    const dirfd = try h.addPreopen(tmp.dir.handle, "/sandbox");
+    const root: std.Io.Dir = .{ .handle = tmp.dir.handle };
+    try root.createDir(testing.io, "sub", std.Io.File.Permissions.default_dir);
+
+    var mem: [128]u8 = @splat(0);
+    @memcpy(mem[0..3], "sub");
+    const dr = p1.rightsForRightlessOpen(p1.OFLAGS_DIRECTORY);
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 0, 3, p1.OFLAGS_DIRECTORY, dr.base, dr.inheriting, 0, 96));
+    const subfd = std.mem.readInt(u32, mem[96..100], .little);
+
+    @memset(mem[0..128], 0);
+    @memcpy(mem[0..5], "f.txt");
+    const fr = p1.rightsForRightlessOpen(p1.OFLAGS_CREAT);
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, subfd, 0, 0, 5, p1.OFLAGS_CREAT, fr.base, fr.inheriting, 0, 96));
+    const ffd = std.mem.readInt(u32, mem[96..100], .little);
+
+    @memcpy(mem[48..56], "hello fd");
+    std.mem.writeInt(u32, mem[32..36], 48, .little);
+    std.mem.writeInt(u32, mem[36..40], 8, .little);
+    try testing.expectEqual(p1.Errno.success, fdWrite(&h, &mem, ffd, 32, 1, 104));
+    try testing.expectEqual(@as(u32, 8), std.mem.readInt(u32, mem[104..108], .little));
+}
+
+test "rights gate: the two ways to reach a directory hold the same capabilities" {
+    // A preopen advertises RIGHTS_DIRECTORY_BASE; the component-model
+    // `open-at` path has no rights model and asks through
+    // `rightsForRightlessOpen`. If those disagree, the same directory answers
+    // differently depending on which interface opened it — measured on
+    // `fd_sync` / `fd_datasync` / `fd_fdstat_set_flags`, the three the type
+    // dispatch lets through to a `.dir` slot.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    h.io = testing.io;
+    const dirfd = try h.addPreopen(tmp.dir.handle, "/sandbox");
+    const root: std.Io.Dir = .{ .handle = tmp.dir.handle };
+    try root.createDir(testing.io, "a", std.Io.File.Permissions.default_dir);
+    try root.createDir(testing.io, "b", std.Io.File.Permissions.default_dir);
+
+    var mem: [128]u8 = @splat(0);
+    @memcpy(mem[0..1], "a");
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 0, 1, p1.OFLAGS_DIRECTORY, p1.RIGHTS_DIRECTORY_BASE, p1.RIGHTS_DIRECTORY_INHERITING, 0, 96));
+    const via_preopen = std.mem.readInt(u32, mem[96..100], .little);
+
+    @memcpy(mem[0..1], "b");
+    const rr = p1.rightsForRightlessOpen(p1.OFLAGS_DIRECTORY);
+    try testing.expectEqual(p1.Errno.success, pathOpen(&h, &mem, dirfd, 0, 0, 1, p1.OFLAGS_DIRECTORY, rr.base, rr.inheriting, 0, 96));
+    const via_open_at = std.mem.readInt(u32, mem[96..100], .little);
+
+    try testing.expectEqual(h.translateFd(via_preopen).?.rights_base, h.translateFd(via_open_at).?.rights_base);
+    try testing.expectEqual(fdSync(&h, via_preopen), fdSync(&h, via_open_at));
+    try testing.expectEqual(fdDatasync(&h, via_preopen), fdDatasync(&h, via_open_at));
+    try testing.expectEqual(fdFdstatSetFlags(&h, via_preopen, 0), fdFdstatSetFlags(&h, via_open_at, 0));
 }

--- a/src/wasi/host.zig
+++ b/src/wasi/host.zig
@@ -62,6 +62,13 @@ pub const OpenFd = struct {
     /// `fd_seek` sets it, `fd_tell` reads it. `fd_pread`/`fd_pwrite` take an
     /// explicit offset and do NOT touch it (WASI).
     pos: u64 = 0,
+
+    /// True when this fd carries every bit in `needed`. A preview1 call is
+    /// gated by the rights its witx doc comment names; an fd whose
+    /// `fs_rights_base` is missing one owes the guest `notcapable`.
+    pub fn has(self: *const OpenFd, needed: p1.Rights) bool {
+        return self.rights_base & needed == needed;
+    }
 };
 
 /// One environment-variable entry. Both `key` and `value` are

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -72,9 +72,11 @@ fn symlinkTargetEscapes(link_sub: []const u8, target: []const u8) bool {
 
 const Resolved = struct { dir: std.Io.Dir, sub: []const u8 };
 
-/// Resolve `(dirfd, path_ptr, path_len)` to a host `Dir` + bounded guest path.
-/// Returns the errno on failure (`.success` when `out` is populated).
-fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, out: *Resolved) p1.Errno {
+/// Resolve `(dirfd, path_ptr, path_len)` to a host `Dir` + bounded guest path,
+/// and check that `needed` — the right the witx doc comment names for the
+/// calling operation — is present in the dirfd's `fs_rights_base`. Returns the
+/// errno on failure (`.success` when `out` is populated).
+fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, needed: p1.Rights, out: *Resolved) p1.Errno {
     const path = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
     // POSIX: the empty path resolves to nothing (ENOENT). Guarded here because
     // std.Io panics on the resulting EINVAL in debug builds ("programmer bug").
@@ -82,6 +84,7 @@ fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: 
     if (pathHasParentEscape(path)) return .notcapable;
     const slot = host.translateFd(dirfd) orelse return .badf;
     if (slot.kind != .dir) return .notdir;
+    if (!slot.has(needed)) return .notcapable;
     const handle = slot.host_handle orelse return .notdir;
     out.* = .{ .dir = .{ .handle = handle }, .sub = path };
     return .success;
@@ -119,7 +122,7 @@ fn mapDirErr(err: anyerror) p1.Errno {
 /// to the preopen `dirfd` (`std.Io.Dir.createDir`).
 pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_CREATE_DIRECTORY, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     r.dir.createDir(io, r.sub, std.Io.File.Permissions.default_dir) catch |err| return mapDirErr(err);
@@ -130,7 +133,7 @@ pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// relative to `dirfd` (`std.Io.Dir.deleteDir`; non-empty → `notempty`).
 pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     // rmdir(".") is EINVAL per POSIX; guarded because std.Io panics on the
@@ -149,10 +152,10 @@ pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// resolved + escape-guarded.
 pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_RENAME_SOURCE, &ro);
     if (e1 != .success) return e1;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_RENAME_TARGET, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     // rename involving "." is EINVAL/EBUSY per POSIX; guarded because std.Io
@@ -168,10 +171,10 @@ pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, 
 /// (`std.Io.Dir.hardLink`). `old_flags` bit 0 = follow-symlinks.
 pub fn pathLink(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_flags: u32, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_LINK_SOURCE, &ro);
     if (e1 != .success) return e1;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_LINK_TARGET, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     const follow = old_flags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0;
@@ -301,7 +304,7 @@ fn winPathLink(old_dir: std.Io.Dir, old_sub: []const u8, new_dir: std.Io.Dir, ne
 pub fn pathSymlink(host: *Host, mem: []const u8, target_ptr: u32, target_len: u32, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     const target = sliceMemConst(mem, target_ptr, target_len) orelse return .fault;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_SYMLINK, &r);
     if (e != .success) return e;
     if (symlinkTargetEscapes(r.sub, target)) return .notcapable;
     const io = host.io orelse return .nosys;
@@ -320,7 +323,7 @@ pub fn pathReadlink(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_le
         break :blk mem[buf_ptr..end];
     };
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_READLINK, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const n = r.dir.readLink(io, r.sub, buf) catch |err| return mapDirErr(err);
@@ -359,7 +362,7 @@ pub fn pathFilestatGet(host: *Host, mem: []u8, dirfd: p1.Fd, lookupflags: u32, p
         break :blk mem[filestat_ptr..end];
     };
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_GET, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const st = r.dir.statFile(io, r.sub, .{ .follow_symlinks = lookupflags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0 }) catch |err| return mapDirErr(err);
@@ -385,7 +388,7 @@ pub fn pathFilestatSetTimes(host: *Host, mem: []const u8, dirfd: p1.Fd, lookupfl
     if (fst_flags & p1.FSTFLAGS_ATIM != 0 and fst_flags & p1.FSTFLAGS_ATIM_NOW != 0) return .inval;
     if (fst_flags & p1.FSTFLAGS_MTIM != 0 and fst_flags & p1.FSTFLAGS_MTIM_NOW != 0) return .inval;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_SET_TIMES, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const atime = setTimestampOf(fst_flags, p1.FSTFLAGS_ATIM_NOW, p1.FSTFLAGS_ATIM, atim);

--- a/src/wasi/preview1.zig
+++ b/src/wasi/preview1.zig
@@ -309,11 +309,15 @@ pub const RIGHTS_DIRECTORY_APPLICABLE: Rights =
 /// `path_open` — the component-model `open-at` paths, where the preopen IS the
 /// sandbox and WASI 0.2/0.3 has no rights concept at all.
 ///
-/// `base` drops the file-content rights for a directory target, because
-/// `path_open` answers `isdir` to a write right on one. `inheriting` is
-/// **never** masked: `RIGHTS_DIRECTORY_APPLICABLE` is a rule about what THIS
-/// fd may do, not about what it may hand down, and masking it would silently
-/// strip FD_WRITE from every file later opened under the directory.
+/// A directory target gets exactly `RIGHTS_DIRECTORY_BASE` — what a preopen
+/// advertises — so that a directory reached through `open-at` and one reached
+/// through a preopen hold the same capabilities. Anything wider hands the
+/// component fd rights (`fd_sync`, `fd_datasync`, `fd_fdstat_set_flags`) that
+/// a preview1 guest is refused on the same directory.
+///
+/// `inheriting` is **never** narrowed to that set: it is the ceiling for the
+/// FILES opened underneath, and clamping it there would strip FD_WRITE from
+/// every one of them.
 ///
 /// A FILE target is deliberately not filetype-masked, so its `fd_fdstat_get`
 /// reports directory rights it can never use. Two reasons to leave it: the
@@ -330,10 +334,7 @@ pub const RIGHTS_DIRECTORY_APPLICABLE: Rights =
 pub fn rightsForRightlessOpen(oflags: Oflags) struct { base: Rights, inheriting: Rights } {
     const dir_target = (oflags & OFLAGS_DIRECTORY) != 0;
     return .{
-        .base = if (dir_target)
-            RIGHTS_DIRECTORY_INHERITING & RIGHTS_DIRECTORY_APPLICABLE
-        else
-            RIGHTS_DIRECTORY_INHERITING,
+        .base = if (dir_target) RIGHTS_DIRECTORY_BASE else RIGHTS_DIRECTORY_INHERITING,
         .inheriting = RIGHTS_DIRECTORY_INHERITING,
     };
 }
@@ -555,6 +556,10 @@ test "rightsForRightlessOpen: the filetype mask never reaches the inheriting cei
     try testing.expectEqual(RIGHTS_DIRECTORY_INHERITING, dir.inheriting);
     try testing.expect(dir.inheriting & RIGHTS_FD_WRITE != 0);
     try testing.expect(dir.inheriting & RIGHTS_FD_SEEK != 0);
+
+    // A directory gets exactly what a preopen advertises, so the two ways of
+    // reaching a directory hold the same capabilities once rights are enforced.
+    try testing.expectEqual(RIGHTS_DIRECTORY_BASE, dir.base);
 
     // A file target is asked for the whole ceiling on both.
     const file = rightsForRightlessOpen(0);


### PR DESCRIPTION
Refs #204 — the second of three, stacked on the constants/preopen PR. This is
the half that **narrows** acceptance.

## What broke

`fd.zig` has 31 `pub fn`; not one of them read `rights_base`. `rights` were
carried on every fd and narrowable through `fd_fdstat_set_rights`, and then
ignored. A guest could drop `FD_READ` and keep reading — the official
`fd_fdstat_set_rights` catches exactly that, and `path_open_read_write` saw a
raw host `IO` error where the spec promised `BADF` / `NOTCAPABLE` / `ACCES`.

## Scope

Each entry point checks the right its flag's witx doc comment names and
answers `notcapable`. `path.zig` threads the right through `resolve`, so its
eight handlers share one check.

**Ordering matters and is deliberate**: the check runs AFTER the fd-type
dispatch. The type decides whether the operation exists at all; only then does
the capability decide whether this fd may perform it. Measured against
wasmtime 47.0.3: `fd_pread(stdin)` → `spipe`, `fd_advise(stdout)` → `badf`,
`fd_filestat_get(stdout)` → `success` — type errors, never `notcapable`.
Checking rights first would have replaced all of those.

Left ungated on purpose, with reasons in `.dev/wasi_p1_rights.md`:
`poll_fd_readwrite` (fd-readiness is `notsup` here), `sock_shutdown` /
`sock_accept` (the stubs answer `notsock` and the corpus asserts it), and the
`fdflags` clauses on `path_open` (our `fdflags` handling is itself incomplete
— `fd_flags_set` is still red).

## One thing enforcement makes reachable

`rightsForRightlessOpen` gave a directory target
`RIGHTS_DIRECTORY_INHERITING & RIGHTS_DIRECTORY_APPLICABLE` — 25 bits, against
the 17 a preopen advertises. Five of the eight extra bits are unreachable
(the type dispatch answers `isdir` / `badf` first), but three are not:
measured, `fd_sync`, `fd_datasync` and `fd_fdstat_set_flags` succeed on a
directory opened through `open-at` and are `notcapable` on the same directory
opened through a preopen.

Unobservable before this PR, which is why it ships here rather than with the
helper. The base is now `RIGHTS_DIRECTORY_BASE`, and a test opens the same
directory both ways and asserts the three calls agree.

## What was lost

This is a narrowing change, so the question is what stopped being accepted.
`zig build test-all` on the stack: green, and the only expectation changes are
six `fd.zig` fixtures that opened a file and then exercised an operation they
had not asked a right for. Each now requests it — which is what a real guest
does. Three `component_tests.zig` sites likewise add `FD_SEEK` before
`fd_pread`, since positional IO is a seek plus a read.

The 57 `test/realworld/` fixtures, the `test/wasi/` fixtures and the spec
suites are untouched: no fixture lost a call it used to make.

That accounting covers the suites, not the capability surface, so one case it
misses — raised in review: `fd_sync` / `fd_datasync` on a **directory** fd
succeeded before this PR and is `notcapable` after, because
`RIGHTS_DIRECTORY_BASE` carries neither right. fsyncing a parent directory
after a create or rename is a real durability pattern, so it is worth being
explicit about. Measured against wasmtime 47.0.3 on the same probe:

```
                       wasmtime      zwasm+this
fd_sync(preopen)       badf          notcapable
fd_sync(subdir)        badf          notcapable
fd_datasync(subdir)    badf          notcapable
```

Both hosts refuse; only the errno differs. The reference host does not support
the pattern either, so this is not the "narrower than wasmtime" trade ADR-0215
warns about — that trade is real elsewhere (`fd_tell` on an fd opened with
`FD_READ` alone is `notcapable` here and `success` there, and is spec-correct:
witx gates `fd_tell` on `FD_TELL`). Granting the two bits to directories would
make zwasm strictly more permissive than the reference; no test asks for it,
so it is not taken here.

The decisions this rests on — enforce vs advertise, the preopen defaults, the
check ordering, the errno — are recorded in ADR-0215, landed on the first PR
of the stack.

## Verification

- `test-wasi-p1-official`: interp 60 → **63**, jit 60 → **63**.
  Newly green: `truncation_rights`, `path_open_read_write`,
  `fd_fdstat_set_rights`.
- `zig build test-all` green (x86_64-linux).
