### PR TITLE
fix(wasi): a `..` that stays inside the preopen is an ordinary path

### DIFF
--- a/.dev/wasi_p1_rights.md
+++ b/.dev/wasi_p1_rights.md
@@ -11,9 +11,8 @@ they operate on.
 
 > **Implementation status.** The model lands in three changes and this file
 > describes all of it, so parts of it lead the code. Advertising the table and
-> deriving rights onto opened fds: **landed**. Reading a right at each call:
-> **landed**. Folding `..` (`path.normalize`): **not yet**. Each section that
-> runs ahead of the code repeats the fact where it appears.
+> deriving rights onto opened fds, reading a right at each call, and folding
+> `..` (`path.normalize`): all **landed**.
 
 ## Sources
 
@@ -215,14 +214,7 @@ confined to its preopen, but `..` is not itself the violation — a path that
 dips through `..` and comes back stays inside and must resolve. Only an
 absolute path, or one whose `..` ascends past the root, escapes.
 
-**Not yet implemented.** `fd.zig` and `path.zig` still carry a copy each of
-`pathHasParentEscape`, which rejects any `..` segment outright; this section
-states where the rule is going, not where it is. `interesting_paths` is red
-until it lands. The change is scoped to its own PR because it is path
-resolution rather than rights, and it widens acceptance in a different
-subsystem — the criterion is being able to name one cause when a green falls.
-
-The planned shape: a single `path.normalize` folds the path lexically and
+One `path.normalize` folds the path lexically and
 answers `notcapable` only when the fold would leave the root. A trailing
 separator is preserved, because POSIX reads `x/` as "x, which must be a
 directory" and the host syscalls already enforce that. The fold is lexical, so

--- a/.dev/wasi_p1_rights.md
+++ b/.dev/wasi_p1_rights.md
@@ -12,7 +12,7 @@ they operate on.
 > **Implementation status.** The model lands in three changes and this file
 > describes all of it, so parts of it lead the code. Advertising the table and
 > deriving rights onto opened fds, reading a right at each call, and folding
-> `..` (`path.normalize`): all **landed**.
+> `..` (`path.confine`): all **landed**.
 
 ## Sources
 
@@ -214,10 +214,17 @@ confined to its preopen, but `..` is not itself the violation — a path that
 dips through `..` and comes back stays inside and must resolve. Only an
 absolute path, or one whose `..` ascends past the root, escapes.
 
-One `path.normalize` folds the path lexically and
-answers `notcapable` only when the fold would leave the root. A trailing
-separator is preserved, because POSIX reads `x/` as "x, which must be a
-directory" and the host syscalls already enforce that. The fold is lexical, so
-`a/b/..` does not verify that `a/b` exists — the trade-off `path.Clean` makes,
-and the reason follow-time symlink confinement (D-315) remains a separate,
-still-open problem.
+One `path.confine` replaces both copies of the old check. It walks the
+segments with a depth counter and answers `notcapable` only when a `..` would
+take the depth below zero — an absolute path is rejected outright.
+
+It is a **check, not a rewrite**: the path reaches the host exactly as the
+guest wrote it. That matters more than it looks. A folded path drops `.` and
+resolves `..` before the host sees it, so `f/.` and `f/..` on a regular file
+become a successful open of `f`, where POSIX — and wasmtime — answer `notdir`.
+Not rewriting keeps every such case correct for free, and keeps trailing
+separators meaningful without a special case.
+
+The walk is lexical, so it cannot see a symlink component that redirects the
+real resolution. That is the follow-time confinement D-315 tracks, and it is
+unchanged.

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -32,6 +32,7 @@ const std = @import("std");
 
 const p1 = @import("preview1.zig");
 const host_mod = @import("host.zig");
+const path_mod = @import("path.zig");
 const dbg = @import("../support/dbg.zig");
 
 const Host = host_mod.Host;
@@ -662,15 +663,6 @@ pub fn fdFdstatSetRights(host: *Host, fd: p1.Fd, rights_base: p1.Rights, rights_
 // path_open  (§9.4 / 4.5 chunk b)
 // ============================================================
 
-fn pathHasParentEscape(path: []const u8) bool {
-    if (path.len > 0 and path[0] == '/') return true;
-    var iter = std.mem.tokenizeScalar(u8, path, '/');
-    while (iter.next()) |seg| {
-        if (std.mem.eql(u8, seg, "..")) return true;
-    }
-    return false;
-}
-
 /// The rights a `path_open`ed fd receives. Two clamps, both from the witx
 /// `path_open` contract: a derived fd can never exceed the parent directory's
 /// `fs_rights_inheriting` ("rights that apply to file descriptors derived
@@ -936,11 +928,14 @@ pub fn pathOpen(
     // Bounds-check the path slice.
     const path_end = @as(usize, path_ptr) + @as(usize, path_len);
     if (path_end > mem.len) return .fault;
-    const path = mem[path_ptr..path_end];
+    const raw = mem[path_ptr..path_end];
     // POSIX: the empty path is ENOENT. Must be pre-OS: NT resolves "" against
     // a RootDirectory handle as the directory itself.
-    if (path.len == 0) return .noent;
-    if (pathHasParentEscape(path)) return .notcapable;
+    if (raw.len == 0) return .noent;
+    var path_buf: [path_mod.max_guest_path]u8 = undefined;
+    var path: []const u8 = undefined;
+    const norm = path_mod.normalize(raw, &path_buf, &path);
+    if (norm != .success) return norm;
 
     // Resolve dirfd.
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
@@ -1132,11 +1127,14 @@ pub fn fdFilestatGet(host: *Host, mem: []u8, fd: p1.Fd, filestat_ptr: u32) p1.Er
 /// + `..`-escape guard) then `std.Io.Dir.deleteFile`. Non-preopen dirfd →
 /// `notdir`; absolute / `..`-escaping path → `notcapable`.
 pub fn pathUnlinkFile(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
-    const path = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
+    const raw = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
     // POSIX: the empty path is ENOENT. Must be pre-OS: NT resolves "" against
     // a RootDirectory handle as the directory itself (delete would hit the dir).
-    if (path.len == 0) return .noent;
-    if (pathHasParentEscape(path)) return .notcapable;
+    if (raw.len == 0) return .noent;
+    var path_buf: [path_mod.max_guest_path]u8 = undefined;
+    var path: []const u8 = undefined;
+    const norm = path_mod.normalize(raw, &path_buf, &path);
+    if (norm != .success) return norm;
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
     if (dir_slot.kind != .dir) return .notdir;
     if (!dir_slot.has(p1.RIGHTS_PATH_UNLINK_FILE)) return .notcapable;

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -932,10 +932,9 @@ pub fn pathOpen(
     // POSIX: the empty path is ENOENT. Must be pre-OS: NT resolves "" against
     // a RootDirectory handle as the directory itself.
     if (raw.len == 0) return .noent;
-    var path_buf: [path_mod.max_guest_path]u8 = undefined;
-    var path: []const u8 = undefined;
-    const norm = path_mod.normalize(raw, &path_buf, &path);
-    if (norm != .success) return norm;
+    const path = raw;
+    const conf = path_mod.confine(path);
+    if (conf != .success) return conf;
 
     // Resolve dirfd.
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
@@ -1131,10 +1130,9 @@ pub fn pathUnlinkFile(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_
     // POSIX: the empty path is ENOENT. Must be pre-OS: NT resolves "" against
     // a RootDirectory handle as the directory itself (delete would hit the dir).
     if (raw.len == 0) return .noent;
-    var path_buf: [path_mod.max_guest_path]u8 = undefined;
-    var path: []const u8 = undefined;
-    const norm = path_mod.normalize(raw, &path_buf, &path);
-    if (norm != .success) return norm;
+    const path = raw;
+    const conf = path_mod.confine(path);
+    if (conf != .success) return conf;
     const dir_slot = host.translateFd(dirfd) orelse return .badf;
     if (dir_slot.kind != .dir) return .notdir;
     if (!dir_slot.has(p1.RIGHTS_PATH_UNLINK_FILE)) return .notcapable;

--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -896,11 +896,12 @@ pub fn fdReaddir(host: *Host, mem: []u8, fd: p1.Fd, buf_ptr: u32, buf_len: u32, 
 ///   (preopens are the only roots) → `notdir` otherwise.
 /// - The path string spans `mem[path_ptr .. path_ptr +
 ///   path_len]`. Out-of-bounds → `fault`.
-/// - Path must be relative and contain no `..` segments —
-///   absolute paths or any traversal escape returns
-///   `notcapable`. The kernel-side `openat` would also block
-///   most escapes, but the explicit pre-check is part of the
-///   WASI security contract.
+/// - Path must be relative and must not ascend past the preopen —
+///   `path.confine` walks the segments with a depth counter, so a
+///   `..` that comes back stays inside and resolves, while an
+///   absolute path or one that would leave returns `notcapable`.
+///   The kernel-side `openat` would also block most escapes, but
+///   the explicit pre-check is part of the WASI security contract.
 /// - Open is delegated to `std.Io.Dir{.fd = slot.host_handle}
 ///   .openFile(io, ...)`. Errors map through `mapOpenError`.
 ///
@@ -1123,8 +1124,9 @@ pub fn fdFilestatGet(host: *Host, mem: []u8, fd: p1.Fd, filestat_ptr: u32) p1.Er
 
 /// Wasm WASI snapshot-1 `path_unlink_file` — delete a file relative to a
 /// preopen `.dir` fd. Mirrors `pathOpen`'s front-half (preopen resolution
-/// + `..`-escape guard) then `std.Io.Dir.deleteFile`. Non-preopen dirfd →
-/// `notdir`; absolute / `..`-escaping path → `notcapable`.
+/// + `path.confine`) then `std.Io.Dir.deleteFile`. Non-preopen dirfd →
+/// `notdir`; an absolute path, or one whose `..` ascends past the preopen →
+/// `notcapable`. A balanced `..` resolves.
 pub fn pathUnlinkFile(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     const raw = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
     // POSIX: the empty path is ENOENT. Must be pre-OS: NT resolves "" against

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -25,15 +25,56 @@ fn sliceMemConst(mem: []const u8, ptr: u32, len: u32) ?[]const u8 {
     return mem[ptr..end];
 }
 
-/// A guest path is sandboxed to its preopen root: absolute paths and any `..`
-/// segment escape the root and are rejected with `notcapable`.
-fn pathHasParentEscape(path: []const u8) bool {
-    if (path.len > 0 and path[0] == '/') return true;
+/// The longest guest path a preview1 call may present, in bytes. Longer is
+/// `nametoolong` — the host syscalls would say the same.
+pub const max_guest_path = 4096;
+
+/// Fold a guest path into a form relative to the preopen root it is resolved
+/// against, writing the result into `buf` and publishing it through `out`.
+///
+/// A preview1 path is confined to its preopen, but `..` is NOT itself the
+/// violation: a path that dips through `..` and comes back stays inside the
+/// root and must resolve. Only an absolute path, or one whose `..` segments
+/// ascend PAST the root, escapes — both are `notcapable`.
+///
+/// `.` and repeated separators are folded out. A trailing separator is KEPT,
+/// because POSIX reads `x/` as "x, which must be a directory" and the host
+/// syscalls already enforce that. The fold is lexical, so `a/b/..` does not
+/// verify that `a/b` exists — the same trade-off `path.Clean` makes.
+pub fn normalize(path: []const u8, buf: []u8, out: *[]const u8) p1.Errno {
+    if (path.len == 0) return .noent;
+    if (path[0] == '/') return .notcapable;
+    // An interior NUL would be truncated by the host's C path conversion, so
+    // the guest would silently open a DIFFERENT path than the one it named.
+    if (std.mem.findScalar(u8, path, 0) != null) return .inval;
+    // Each kept component is written with its separator, so the fold can be
+    // one byte longer than the input ("a" -> "a/").
+    if (path.len + 1 > buf.len) return .nametoolong;
+
+    var len: usize = 0;
     var it = std.mem.tokenizeScalar(u8, path, '/');
     while (it.next()) |seg| {
-        if (std.mem.eql(u8, seg, "..")) return true;
+        if (std.mem.eql(u8, seg, ".")) continue;
+        if (std.mem.eql(u8, seg, "..")) {
+            if (len == 0) return .notcapable; // ascends above the preopen root
+            // Drop the last component: every written one ends in '/', so the
+            // separator before it bounds what to cut.
+            len = if (std.mem.findScalarLast(u8, buf[0 .. len - 1], '/')) |i| i + 1 else 0;
+            continue;
+        }
+        @memcpy(buf[len..][0..seg.len], seg);
+        len += seg.len;
+        buf[len] = '/';
+        len += 1;
     }
-    return false;
+    if (len == 0) {
+        // Everything folded away: the path names the dirfd itself.
+        out.* = ".";
+        return .success;
+    }
+    if (path[path.len - 1] != '/') len -= 1; // no trailing separator asked for
+    out.* = buf[0..len];
+    return .success;
 }
 
 /// A symlink TARGET escapes the preopen root if, resolved relative to the
@@ -42,7 +83,7 @@ fn pathHasParentEscape(path: []const u8) bool {
 /// stops a guest from CREATING, through zwasm's own API, a symlink that points
 /// outside the sandbox — the primary "plant then read through it" escalation.
 /// `link_sub` is the link's path relative to the preopen root and has already
-/// passed `pathHasParentEscape` (no `..`, not absolute).
+/// been folded by `normalize` (no `..`, no `.`, not absolute).
 ///
 /// Following a PRE-EXISTING on-disk symlink that escapes is the separate
 /// follow-time confinement (RESOLVE_BENEATH / component walk) tracked by D-315;
@@ -72,21 +113,27 @@ fn symlinkTargetEscapes(link_sub: []const u8, target: []const u8) bool {
 
 const Resolved = struct { dir: std.Io.Dir, sub: []const u8 };
 
+/// Scratch for one normalised path. Declared by the caller so `Resolved.sub`
+/// points at storage that outlives `resolve`.
+const PathBuf = [max_guest_path]u8;
+
 /// Resolve `(dirfd, path_ptr, path_len)` to a host `Dir` + bounded guest path,
 /// and check that `needed` — the right the witx doc comment names for the
 /// calling operation — is present in the dirfd's `fs_rights_base`. Returns the
 /// errno on failure (`.success` when `out` is populated).
-fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, needed: p1.Rights, out: *Resolved) p1.Errno {
+fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, needed: p1.Rights, buf: *PathBuf, out: *Resolved) p1.Errno {
     const path = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
     // POSIX: the empty path resolves to nothing (ENOENT). Guarded here because
     // std.Io panics on the resulting EINVAL in debug builds ("programmer bug").
     if (path.len == 0) return .noent;
-    if (pathHasParentEscape(path)) return .notcapable;
+    var sub: []const u8 = undefined;
+    const ne = normalize(path, buf, &sub);
+    if (ne != .success) return ne;
     const slot = host.translateFd(dirfd) orelse return .badf;
     if (slot.kind != .dir) return .notdir;
     if (!slot.has(needed)) return .notcapable;
     const handle = slot.host_handle orelse return .notdir;
-    out.* = .{ .dir = .{ .handle = handle }, .sub = path };
+    out.* = .{ .dir = .{ .handle = handle }, .sub = sub };
     return .success;
 }
 
@@ -121,8 +168,9 @@ fn mapDirErr(err: anyerror) p1.Errno {
 /// `path_create_directory(dirfd, path) → errno` — create a directory relative
 /// to the preopen `dirfd` (`std.Io.Dir.createDir`).
 pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
+    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_CREATE_DIRECTORY, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_CREATE_DIRECTORY, &buf, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     r.dir.createDir(io, r.sub, std.Io.File.Permissions.default_dir) catch |err| return mapDirErr(err);
@@ -132,8 +180,9 @@ pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// `path_remove_directory(dirfd, path) → errno` — remove an empty directory
 /// relative to `dirfd` (`std.Io.Dir.deleteDir`; non-empty → `notempty`).
 pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
+    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &buf, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     // rmdir(".") is EINVAL per POSIX; guarded because std.Io panics on the
@@ -151,11 +200,13 @@ pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// (move) a path across two preopen dirfds (`std.Io.Dir.rename`). Both ends are
 /// resolved + escape-guarded.
 pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
+    var obuf: PathBuf = undefined;
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_RENAME_SOURCE, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_RENAME_SOURCE, &obuf, &ro);
     if (e1 != .success) return e1;
+    var nbuf: PathBuf = undefined;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_RENAME_TARGET, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_RENAME_TARGET, &nbuf, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     // rename involving "." is EINVAL/EBUSY per POSIX; guarded because std.Io
@@ -170,11 +221,13 @@ pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, 
 /// create a hard link at `new_path` to the existing `old_path`
 /// (`std.Io.Dir.hardLink`). `old_flags` bit 0 = follow-symlinks.
 pub fn pathLink(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_flags: u32, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
+    var obuf: PathBuf = undefined;
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_LINK_SOURCE, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_LINK_SOURCE, &obuf, &ro);
     if (e1 != .success) return e1;
+    var nbuf: PathBuf = undefined;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_LINK_TARGET, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_LINK_TARGET, &nbuf, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     const follow = old_flags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0;
@@ -303,8 +356,9 @@ fn winPathLink(old_dir: std.Io.Dir, old_sub: []const u8, new_dir: std.Io.Dir, ne
 /// points outside the sandbox (`notcapable`).
 pub fn pathSymlink(host: *Host, mem: []const u8, target_ptr: u32, target_len: u32, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     const target = sliceMemConst(mem, target_ptr, target_len) orelse return .fault;
+    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_SYMLINK, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_SYMLINK, &buf, &r);
     if (e != .success) return e;
     if (symlinkTargetEscapes(r.sub, target)) return .notcapable;
     const io = host.io orelse return .nosys;
@@ -322,8 +376,9 @@ pub fn pathReadlink(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_le
         if (end > mem.len) return .fault;
         break :blk mem[buf_ptr..end];
     };
+    var pbuf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_READLINK, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_READLINK, &pbuf, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const n = r.dir.readLink(io, r.sub, buf) catch |err| return mapDirErr(err);
@@ -361,8 +416,9 @@ pub fn pathFilestatGet(host: *Host, mem: []u8, dirfd: p1.Fd, lookupflags: u32, p
         if (end > mem.len) return .fault;
         break :blk mem[filestat_ptr..end];
     };
+    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_GET, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_GET, &buf, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const st = r.dir.statFile(io, r.sub, .{ .follow_symlinks = lookupflags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0 }) catch |err| return mapDirErr(err);
@@ -387,8 +443,9 @@ pub fn pathFilestatGet(host: *Host, mem: []u8, dirfd: p1.Fd, lookupflags: u32, p
 pub fn pathFilestatSetTimes(host: *Host, mem: []const u8, dirfd: p1.Fd, lookupflags: u32, path_ptr: u32, path_len: u32, atim: u64, mtim: u64, fst_flags: p1.Fstflags) p1.Errno {
     if (fst_flags & p1.FSTFLAGS_ATIM != 0 and fst_flags & p1.FSTFLAGS_ATIM_NOW != 0) return .inval;
     if (fst_flags & p1.FSTFLAGS_MTIM != 0 and fst_flags & p1.FSTFLAGS_MTIM_NOW != 0) return .inval;
+    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_SET_TIMES, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_SET_TIMES, &buf, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const atime = setTimestampOf(fst_flags, p1.FSTFLAGS_ATIM_NOW, p1.FSTFLAGS_ATIM, atim);
@@ -610,4 +667,65 @@ test "path_* resolution: escape / non-dir / out-of-bounds rejections" {
     // Removing a missing directory → noent.
     writeGuestPath(&mem, 0, "ghost");
     try testing.expectEqual(p1.Errno.noent, pathRemoveDirectory(&h, &mem, dirfd, 0, 5));
+}
+
+// ============================================================
+// Path folding
+// ============================================================
+
+fn expectNormalized(expected: []const u8, path: []const u8) !void {
+    var buf: PathBuf = undefined;
+    var got: []const u8 = undefined;
+    try testing.expectEqual(p1.Errno.success, normalize(path, &buf, &got));
+    try testing.expectEqualStrings(expected, got);
+}
+
+test "normalize: folds `.` and `..` that stay inside the preopen root" {
+    // The literal path the official `interesting_paths` opens and expects to
+    // resolve — it dips through `..` twice and comes back.
+    try expectNormalized("dir/nested/file", "dir/.//nested/../../dir/nested/../nested///./file");
+    try expectNormalized("a/b", "a/b");
+    try expectNormalized("a/b", "./a/./b");
+    try expectNormalized("a/c", "a/b/../c");
+    try expectNormalized("b", "a/../b");
+    // Folding everything away names the dirfd itself.
+    try expectNormalized(".", ".");
+    try expectNormalized(".", "a/..");
+    try expectNormalized(".", "./");
+}
+
+test "normalize: a trailing separator survives the fold" {
+    // POSIX reads `x/` as "x, which must be a directory"; the host syscalls
+    // enforce that, so the fold must not quietly drop it (official
+    // `interesting_paths` opens `dir/nested/` and `dir/nested/file/`).
+    try expectNormalized("dir/nested/", "dir/nested/");
+    try expectNormalized("dir/nested/", "dir/nested///");
+    try expectNormalized("dir/nested/file/", "dir/nested/file///");
+    try expectNormalized("dir/nested/file", "dir/nested/file");
+}
+
+test "normalize: leaving the preopen root is notcapable" {
+    var buf: PathBuf = undefined;
+    var got: []const u8 = undefined;
+    // Absolute.
+    try testing.expectEqual(p1.Errno.notcapable, normalize("/dir/nested/file", &buf, &got));
+    try testing.expectEqual(p1.Errno.notcapable, normalize("/", &buf, &got));
+    // One `..` too many — the fold would ascend above the root.
+    try testing.expectEqual(p1.Errno.notcapable, normalize("..", &buf, &got));
+    try testing.expectEqual(p1.Errno.notcapable, normalize("../escape", &buf, &got));
+    try testing.expectEqual(p1.Errno.notcapable, normalize("dir/nested/../../../dir/nested/file", &buf, &got));
+    // Balanced to exactly the root is still inside it.
+    try expectNormalized(".", "dir/..");
+}
+
+test "normalize: an interior NUL and an over-long path are rejected" {
+    var buf: PathBuf = undefined;
+    var got: []const u8 = undefined;
+    // The host's C path conversion would truncate at the NUL and resolve a
+    // DIFFERENT path than the guest named.
+    try testing.expectEqual(p1.Errno.inval, normalize("dir/nested/file\x00", &buf, &got));
+    try testing.expectEqual(p1.Errno.noent, normalize("", &buf, &got));
+
+    var long: [max_guest_path + 1]u8 = @splat('a');
+    try testing.expectEqual(p1.Errno.nametoolong, normalize(&long, &buf, &got));
 }

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -25,55 +25,39 @@ fn sliceMemConst(mem: []const u8, ptr: u32, len: u32) ?[]const u8 {
     return mem[ptr..end];
 }
 
-/// The longest guest path a preview1 call may present, in bytes. Longer is
-/// `nametoolong` — the host syscalls would say the same.
-pub const max_guest_path = 4096;
-
-/// Fold a guest path into a form relative to the preopen root it is resolved
-/// against, writing the result into `buf` and publishing it through `out`.
+/// Reject a guest path that would leave the preopen it is resolved against.
 ///
-/// A preview1 path is confined to its preopen, but `..` is NOT itself the
-/// violation: a path that dips through `..` and comes back stays inside the
-/// root and must resolve. Only an absolute path, or one whose `..` segments
-/// ascend PAST the root, escapes — both are `notcapable`.
+/// preview1 confines every path to its preopen, but `..` is not itself the
+/// violation: a path that dips through `..` and comes back stays inside and
+/// must resolve. Only an absolute path, or one whose `..` segments ascend PAST
+/// the root, escapes.
 ///
-/// `.` and repeated separators are folded out. A trailing separator is KEPT,
-/// because POSIX reads `x/` as "x, which must be a directory" and the host
-/// syscalls already enforce that. The fold is lexical, so `a/b/..` does not
-/// verify that `a/b` exists — the same trade-off `path.Clean` makes.
-pub fn normalize(path: []const u8, buf: []u8, out: *[]const u8) p1.Errno {
+/// This is a CHECK, not a rewrite. The path reaches the host exactly as the
+/// guest wrote it, so `.`, `..` and trailing separators keep their POSIX
+/// meaning — `f/.` and `f/..` on a regular file stay `notdir`, which a folded
+/// path would silently turn into a successful open of `f`.
+///
+/// The walk is lexical, so it cannot see a symlink component that redirects
+/// the real resolution; that is the follow-time confinement D-315 tracks, and
+/// it is unchanged by this.
+pub fn confine(path: []const u8) p1.Errno {
     if (path.len == 0) return .noent;
     if (path[0] == '/') return .notcapable;
     // An interior NUL would be truncated by the host's C path conversion, so
     // the guest would silently open a DIFFERENT path than the one it named.
     if (std.mem.findScalar(u8, path, 0) != null) return .inval;
-    // Each kept component is written with its separator, so the fold can be
-    // one byte longer than the input ("a" -> "a/").
-    if (path.len + 1 > buf.len) return .nametoolong;
 
-    var len: usize = 0;
+    var depth: usize = 0;
     var it = std.mem.tokenizeScalar(u8, path, '/');
     while (it.next()) |seg| {
         if (std.mem.eql(u8, seg, ".")) continue;
         if (std.mem.eql(u8, seg, "..")) {
-            if (len == 0) return .notcapable; // ascends above the preopen root
-            // Drop the last component: every written one ends in '/', so the
-            // separator before it bounds what to cut.
-            len = if (std.mem.findScalarLast(u8, buf[0 .. len - 1], '/')) |i| i + 1 else 0;
+            if (depth == 0) return .notcapable; // ascends above the preopen root
+            depth -= 1;
             continue;
         }
-        @memcpy(buf[len..][0..seg.len], seg);
-        len += seg.len;
-        buf[len] = '/';
-        len += 1;
+        depth += 1;
     }
-    if (len == 0) {
-        // Everything folded away: the path names the dirfd itself.
-        out.* = ".";
-        return .success;
-    }
-    if (path[path.len - 1] != '/') len -= 1; // no trailing separator asked for
-    out.* = buf[0..len];
     return .success;
 }
 
@@ -82,8 +66,9 @@ pub fn normalize(path: []const u8, buf: []u8, out: *[]const u8) p1.Errno {
 /// absolute). This is the PLANT-time half of cap-std-style confinement: it
 /// stops a guest from CREATING, through zwasm's own API, a symlink that points
 /// outside the sandbox — the primary "plant then read through it" escalation.
-/// `link_sub` is the link's path relative to the preopen root and has already
-/// been folded by `normalize` (no `..`, no `.`, not absolute).
+/// `link_sub` is the link's path relative to the preopen root, as the guest
+/// wrote it — `confine` has passed it, so it is relative and stays inside, but
+/// it may still carry `.` and `..`, which the depth walk below folds.
 ///
 /// Following a PRE-EXISTING on-disk symlink that escapes is the separate
 /// follow-time confinement (RESOLVE_BENEATH / component walk) tracked by D-315;
@@ -95,6 +80,10 @@ fn symlinkTargetEscapes(link_sub: []const u8, target: []const u8) bool {
     var lit = std.mem.tokenizeScalar(u8, link_sub, '/');
     while (lit.next()) |seg| {
         if (std.mem.eql(u8, seg, ".")) continue;
+        if (std.mem.eql(u8, seg, "..")) {
+            if (depth > 0) depth -= 1;
+            continue;
+        }
         depth += 1;
     }
     if (depth > 0) depth -= 1; // drop the link's own final component
@@ -113,27 +102,22 @@ fn symlinkTargetEscapes(link_sub: []const u8, target: []const u8) bool {
 
 const Resolved = struct { dir: std.Io.Dir, sub: []const u8 };
 
-/// Scratch for one normalised path. Declared by the caller so `Resolved.sub`
-/// points at storage that outlives `resolve`.
-const PathBuf = [max_guest_path]u8;
-
 /// Resolve `(dirfd, path_ptr, path_len)` to a host `Dir` + bounded guest path,
 /// and check that `needed` — the right the witx doc comment names for the
 /// calling operation — is present in the dirfd's `fs_rights_base`. Returns the
 /// errno on failure (`.success` when `out` is populated).
-fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, needed: p1.Rights, buf: *PathBuf, out: *Resolved) p1.Errno {
+fn resolve(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32, needed: p1.Rights, out: *Resolved) p1.Errno {
     const path = sliceMemConst(mem, path_ptr, path_len) orelse return .fault;
     // POSIX: the empty path resolves to nothing (ENOENT). Guarded here because
     // std.Io panics on the resulting EINVAL in debug builds ("programmer bug").
     if (path.len == 0) return .noent;
-    var sub: []const u8 = undefined;
-    const ne = normalize(path, buf, &sub);
-    if (ne != .success) return ne;
+    const ce = confine(path);
+    if (ce != .success) return ce;
     const slot = host.translateFd(dirfd) orelse return .badf;
     if (slot.kind != .dir) return .notdir;
     if (!slot.has(needed)) return .notcapable;
     const handle = slot.host_handle orelse return .notdir;
-    out.* = .{ .dir = .{ .handle = handle }, .sub = sub };
+    out.* = .{ .dir = .{ .handle = handle }, .sub = path };
     return .success;
 }
 
@@ -168,9 +152,8 @@ fn mapDirErr(err: anyerror) p1.Errno {
 /// `path_create_directory(dirfd, path) → errno` — create a directory relative
 /// to the preopen `dirfd` (`std.Io.Dir.createDir`).
 pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
-    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_CREATE_DIRECTORY, &buf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_CREATE_DIRECTORY, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     r.dir.createDir(io, r.sub, std.Io.File.Permissions.default_dir) catch |err| return mapDirErr(err);
@@ -180,9 +163,8 @@ pub fn pathCreateDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// `path_remove_directory(dirfd, path) → errno` — remove an empty directory
 /// relative to `dirfd` (`std.Io.Dir.deleteDir`; non-empty → `notempty`).
 pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
-    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &buf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     // rmdir(".") is EINVAL per POSIX; guarded because std.Io panics on the
@@ -200,13 +182,11 @@ pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
 /// (move) a path across two preopen dirfds (`std.Io.Dir.rename`). Both ends are
 /// resolved + escape-guarded.
 pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
-    var obuf: PathBuf = undefined;
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_RENAME_SOURCE, &obuf, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_RENAME_SOURCE, &ro);
     if (e1 != .success) return e1;
-    var nbuf: PathBuf = undefined;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_RENAME_TARGET, &nbuf, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_RENAME_TARGET, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     // rename involving "." is EINVAL/EBUSY per POSIX; guarded because std.Io
@@ -221,13 +201,11 @@ pub fn pathRename(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_ptr: u32, 
 /// create a hard link at `new_path` to the existing `old_path`
 /// (`std.Io.Dir.hardLink`). `old_flags` bit 0 = follow-symlinks.
 pub fn pathLink(host: *Host, mem: []const u8, old_dirfd: p1.Fd, old_flags: u32, old_ptr: u32, old_len: u32, new_dirfd: p1.Fd, new_ptr: u32, new_len: u32) p1.Errno {
-    var obuf: PathBuf = undefined;
     var ro: Resolved = undefined;
-    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_LINK_SOURCE, &obuf, &ro);
+    const e1 = resolve(host, mem, old_dirfd, old_ptr, old_len, p1.RIGHTS_PATH_LINK_SOURCE, &ro);
     if (e1 != .success) return e1;
-    var nbuf: PathBuf = undefined;
     var rn: Resolved = undefined;
-    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_LINK_TARGET, &nbuf, &rn);
+    const e2 = resolve(host, mem, new_dirfd, new_ptr, new_len, p1.RIGHTS_PATH_LINK_TARGET, &rn);
     if (e2 != .success) return e2;
     const io = host.io orelse return .nosys;
     const follow = old_flags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0;
@@ -356,9 +334,8 @@ fn winPathLink(old_dir: std.Io.Dir, old_sub: []const u8, new_dir: std.Io.Dir, ne
 /// points outside the sandbox (`notcapable`).
 pub fn pathSymlink(host: *Host, mem: []const u8, target_ptr: u32, target_len: u32, dirfd: p1.Fd, path_ptr: u32, path_len: u32) p1.Errno {
     const target = sliceMemConst(mem, target_ptr, target_len) orelse return .fault;
-    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_SYMLINK, &buf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_SYMLINK, &r);
     if (e != .success) return e;
     if (symlinkTargetEscapes(r.sub, target)) return .notcapable;
     const io = host.io orelse return .nosys;
@@ -376,9 +353,8 @@ pub fn pathReadlink(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_le
         if (end > mem.len) return .fault;
         break :blk mem[buf_ptr..end];
     };
-    var pbuf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_READLINK, &pbuf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_READLINK, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const n = r.dir.readLink(io, r.sub, buf) catch |err| return mapDirErr(err);
@@ -416,9 +392,8 @@ pub fn pathFilestatGet(host: *Host, mem: []u8, dirfd: p1.Fd, lookupflags: u32, p
         if (end > mem.len) return .fault;
         break :blk mem[filestat_ptr..end];
     };
-    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_GET, &buf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_GET, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const st = r.dir.statFile(io, r.sub, .{ .follow_symlinks = lookupflags & p1.LOOKUPFLAGS_SYMLINK_FOLLOW != 0 }) catch |err| return mapDirErr(err);
@@ -443,9 +418,8 @@ pub fn pathFilestatGet(host: *Host, mem: []u8, dirfd: p1.Fd, lookupflags: u32, p
 pub fn pathFilestatSetTimes(host: *Host, mem: []const u8, dirfd: p1.Fd, lookupflags: u32, path_ptr: u32, path_len: u32, atim: u64, mtim: u64, fst_flags: p1.Fstflags) p1.Errno {
     if (fst_flags & p1.FSTFLAGS_ATIM != 0 and fst_flags & p1.FSTFLAGS_ATIM_NOW != 0) return .inval;
     if (fst_flags & p1.FSTFLAGS_MTIM != 0 and fst_flags & p1.FSTFLAGS_MTIM_NOW != 0) return .inval;
-    var buf: PathBuf = undefined;
     var r: Resolved = undefined;
-    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_SET_TIMES, &buf, &r);
+    const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_FILESTAT_SET_TIMES, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
     const atime = setTimestampOf(fst_flags, p1.FSTFLAGS_ATIM_NOW, p1.FSTFLAGS_ATIM, atim);
@@ -670,62 +644,43 @@ test "path_* resolution: escape / non-dir / out-of-bounds rejections" {
 }
 
 // ============================================================
-// Path folding
+// Path confinement
 // ============================================================
 
-fn expectNormalized(expected: []const u8, path: []const u8) !void {
-    var buf: PathBuf = undefined;
-    var got: []const u8 = undefined;
-    try testing.expectEqual(p1.Errno.success, normalize(path, &buf, &got));
-    try testing.expectEqualStrings(expected, got);
-}
-
-test "normalize: folds `.` and `..` that stay inside the preopen root" {
+test "confine: a `..` that stays inside the preopen root is allowed" {
     // The literal path the official `interesting_paths` opens and expects to
     // resolve — it dips through `..` twice and comes back.
-    try expectNormalized("dir/nested/file", "dir/.//nested/../../dir/nested/../nested///./file");
-    try expectNormalized("a/b", "a/b");
-    try expectNormalized("a/b", "./a/./b");
-    try expectNormalized("a/c", "a/b/../c");
-    try expectNormalized("b", "a/../b");
-    // Folding everything away names the dirfd itself.
-    try expectNormalized(".", ".");
-    try expectNormalized(".", "a/..");
-    try expectNormalized(".", "./");
+    try testing.expectEqual(p1.Errno.success, confine("dir/.//nested/../../dir/nested/../nested///./file"));
+    try testing.expectEqual(p1.Errno.success, confine("a/b"));
+    try testing.expectEqual(p1.Errno.success, confine("./a/./b"));
+    try testing.expectEqual(p1.Errno.success, confine("a/b/../c"));
+    try testing.expectEqual(p1.Errno.success, confine("a/../b"));
+    try testing.expectEqual(p1.Errno.success, confine("."));
+    try testing.expectEqual(p1.Errno.success, confine("a/.."));
 }
 
-test "normalize: a trailing separator survives the fold" {
-    // POSIX reads `x/` as "x, which must be a directory"; the host syscalls
-    // enforce that, so the fold must not quietly drop it (official
-    // `interesting_paths` opens `dir/nested/` and `dir/nested/file/`).
-    try expectNormalized("dir/nested/", "dir/nested/");
-    try expectNormalized("dir/nested/", "dir/nested///");
-    try expectNormalized("dir/nested/file/", "dir/nested/file///");
-    try expectNormalized("dir/nested/file", "dir/nested/file");
-}
-
-test "normalize: leaving the preopen root is notcapable" {
-    var buf: PathBuf = undefined;
-    var got: []const u8 = undefined;
-    // Absolute.
-    try testing.expectEqual(p1.Errno.notcapable, normalize("/dir/nested/file", &buf, &got));
-    try testing.expectEqual(p1.Errno.notcapable, normalize("/", &buf, &got));
-    // One `..` too many — the fold would ascend above the root.
-    try testing.expectEqual(p1.Errno.notcapable, normalize("..", &buf, &got));
-    try testing.expectEqual(p1.Errno.notcapable, normalize("../escape", &buf, &got));
-    try testing.expectEqual(p1.Errno.notcapable, normalize("dir/nested/../../../dir/nested/file", &buf, &got));
+test "confine: leaving the preopen root is notcapable" {
+    try testing.expectEqual(p1.Errno.notcapable, confine("/dir/nested/file"));
+    try testing.expectEqual(p1.Errno.notcapable, confine("/"));
+    try testing.expectEqual(p1.Errno.notcapable, confine(".."));
+    try testing.expectEqual(p1.Errno.notcapable, confine("../escape"));
+    try testing.expectEqual(p1.Errno.notcapable, confine("dir/nested/../../../dir/nested/file"));
     // Balanced to exactly the root is still inside it.
-    try expectNormalized(".", "dir/..");
+    try testing.expectEqual(p1.Errno.success, confine("dir/.."));
 }
 
-test "normalize: an interior NUL and an over-long path are rejected" {
-    var buf: PathBuf = undefined;
-    var got: []const u8 = undefined;
+test "confine: the empty path and an interior NUL are rejected" {
+    try testing.expectEqual(p1.Errno.noent, confine(""));
     // The host's C path conversion would truncate at the NUL and resolve a
     // DIFFERENT path than the guest named.
-    try testing.expectEqual(p1.Errno.inval, normalize("dir/nested/file\x00", &buf, &got));
-    try testing.expectEqual(p1.Errno.noent, normalize("", &buf, &got));
+    try testing.expectEqual(p1.Errno.inval, confine("dir/nested/file\x00"));
+}
 
-    var long: [max_guest_path + 1]u8 = @splat('a');
-    try testing.expectEqual(p1.Errno.nametoolong, normalize(&long, &buf, &got));
+test "confine: POSIX meaning survives, because the path is not rewritten" {
+    // A fold would drop these components and turn `f/.` into a successful open
+    // of `f`; the host has to see them to answer `notdir`. Verified end to end
+    // against wasmtime 47.3: `f/.`, `f/./.` and `f/..` are all `notdir` there.
+    for ([_][]const u8{ "f/.", "f/./.", "f/..", "f/", "dir/nested/", "dir/nested/file/" }) |p| {
+        try testing.expectEqual(p1.Errno.success, confine(p));
+    }
 }

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -70,6 +70,21 @@ pub fn confine(path: []const u8) p1.Errno {
 /// wrote it — `confine` has passed it, so it is relative and stays inside, but
 /// it may still carry `.` and `..`, which the depth walk below folds.
 ///
+/// Two things make that fold sound, and neither is local to this function:
+///
+///  - `depth` is a PERMISSIVENESS budget: a larger one lets the target spend
+///    more `..` before this returns true. So an under-count is strict and an
+///    over-count is the dangerous direction. `confine` running first is what
+///    rules out the over-count — it guarantees `link_sub` is relative and
+///    never dips below the root, so the `depth > 0` clamp here can only fire
+///    on a path that already balanced out.
+///  - A `link_sub` whose last component is `.` or `..` DOES mis-count, because
+///    the fold consumes it and then "drop the link's own final component"
+///    drops a second one. It under-counts, so it errs strict. It is also
+///    unreachable: `symlinkat` answers EEXIST for every such name (measured —
+///    `a/.`, `a/..`, `a/b/.`, `a/b/..` on Linux), so the host refuses before
+///    the miscount could matter.
+///
 /// Following a PRE-EXISTING on-disk symlink that escapes is the separate
 /// follow-time confinement (RESOLVE_BENEATH / component walk) tracked by D-315;
 /// this lexical check is sound and matches the WASI host policy for creation.

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -1,7 +1,7 @@
 //! WASI 0.1 `path_*` handlers (D-278): filesystem operations relative to a
 //! preopen `.dir` fd. Each resolves the dirfd + bounds-checks the guest path
-//! + rejects `..`-escape (the WASI sandbox contract, mirroring `fd.zig`'s
-//! `pathOpen` front-half), then delegates to the cross-platform `std.Io.Dir`
+//! + confines it to the preopen (`confine`: a balanced `..` resolves, one that
+//! ascends past the root does not), then delegates to the cross-platform `std.Io.Dir`
 //! API (NOT `std.posix.*` — those hardcode POSIX `c_int` fds and break Win64;
 //! see lesson windowsmini-reconciliation).
 //!
@@ -70,21 +70,6 @@ pub fn confine(path: []const u8) p1.Errno {
 /// wrote it — `confine` has passed it, so it is relative and stays inside, but
 /// it may still carry `.` and `..`, which the depth walk below folds.
 ///
-/// Two things make that fold sound, and neither is local to this function:
-///
-///  - `depth` is a PERMISSIVENESS budget: a larger one lets the target spend
-///    more `..` before this returns true. So an under-count is strict and an
-///    over-count is the dangerous direction. `confine` running first is what
-///    rules out the over-count — it guarantees `link_sub` is relative and
-///    never dips below the root, so the `depth > 0` clamp here can only fire
-///    on a path that already balanced out.
-///  - A `link_sub` whose last component is `.` or `..` DOES mis-count, because
-///    the fold consumes it and then "drop the link's own final component"
-///    drops a second one. It under-counts, so it errs strict. It is also
-///    unreachable: `symlinkat` answers EEXIST for every such name (measured —
-///    `a/.`, `a/..`, `a/b/.`, `a/b/..` on Linux), so the host refuses before
-///    the miscount could matter.
-///
 /// Following a PRE-EXISTING on-disk symlink that escapes is the separate
 /// follow-time confinement (RESOLVE_BENEATH / component walk) tracked by D-315;
 /// this lexical check is sound and matches the WASI host policy for creation.
@@ -113,6 +98,20 @@ fn symlinkTargetEscapes(link_sub: []const u8, target: []const u8) bool {
         }
     }
     return false;
+}
+
+/// Whether `path`'s LAST component is `.` — `a/.`, `./`, `.` all qualify.
+///
+/// POSIX makes `rmdir` on such a path EINVAL, and Zig's `std.Io` classifies
+/// that errno as a programmer bug and panics on it in debug builds. So the
+/// check has to happen here, and it has to match every spelling: guarding the
+/// literal `.` and `./` alone left `a/.` reaching the host, where a guest
+/// could abort the runtime with one call.
+fn endsInDotComponent(path: []const u8) bool {
+    var last: []const u8 = &.{};
+    var it = std.mem.tokenizeScalar(u8, path, '/');
+    while (it.next()) |seg| last = seg;
+    return std.mem.eql(u8, last, ".");
 }
 
 const Resolved = struct { dir: std.Io.Dir, sub: []const u8 };
@@ -182,9 +181,9 @@ pub fn pathRemoveDirectory(host: *Host, mem: []const u8, dirfd: p1.Fd, path_ptr:
     const e = resolve(host, mem, dirfd, path_ptr, path_len, p1.RIGHTS_PATH_REMOVE_DIRECTORY, &r);
     if (e != .success) return e;
     const io = host.io orelse return .nosys;
-    // rmdir(".") is EINVAL per POSIX; guarded because std.Io panics on the
-    // unexpected EINVAL in debug builds.
-    if (std.mem.eql(u8, r.sub, ".") or std.mem.eql(u8, r.sub, "./")) return .inval;
+    // rmdir on a path whose last component is `.` is EINVAL per POSIX; guarded
+    // because std.Io panics on that errno in debug builds (see the helper).
+    if (endsInDotComponent(r.sub)) return .inval;
     r.dir.deleteDir(io, r.sub) catch |err| return mapDirErr(err);
     return .success;
 }
@@ -698,4 +697,30 @@ test "confine: POSIX meaning survives, because the path is not rewritten" {
     for ([_][]const u8{ "f/.", "f/./.", "f/..", "f/", "dir/nested/", "dir/nested/file/" }) |p| {
         try testing.expectEqual(p1.Errno.success, confine(p));
     }
+}
+
+test "path_remove_directory: every spelling of a trailing `.` is inval, not a host panic" {
+    // `std.Io` treats the EINVAL that `rmdir` returns for these as a programmer
+    // bug and panics in debug builds, so reaching the host at all is a guest
+    // aborting the runtime. Guarding only the literal `.` and `./` left `a/.`.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    h.io = testing.io;
+    const dirfd = try h.addPreopen(tmp.dir.handle, "/sandbox");
+    const root: std.Io.Dir = .{ .handle = tmp.dir.handle };
+    try root.createDir(testing.io, "a", std.Io.File.Permissions.default_dir);
+
+    var mem: [64]u8 = @splat(0);
+    for ([_][]const u8{ ".", "./", "a/.", "a/./", "./a/." }) |p| {
+        @memset(mem[0..32], 0);
+        @memcpy(mem[0..p.len], p);
+        try testing.expectEqual(p1.Errno.inval, pathRemoveDirectory(&h, &mem, dirfd, 0, @intCast(p.len)));
+    }
+    // A trailing `..` is NOT this case: the host answers notempty, which maps
+    // cleanly, so it must still reach it.
+    @memset(mem[0..32], 0);
+    @memcpy(mem[0..4], "a/..");
+    try testing.expectEqual(p1.Errno.notempty, pathRemoveDirectory(&h, &mem, dirfd, 0, 4));
 }


### PR DESCRIPTION
Refs #204 — the third of three. Not the rights model: this one is path
resolution, which the triage had clustered with the rights failures only
because the old code answered `notcapable` for it.

## What broke

`fd.zig` and `path.zig` each carried their own `pathHasParentEscape`, and both
rejected **any** `..` segment as an escape. But `..` is not the violation — a
path that dips through it and comes back never leaves the preopen. The
official `interesting_paths` opens
`dir/.//nested/../../dir/nested/../nested///./file` and expects it to resolve.

## Scope

One `path.confine` replaces both copies (the duplication was the defect's
shape as much as the rule was). It walks the segments with a depth counter and
answers `notcapable` only when a `..` would take the depth below zero; an
absolute path is rejected outright. An interior NUL is `inval`, not a silently
truncated different path.

It is a **check, not a rewrite** — and that distinction is the whole design.
The first draft folded the path and handed the fold to the host, which review
caught: `f/.` opened the file successfully where POSIX says `notdir`, because
the `.` was gone before the kernel saw it. Probing the same shape found `f/./.`
and `f/..` too. Not rewriting fixes all three at once, and drops the scratch
buffer, the length cap and the trailing-separator special case that the folding
version needed.

The walk is lexical, so it cannot see a symlink component that redirects the
real resolution. Follow-time confinement (D-315) is a separate, still-open
problem and is untouched.

The decisions this rests on — enforce vs advertise, the preopen defaults, the
check ordering, the errno — are recorded in ADR-0215, landed on the first PR
of the stack.

## Verification

- `test-wasi-p1-official`: interp 63 → **64**, jit 63 → **64**.
  Newly green: `interesting_paths`.
- Twelve `.` / `..` / trailing-separator combinations on a file and on a
  directory, measured against wasmtime 47.3: all twelve agree.
- `zig build test-all` green (x86_64-linux).
- The remaining 8 interp failures are the out-of-scope clusters #204 lists:
  symlink 2, readdir 1, fdflags 2, fd management 2, poll 1.
