### PR TITLE
docs(rules): a measured value does not go in a debt row

### DIFF
--- a/.claude/rules/yaml_ssot_yq.md
+++ b/.claude/rules/yaml_ssot_yq.md
@@ -84,3 +84,14 @@ error).
   use `key: ""`.
 - **Block-scalar indent**: content is exactly 2 spaces deeper than its key; drift
   = parse failure. Use the Edit tool, mirror an existing entry's indent.
+
+## Rotting values
+
+**A measured value does not go in a row.** The row carries the claim; a
+re-derivation command carries the evidence — `zig build test-wasi-p1-official`,
+not `58/72`. A value that must be written carries its measurement date and SHA
+(`measured 2026-08-24 on 5058d517f`).
+
+Measured 2026-08-24: 28 of 89 rows held a rotting number, and most of the 11
+corrections in the never-reviewed sweep (#273) were replacing one.
+

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -27,7 +27,8 @@ entries:
       surfaces as a bare number with no baseline in the reviewer's diff.
       No live instance in `src/` today (measured: `std.c.*` calls are 6 files
       under `platform/` and 2 under `api/`; `support/` and `diagnostic/`
-      mention it in comments only; zero in Zones 1 and 2).
+      mention it in comments only; zero calls in Zones 1 and 2 — #269 shipped two
+      comments naming `std.c.getenv` there, so a bare grep hits).
       Same shape in two other gates, discharged separately: `zig build lint`
       points the linter at the repository root with no exclusions, so it walks
       every worktree and the gitignored `private/` scratch (#266);


### PR DESCRIPTION
The never-reviewed sweep (#273) corrected 11 rows; most of those corrections were replacing a number that had drifted. D-583 is the clearest — it carried `58/72 interp, 54/72 jit` while the corpus had moved to 64/64. The row did not rot because its condition changed; it rotted because someone wrote a measurement into it.

Measured at `06ea7f2b5`: **28 of 89 rows hold a value that will drift.** `.claude/rules/yaml_ssot_yq.md` already loads on a `.dev/debt.yaml` edit, so the rule goes there rather than into a new file.

Also amends D-597: it says `zero in Zones 1 and 2`, which is true of *calls* but reads as false once #269 shipped two comments naming `std.c.getenv` in those zones. One word.

Doc-only.