### PR TITLE
fix(jit): liveness runs the else arm param_arity deeper than the emit

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -88,15 +88,16 @@ entries:
       `pushed_vregs` and liveness drops them. Landed in #269 (`3930aa6eb`);
       measured 2026-08-24 on `5058d517f`: fires on all four instances, 1 residual line
       over the realworld corpus (21,102 functions / 9.97M instrs), 239 over the
-      spec + edge-case corpora; +0.9% compile time gated off, 12 B/instr while on, comptime-zero
+      spec + edge-case corpora of which 61 are the fifth instance below and 178
+      remain; +0.9% compile time gated off, 12 B/instr while on, comptime-zero
       in ReleaseFast/ReleaseSmall. Shape: one shared
       `engine/codegen/shared/liveness_parity.zig` plus one call line in each
       emit loop, and the
       snapshot rides on `zir.Liveness`, which `compile.zig:235` already threads
       into the emit.
       **Reach.** Through the CLI only. `ZWASM_DEBUG` never reaches any test
-      runner, so **the figures above were taken with the gate bypassed**
-      (a direct env read, kept out of the patch: `support/dbg.zig:16-23` states
+      runner, so **the 239/178 figures above were taken with the gate bypassed**
+      (a direct env read, kept out of the patch: `support/dbg.zig:16-19` states
       why `dbg` cannot read the env itself, and `std.c` has no call site in
       Zone 1 or Zone 2 today) and are not values CI re-derives today. That gap, and the AOT-serialization refusal
       sitting behind it, are filed as an issue — see refs; this row does not
@@ -105,9 +106,16 @@ entries:
       continues, no ADR — `regverify` (`shared/compile.zig:306`) is the
       precedent. Making it block CI does need one: ADR-0076 D9 defines the
       merge gate and ADR-0212 D1 puts gate definitions in the sign-off set. The
-      precondition for that ADR is the spec residual at **zero**, not "the
-      corpus is green" — it already is. 180 lines on `3930aa6eb`, measured
-      241 → 180 when the fifth instance closed.
+      precondition for that ADR is the 178-line spec residual at **zero**, not
+      "the corpus is green" — it already is.
+      **A fifth instance is open.** liveness's `.else` restores to
+      `entry_depth` and then re-pushes `param_arity` params, while `emitElse`
+      truncates to `entry_stack_depth - param_arity` first, and both record the
+      depth after the cond pop (`x86_64/op_control.zig:1093`,
+      `arm64/op_control.zig:586`) — so liveness runs `param_arity` too deep
+      inside every `if (param T…)` else arm. One line; `test-all` green with
+      it; it accounts for 61 of the check's 239 spec-corpus lines, so once the
+      check lands the check firing IS its red test. Land it second.
       **A third consumer is uncovered.** `shared/regalloc_shape_tags.zig:88-346`
       re-derives the same def-order vreg numbering from the same `stackEffect`
       table to index a per-vreg ShapeTag array. This check does not reach it.
@@ -129,7 +137,7 @@ entries:
       src/engine/codegen/shared/regalloc_shape_tags.zig:88-346 (third reader of the table);
       .claude/skills/debug_jit_auto/RECIPES.md (Recipe 22);
       .dev/lessons/2026-06-02-jit-liveness-must-mirror-emit-pushed-vregs.md;
-      D-093 (d-3), D-220, D-330; issues #245, #250, #253, #268; PR #272;
+      D-093 (d-3), D-220, D-330; issues #245, #250, #253, #268;
       commits 64e634336, ca6f934ec, b9a8afb5c, 163062bd0.
   - id: "D-595"
     layer: "ci"

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -88,16 +88,15 @@ entries:
       `pushed_vregs` and liveness drops them. Landed in #269 (`3930aa6eb`);
       measured 2026-08-24 on `5058d517f`: fires on all four instances, 1 residual line
       over the realworld corpus (21,102 functions / 9.97M instrs), 239 over the
-      spec + edge-case corpora of which 61 are the fifth instance below and 178
-      remain; +0.9% compile time gated off, 12 B/instr while on, comptime-zero
+      spec + edge-case corpora; +0.9% compile time gated off, 12 B/instr while on, comptime-zero
       in ReleaseFast/ReleaseSmall. Shape: one shared
       `engine/codegen/shared/liveness_parity.zig` plus one call line in each
       emit loop, and the
       snapshot rides on `zir.Liveness`, which `compile.zig:235` already threads
       into the emit.
       **Reach.** Through the CLI only. `ZWASM_DEBUG` never reaches any test
-      runner, so **the 239/178 figures above were taken with the gate bypassed**
-      (a direct env read, kept out of the patch: `support/dbg.zig:16-19` states
+      runner, so **the figures above were taken with the gate bypassed**
+      (a direct env read, kept out of the patch: `support/dbg.zig:16-23` states
       why `dbg` cannot read the env itself, and `std.c` has no call site in
       Zone 1 or Zone 2 today) and are not values CI re-derives today. That gap, and the AOT-serialization refusal
       sitting behind it, are filed as an issue — see refs; this row does not
@@ -106,16 +105,9 @@ entries:
       continues, no ADR — `regverify` (`shared/compile.zig:306`) is the
       precedent. Making it block CI does need one: ADR-0076 D9 defines the
       merge gate and ADR-0212 D1 puts gate definitions in the sign-off set. The
-      precondition for that ADR is the 178-line spec residual at **zero**, not
-      "the corpus is green" — it already is.
-      **A fifth instance is open.** liveness's `.else` restores to
-      `entry_depth` and then re-pushes `param_arity` params, while `emitElse`
-      truncates to `entry_stack_depth - param_arity` first, and both record the
-      depth after the cond pop (`x86_64/op_control.zig:1093`,
-      `arm64/op_control.zig:586`) — so liveness runs `param_arity` too deep
-      inside every `if (param T…)` else arm. One line; `test-all` green with
-      it; it accounts for 61 of the check's 239 spec-corpus lines, so once the
-      check lands the check firing IS its red test. Land it second.
+      precondition for that ADR is the spec residual at **zero**, not "the
+      corpus is green" — it already is. 180 lines on `3930aa6eb`, measured
+      241 → 180 when the fifth instance closed.
       **A third consumer is uncovered.** `shared/regalloc_shape_tags.zig:88-346`
       re-derives the same def-order vreg numbering from the same `stackEffect`
       table to index a per-vreg ShapeTag array. This check does not reach it.
@@ -137,7 +129,7 @@ entries:
       src/engine/codegen/shared/regalloc_shape_tags.zig:88-346 (third reader of the table);
       .claude/skills/debug_jit_auto/RECIPES.md (Recipe 22);
       .dev/lessons/2026-06-02-jit-liveness-must-mirror-emit-pushed-vregs.md;
-      D-093 (d-3), D-220, D-330; issues #245, #250, #253, #268;
+      D-093 (d-3), D-220, D-330; issues #245, #250, #253, #268; PR #272;
       commits 64e634336, ca6f934ec, b9a8afb5c, 163062bd0.
   - id: "D-595"
     layer: "ci"

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -498,7 +498,14 @@ pub fn compute(
                         }
                         fr.merge_captured = true;
                     }
-                    sim_len = fr.entry_depth;
+                    // D-596 — mirror `emitElse`, which truncates to
+                    // `entry_stack_depth - param_arity` BEFORE re-pushing the
+                    // params. Both depths are recorded after the cond pop
+                    // (with the params still on the stack), so restoring to
+                    // `entry_depth` and then pushing left this side
+                    // `param_arity` too deep through every `if (param T...)`
+                    // else arm. Same base the `.end` arms above compute.
+                    sim_len = @as(usize, fr.entry_depth) -| @as(usize, fr.param_arity);
                     var i: u32 = 0;
                     while (i < fr.param_arity) : (i += 1) {
                         if (sim_len == max_simulated_stack) return Error.OperandStackUnderflow;

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -38,9 +38,10 @@ const dbg = @import("../../support/dbg.zig");
 /// Reach: the CLI, today. `dbg.initFromEnv` has two call sites
 /// (`cli/main.zig`, `api/instance.zig`) and no test runner reaches either, so
 /// the channel is dark for the whole of `zig build test-all`. Lane coverage
-/// arrives with that gap, not with a second env mechanism here — Zone 0 and
-/// Zone 1 cannot read the env directly (ROADMAP §A1: `std.c.getenv` would
-/// re-introduce the libc dependency, and `std.posix.getenv` is gone in 0.16).
+/// arrives with that gap, not with a second env mechanism here — a
+/// `std.c.getenv` in Zone 1 would be a new site outside ADR-0070's c_api
+/// classification, and `std.posix.getenv` is gone in 0.16. `support/dbg.zig`
+/// carries the whole argument; this is a pointer, not a second copy.
 pub fn snapshotEnabled() bool {
     return dbg.on("liveverify");
 }

--- a/src/support/dbg.zig
+++ b/src/support/dbg.zig
@@ -13,11 +13,14 @@
 //!
 //! ## Initialization (D-009 refactor)
 //!
-//! Zone 0 (`src/support/`) cannot read process env directly per
-//! ROADMAP §A1 (`std.c.getenv` would re-introduce the libc
-//! dependency this zone explicitly excludes; `std.posix.getenv`
-//! was removed in Zig 0.16). The env value is plumbed down from
-//! Zone 3 entry points:
+//! Zone 0 (`src/support/`) cannot read process env directly:
+//! `std.posix.getenv` was removed in Zig 0.16, and
+//! `std.process.Environ.getPosix` needs a `std.process.Init`
+//! that only a Zig `main` owns. That leaves `std.c.getenv`,
+//! which ADR-0070 classifies Necessary for the c_api context
+//! only — a new site here needs an ADR-0070 amendment (ROADMAP
+//! §14 forbidden list; `.claude/rules/libc_boundary.md`). The
+//! env value is plumbed down from Zone 3 entry points:
 //!
 //! - `cli/main.zig` reads `init.environ.getPosix("ZWASM_DEBUG")`
 //!   and calls `dbg.initFromEnv(value)` at startup.


### PR DESCRIPTION
liveness's `.else` restored `sim_len` to `entry_depth` then re-pushed
`param_arity` params; `emitElse` truncates to `entry_stack_depth -
param_arity` **before** re-pushing. Both record the depth after the cond pop
with the params still on the stack (`x86_64/op_control.zig:1093`,
`arm64/op_control.zig:586`), so liveness ran `param_arity` too deep through
every `if (param T...)` else arm. The `.end` arms in the same function
already compute the subtracted base — this line was the odd one out.

Fifth instance of the D-596 class.

**Red test** — `ZWASM_DEBUG=liveverify` from #269. Through the product gate,
`(if (param i32) (result i32))` fixtures fire on every else-arm pc with
liveness exactly 1 deeper. `implicit_else_param.wat` — same shape, no `else`
— is silent, which isolates it to the `.else` handler.

**Corpus** (needs the measurement gate; `ZWASM_DEBUG` is dark under every
runner, #268 — applied only to measure, not in this branch): 241 hit lines
before, 180 after, 0 new. Of the 61 removed, **59** have liveness deeper by
+1 or +2 — the `param_arity` signature — and **2** have it *shallower* by 1
(`func[0] pc=4 op=drop`, `func[0] pc=8 op=end`, both under `unreached-valid`),
which belong to the dead-code residual rather than to this shape. None at 0.

**No CI protection.** The red test is the #269 check firing, and that check is
dark under every runner (#268): `test-all` on `3930aa6eb` — which carries this
bug — is green. Reverting this line would not fail a lane until #268 closes.

`test-all` green. `test-spec-wasm-3.0-assert` counter-identical to baseline
on both engines (interp and `ZWASM_SPEC_ENGINE=jit`), every proposal, every
counter — not merely green.

Out of scope: the 180-line residual, #268, and the third `stackEffect`
consumer in `regalloc_shape_tags.zig`. The D-596 row keeps its condition;
dropping the fifth-instance paragraph waits on #271, which owns the row.

---

Second commit is unrelated to the fix and comment-only: two sites cited
ROADMAP §A1 (a zone-import rule) as the reason Zone 0 cannot read the env.
The constraint is ADR-0070's libc classification. `liveness.zig` had copied
the claim from `dbg.zig` in #269 and now points there instead.

