### PR TITLE
ci: run the advisory preview1 corpus on the merge, not on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,14 @@ jobs:
       # `conclusion` — and therefore the job's, and therefore
       # `needs.gate.result` that `ci-required` reads — stays `success`.
       #
+      # PUSH-ONLY since 2026-08-24. The paragraph above is exactly why: a
+      # failure here could not block a PR and never could, so the 175 s it
+      # cost on every PR bought no gate signal — measured at `c294ac99f`,
+      # 135 s on the macOS leg plus 40 s across linux and windows. It still
+      # runs on the merge to `main`, the same window `ZWASM_CI_EXTENDED`
+      # already accepts for its own checks, so the corpus verdict stays a
+      # per-merge number. D-583's 14 known failures are unaffected either way.
+      #
       # Deliberately a step in THIS job rather than a job of its own: a
       # separate job would repeat the Zig install and rebuild zwasm from a cold
       # `.zig-cache` on all three runners (nothing caches `.zig-cache`), paying
@@ -276,6 +284,7 @@ jobs:
       # green on all three OSes the step moves into `test-all` and this block
       # is deleted.
       - name: test-wasi-p1-official (advisory, D-582)
+        if: github.event_name == 'push'
         continue-on-error: true
         shell: bash
         run: zig build test-wasi-p1-official

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,19 +260,24 @@ jobs:
         run: bash scripts/ci_gate.sh
 
       # Official wasi-testsuite wasm32-wasip1 corpus (D-582). ADVISORY: the
-      # corpus reports 14 engine-independent failures today (D-583), so a
-      # blocking placement would red every PR. Step-level `continue-on-error`
+      # corpus is not green (D-583), so a blocking placement would red every
+      # PR. No count here on purpose: D-583 carries the live one and
+      # `zig build test-wasi-p1-official` re-derives it. A count copied to a
+      # second file is what went stale — this block said 14 while the row
+      # already said 8. Step-level `continue-on-error`
       # keeps the step's `outcome` as `failure` (visible in the run) while its
       # `conclusion` — and therefore the job's, and therefore
       # `needs.gate.result` that `ci-required` reads — stays `success`.
       #
       # PUSH-ONLY since 2026-08-24. The paragraph above is exactly why: a
-      # failure here could not block a PR and never could, so the 175 s it
-      # cost on every PR bought no gate signal — measured at `c294ac99f`,
-      # 135 s on the macOS leg plus 40 s across linux and windows. It still
-      # runs on the merge to `main`, the same window `ZWASM_CI_EXTENDED`
-      # already accepts for its own checks, so the corpus verdict stays a
-      # per-merge number. D-583's 14 known failures are unaffected either way.
+      # failure here could not block a PR and never could, so the 182 s it
+      # cost on every PR bought no gate signal — measured 2026-08-25 on
+      # `286a91f89`, over the four same-base PR runs that still ran it:
+      # 138 s on the macOS leg (spread 7 s) plus 44 s across linux and
+      # windows. It still runs on the merge to `main`, the same window
+      # `ZWASM_CI_EXTENDED` already accepts for its own checks, so the corpus
+      # verdict stays a per-merge number. D-583's remaining failures are
+      # unaffected either way.
       #
       # Deliberately a step in THIS job rather than a job of its own: a
       # separate job would repeat the Zig install and rebuild zwasm from a cold
@@ -280,9 +285,9 @@ jobs:
       # a second full build per PR to run two lanes over 72 small binaries.
       # Here it reuses what `ci_gate.sh` just built.
       #
-      # Time-boxed in the ADR-0174 sense, not indefinite: when D-583's 14 go
+      # Time-boxed in the ADR-0174 sense, not indefinite: when D-583 goes
       # green on all three OSes the step moves into `test-all` and this block
-      # is deleted.
+      # is deleted. That row's DISCHARGE clause lists the four edits.
       - name: test-wasi-p1-official (advisory, D-582)
         if: github.event_name == 'push'
         continue-on-error: true

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,12 +76,14 @@ fixtures from source (emcc / TinyGo / Rust) is a maintainer task using the Nix
 | `zig build lint -- --max-warnings 0` | project linter |
 
 `test-wasi-p1-official` is the one layer `test-all` does not carry. The corpus
-currently reports 14 engine-independent failures (D-583), so CI runs it as an
-**advisory step** in the `gate` job — the red is visible in the run without
-blocking the merge. It is not part of the local `gate_commit.sh` /
-`gate_merge.sh` flow either, so run it directly when touching WASI preview1.
-When D-583 discharges, the step joins `test-all` and the advisory goes away
-(ADR-0208 D2/D3).
+is not green (D-583 carries the live count — no copy of it here, that is what
+went stale last time), so CI runs it as an **advisory step** in the `gate`
+job: the red shows in the run without blocking the merge. Because it cannot
+block either way, it runs **only on the merge to `main`**, like the extended
+checks below — your PR will not show it. It is not part of the local
+`gate_commit.sh` / `gate_merge.sh` flow either, so run it directly when
+touching WASI preview1. When D-583 discharges, the step joins `test-all` and
+the advisory goes away (ADR-0208 D2/D3).
 
 ## The merge gate — CI is authoritative
 


### PR DESCRIPTION
`test-wasi-p1-official (advisory, D-582)` gains
`if: github.event_name == 'push'`. One step, one condition, plus a
paragraph in the comment block that already explains the step.

**Nothing CI can block on changes.** The step is `continue-on-error: true`,
so its `conclusion` is `success` whatever the corpus reports, and
`ci-required` reads `needs.gate.result` — the job's result, which a
`continue-on-error` step cannot move. On PR run 32722166598 the step
failed on all three legs (`Process completed with exit code 1` in the
macOS log) and reported `conclusion: success` on all three, job
`success`. A failure there could not block a PR and never could.

**What it cost:** 182 s of runner time per PR — 138 s on the macOS leg,
44 s across linux and windows — measured 2026-08-25 on `286a91f89`, over
the four same-base PR runs that still ran the step (#278/#279/#281/#288;
macOS spread 7 s). The macOS leg sets time-to-green, so a PR gets its
verdict ~138 s sooner. Leg totals are *not* the evidence: `ci_gate.sh`
alone varies by 397 s across those same four runs.

**What is kept:** the corpus still runs on every merge to `main`, the
same window `ZWASM_CI_EXTENDED` already accepts for its own checks, so
the verdict stays a per-merge number rather than disappearing. D-583's
remaining failures are unaffected; when D-583 goes green on all three OSes
the whole block is deleted and the corpus moves into `test-all`, as the
existing comment says.

`workflow_dispatch` now skips this step too. That matches the
precedent one step above: `ZWASM_CI_EXTENDED` is
`(github.event_name == 'push' && matrix.extended)`, so a manual dispatch
already gets the core gate only.

### Verification

- **No other step changed trigger.** Parsed both revisions of the file
  with pyyaml and compared all 24 (job, step, `if`, `continue-on-error`)
  rows plus the workflow `on:` block: exactly one row differs, and
  `continue-on-error` is untouched.
- **The condition gates the way it claims.** Rather than re-reading it,
  I observed the *identical* expression already live in this workflow —
  `ZWASM_CI_EXTENDED: ${{ (github.event_name == 'push' && ...) }}`, whose
  value `ci_gate.sh` branches on. PR run 32722166598 emitted 0
  `[ci_gate] extended:` lines (expression false); push run 32703725326
  emitted 8 (expression true). Same runners, same workflow.
- **A skipped step does not move the job conclusion** — precedent in the
  same runs: `Install Zig 0.16.0 (Unix)`/`(Windows)` are `skipped` on
  every leg and every job is `success`.

---
*Updated after @chaploud's review*: the comment block carried the
2026-08-14 count in **three** places (the ADVISORY line, the push-only
paragraph, and the exit condition). All three now name D-583 and the
re-derivation command instead of a number, per
`.claude/rules/yaml_ssot_yq.md` (#275). Timing figures re-anchored to this
branch's base. Behaviour is unchanged: a YAML parse comparing all 24
(job, step, `if`, `continue-on-error`, `run`) rows against `main` still
differs in exactly one row — the `if:` on this step.
