### PR TITLE
fix(validate,parse): a module with no code section is validated like any other

### DIFF
--- a/src/parse/sections.zig
+++ b/src/parse/sections.zig
@@ -639,10 +639,9 @@ pub const Import = struct {
     /// Module name and field name borrowed from the input.
     module: []const u8,
     name: []const u8,
-    /// Discriminator + payload (typeidx for func, valtype+mut for global,
-    /// limits-only for memory/table — only typeidx and global payloads
-    /// are decoded structurally; the runner reads them, the others are
-    /// recorded as kind only).
+    /// Discriminator + payload. Every kind is decoded structurally: a
+    /// typeidx for func and tag, valtype+mutability for global, and the
+    /// full element type / index type / limits for table and memory.
     kind: ImportKind,
     payload: ImportPayload,
 };
@@ -668,10 +667,11 @@ pub const Imports = struct {
 /// Decode the body of an import section (`SectionId.import`):
 ///   vec(import), import = mod:name nm:name desc
 ///   desc = 0x00 typeidx | 0x01 tabletype | 0x02 memtype | 0x03 globaltype
-/// Table and memory descriptions are recorded as kind-only — their
-/// limits payload is consumed but not surfaced (Phase-1 validators
-/// do not need it). Function and global imports are decoded
-/// structurally so the validator can index them.
+/// Every description is decoded structurally and surfaced on the payload,
+/// so a validator can index imported entities by their real types. An
+/// imported table's element type and index type are load-bearing: a
+/// table64's element offset is typed `i64`, and an `externref` table
+/// accepts only `externref` segments.
 pub fn decodeImports(parent_alloc: Allocator, body: []const u8) Error!Imports {
     var arena = std.heap.ArenaAllocator.init(parent_alloc);
     errdefer arena.deinit();

--- a/src/parse/sections_element.zig
+++ b/src/parse/sections_element.zig
@@ -393,6 +393,11 @@ test "decodeElement: single active form 0 with two funcidxs" {
     try testing.expectEqual(ElementKind.active, e.items[0].kind);
     try testing.expectEqual(@as(u32, 0), e.items[0].tableidx);
     try testing.expectEqualSlices(u32, &[_]u32{ 0, 1 }, e.items[0].funcidxs);
+    // The funcidx form's items are `ref.func`, so its element type is the
+    // NON-NULLABLE `(ref func)` — not the nullable `funcref` this used to
+    // record for every shape. A `(ref func)` table accepts this segment
+    // precisely because of the nullability here.
+    try testing.expect(e.items[0].elem_type.eql(.{ .ref = zir.RefType.abs(.func, false) }));
 }
 
 test "decodeElement: form 6 typed-ref (ref 0) elem with ref.func init expr" {

--- a/src/parse/sections_element.zig
+++ b/src/parse/sections_element.zig
@@ -26,10 +26,9 @@ pub const ElementKind = enum { active, passive, declarative };
 ///
 /// which is exactly what the reference decoder assigns — `(NoNull, FuncHT)`
 /// for the first group via `elem`/`elem_kind`, `(Null, FuncHT)` for 0x04
-/// (`interpreter/binary/decode.ml`). Recording the nullable `funcref` for the
-/// funcidx form made a `(ref func)` table refuse its own legacy segment, while
-/// recording the non-nullable one for 0x04 would have let a `funcref` segment
-/// pass into a `(ref func)` table.
+/// (`interpreter/binary/decode.ml`). The nullability is load-bearing in both
+/// directions: a `(ref func)` table accepts the funcidx form and rejects an
+/// 0x04 segment, and only the per-form type tells those apart.
 const FUNCIDX_ELEM_TYPE: ValType = .{ .ref = zir.RefType.abs(.func, false) };
 
 pub const ElementSegment = struct {
@@ -394,8 +393,7 @@ test "decodeElement: single active form 0 with two funcidxs" {
     try testing.expectEqual(@as(u32, 0), e.items[0].tableidx);
     try testing.expectEqualSlices(u32, &[_]u32{ 0, 1 }, e.items[0].funcidxs);
     // The funcidx form's items are `ref.func`, so its element type is the
-    // NON-NULLABLE `(ref func)` — not the nullable `funcref` this used to
-    // record for every shape. A `(ref func)` table accepts this segment
+    // NON-NULLABLE `(ref func)`. A `(ref func)` table accepts this segment
     // precisely because of the nullability here.
     try testing.expect(e.items[0].elem_type.eql(.{ .ref = zir.RefType.abs(.func, false) }));
 }
@@ -422,6 +420,8 @@ test "decodeElement: passive form 1 with elemkind=funcref" {
     defer e.deinit();
     try testing.expectEqual(ElementKind.passive, e.items[0].kind);
     try testing.expectEqualSlices(u32, &[_]u32{3}, e.items[0].funcidxs);
+    // Every funcidx form carries the non-nullable `(ref func)`; see FUNCIDX_ELEM_TYPE.
+    try testing.expect(e.items[0].elem_type.eql(.{ .ref = zir.RefType.abs(.func, false) }));
 }
 
 test "decodeElement: declarative form 3" {
@@ -430,6 +430,8 @@ test "decodeElement: declarative form 3" {
     defer e.deinit();
     try testing.expectEqual(ElementKind.declarative, e.items[0].kind);
     try testing.expectEqual(@as(usize, 0), e.items[0].funcidxs.len);
+    // Every funcidx form carries the non-nullable `(ref func)`; see FUNCIDX_ELEM_TYPE.
+    try testing.expect(e.items[0].elem_type.eql(.{ .ref = zir.RefType.abs(.func, false) }));
 }
 
 test "decodeElement: active form 2 with explicit tableidx" {
@@ -454,6 +456,22 @@ test "decodeElement: active form 2 with explicit tableidx" {
     try testing.expectEqual(ElementKind.active, e.items[0].kind);
     try testing.expectEqual(@as(u32, 1), e.items[0].tableidx);
     try testing.expectEqualSlices(u32, &[_]u32{ 0, 1 }, e.items[0].funcidxs);
+    // Every funcidx form carries the non-nullable `(ref func)`; see FUNCIDX_ELEM_TYPE.
+    try testing.expect(e.items[0].elem_type.eql(.{ .ref = zir.RefType.abs(.func, false) }));
+}
+
+test "decodeElement: active form 4 (expr-vec) keeps the nullable funcref" {
+    // flag=4 is the expr-vector twin of form 0: same active-table-0 shape, but
+    // its items are expressions, so the spec assigns the NULLABLE `funcref`.
+    // The asymmetry with forms 0x00-0x03 is the whole reason the type is
+    // per-form; pinning only one side would let the other drift.
+    // count=1; flag=4; offset = i32.const 0; end; n=1; expr = ref.func 0; end
+    const body = [_]u8{ 0x01, 0x04, 0x41, 0x00, 0x0B, 0x01, 0xD2, 0x00, 0x0B };
+    var e = try decodeElement(testing.allocator, &body);
+    defer e.deinit();
+    try testing.expectEqual(ElementKind.active, e.items[0].kind);
+    try testing.expectEqual(@as(u32, 0), e.items[0].tableidx);
+    try testing.expect(e.items[0].elem_type.eql(ValType.funcref));
 }
 
 test "decodeElement: passive form 5 (reftype + expr-vec)" {

--- a/src/parse/sections_element.zig
+++ b/src/parse/sections_element.zig
@@ -17,6 +17,21 @@ const ValType = zir.ValType;
 
 pub const ElementKind = enum { active, passive, declarative };
 
+/// Wasm 3.0 §5.5.12 — an element segment's element type depends on its FORM,
+/// and the two forms disagree on nullability:
+///
+///   flags 0x00-0x03  funcidx vector  -> NON-NULLABLE `(ref func)`
+///   flags 0x04       expr vector     -> nullable `funcref`
+///   flags 0x05-0x07  expr vector     -> the declared reftype
+///
+/// which is exactly what the reference decoder assigns — `(NoNull, FuncHT)`
+/// for the first group via `elem`/`elem_kind`, `(Null, FuncHT)` for 0x04
+/// (`interpreter/binary/decode.ml`). Recording the nullable `funcref` for the
+/// funcidx form made a `(ref func)` table refuse its own legacy segment, while
+/// recording the non-nullable one for 0x04 would have let a `funcref` segment
+/// pass into a `(ref func)` table.
+const FUNCIDX_ELEM_TYPE: ValType = .{ .ref = zir.RefType.abs(.func, false) };
+
 pub const ElementSegment = struct {
     kind: ElementKind,
     tableidx: u32 = 0,
@@ -111,7 +126,7 @@ pub fn decodeElement(parent_alloc: Allocator, body: []const u8) sections.Error!E
                     .kind = .active,
                     .tableidx = 0,
                     .offset_expr = expr,
-                    .elem_type = .funcref,
+                    .elem_type = FUNCIDX_ELEM_TYPE,
                     .funcidxs = funcs,
                 };
             },
@@ -124,7 +139,7 @@ pub fn decodeElement(parent_alloc: Allocator, body: []const u8) sections.Error!E
                 try sections.checkVecCount(n, body, pos); // ≥1 byte/elem — reject oversized count pre-alloc
                 const funcs = try alloc.alloc(u32, n);
                 for (funcs) |*f| f.* = try leb128.readUleb128(u32, body, &pos);
-                e.* = .{ .kind = .passive, .elem_type = .funcref, .funcidxs = funcs };
+                e.* = .{ .kind = .passive, .elem_type = FUNCIDX_ELEM_TYPE, .funcidxs = funcs };
             },
             3 => {
                 if (pos >= body.len) return sections.Error.UnexpectedEnd;
@@ -135,7 +150,7 @@ pub fn decodeElement(parent_alloc: Allocator, body: []const u8) sections.Error!E
                 try sections.checkVecCount(n, body, pos); // ≥1 byte/elem — reject oversized count pre-alloc
                 const funcs = try alloc.alloc(u32, n);
                 for (funcs) |*f| f.* = try leb128.readUleb128(u32, body, &pos);
-                e.* = .{ .kind = .declarative, .elem_type = .funcref, .funcidxs = funcs };
+                e.* = .{ .kind = .declarative, .elem_type = FUNCIDX_ELEM_TYPE, .funcidxs = funcs };
             },
             4 => {
                 // active, table 0, offset expr, vec(reftype-expr).
@@ -179,7 +194,7 @@ pub fn decodeElement(parent_alloc: Allocator, body: []const u8) sections.Error!E
                     .kind = .active,
                     .tableidx = tableidx,
                     .offset_expr = expr,
-                    .elem_type = .funcref,
+                    .elem_type = FUNCIDX_ELEM_TYPE,
                     .funcidxs = funcs,
                 };
             },

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -264,10 +264,17 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         var cursor: usize = 0;
         if (imports_decoded) |im| for (im.items) |it| {
             if (it.kind != .table) continue;
-            // Imported table descriptions come kind-only via §A10;
-            // synthesise a permissive funcref so `table.*` ops
-            // don't trip bounds checks during validation.
-            table_entries[cursor] = .{ .elem_type = .funcref, .min = 0 };
+            // The import payload carries the table's real element type and
+            // index width, so use them. A synthesised permissive `funcref` /
+            // `.i32` here silently mistypes every check that reads the entry:
+            // an imported table64's elem offset is `i64`, and an imported
+            // `externref` table takes `externref` segments.
+            table_entries[cursor] = .{
+                .elem_type = it.payload.table.elem_type,
+                .idx_type = it.payload.table.idx_type,
+                .min = it.payload.table.min,
+                .max = it.payload.table.max,
+            };
             cursor += 1;
         };
         if (tables_owned) |t| for (t.items) |entry| {
@@ -395,6 +402,10 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // type-check array.init_elem (segment <: array element) and
     // table.init (segment == table elem_type). Empty = legacy callers.
     var elem_types_validate: []zir.ValType = &.{};
+    // Registered at the declaration, not after the block below: the segment
+    // checks in that block return early, and `frontendValidate` returns `bool`
+    // rather than an error union, so an `errdefer` would never fire for them.
+    defer if (elem_types_validate.len != 0) alloc.free(elem_types_validate);
     if (module.find(.element)) |elem_section| {
         var elems = sections.decodeElement(alloc, elem_section.body) catch return false;
         defer elems.deinit();
@@ -415,13 +426,7 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
                     return false;
                 }
                 const tbl = table_entries[seg.tableidx];
-                // An IMPORTED table's entry carries a synthesised permissive
-                // `funcref` (§A10 gives imports kind-only here), not its real
-                // element type, so the subtype rule has nothing truthful to
-                // compare against and is skipped for those slots.
-                if (seg.tableidx >= imp_table_count and
-                    !gc_subtype.gcValTypeSubtype(seg.elem_type, tbl.elem_type, &types_owned))
-                {
+                if (!gc_subtype.gcValTypeSubtype(seg.elem_type, tbl.elem_type, &types_owned)) {
                     diagnostic.setDiag(.validate, .other, .unknown, "elem segment type is not a subtype of the table's element type (§3.3.7)", .{});
                     return false;
                 }
@@ -447,7 +452,6 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
             }
         }
     }
-    defer if (elem_types_validate.len != 0) alloc.free(elem_types_validate);
     if (module.find(.@"export")) |exp_section| {
         // Manual export scan tolerant of Wasm 3.0 export-kind
         // extensions (e.g., `tag = 4` from the EH proposal which

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -10,7 +10,6 @@
 //! Helpers with NO binding dependency (Step A1):
 //!
 //! - `frontendValidate` — read-only parse + per-fn validate pass.
-//! - `validateNoCode` — short-circuit when the module has no code.
 //! - `buildExportTypes` — populate `Instance.export_types` per
 //!   ADR-0014 §3.4.10 (drives D-006's import-vs-export check).
 //! - `evalConstExprValue` / `evalConstI32Expr` — Wasm const-
@@ -98,21 +97,14 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // present.
     if (!preDecodeSectionBodies(alloc, &module)) return false;
 
-    // A module with no type section still needs every section-level check
-    // below — global init-expr typing (§3.4.3), elem/data offset typing.
-    // This used to `return validateNoCode(...)`, a documented no-op, so a
-    // module holding only a global / data / elem section validated clean
-    // here while `compileWasm` rejected the same bytes. Decoding a
-    // synthetic empty type vector keeps ONE path for both shapes.
+    // The type and code sections are both optional, and their absence does
+    // not excuse a module from the section-level checks below — global
+    // init-expr typing (§3.4.3), elem/data offset typing, the function/code
+    // length agreement (§5.5.13). A module holding only a global / data /
+    // elem section is exactly the shape the `assert_invalid` corpus uses, so
+    // the walk must reach it. Decoding a synthetic empty type vector keeps
+    // ONE path for both shapes rather than a second, thinner one.
     const empty_type_body = [_]u8{0x00}; // vec(typedef), count 0
-    // The code section is OPTIONAL here. It used to `orelse return true`,
-    // which skipped every section-level check below — global init-expr
-    // typing (§3.4.3), elem/data offset typing, the function/code length
-    // agreement (§5.5.15) — for any module without functions. The spec's
-    // `assert_invalid` corpus is full of exactly those modules, so 47 of
-    // them validated clean through this path while `compileWasm` rejected
-    // the same bytes (the #233 family: a check that lives on only one of
-    // the two validation paths is unenforced on the other).
     const code_section_opt = module.find(.code);
 
     var types_owned = (if (module.find(.type)) |ts|
@@ -134,9 +126,9 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         null;
     defer if (codes_owned) |*c| c.deinit();
 
-    // §5.5.15 — the code section carries exactly one entry per function
-    // section entry. With the section absent this now rejects a function
-    // section that has no bodies, where the early return accepted it.
+    // §5.5.13 — the code section carries exactly one entry per function
+    // section entry. An absent code section therefore means an absent
+    // function section, not a licence to skip the comparison.
     const code_items = if (codes_owned) |c| c.items else &.{};
     if (code_items.len != defined_func_indices.len) return false;
 
@@ -218,19 +210,17 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     }
 
     // Wasm spec §3.4.3 — each defined global's init-expr result type must
-    // be a subtype of its declared type (GC iso-recursive identity per
-    // ADR-0126). The native-API validate path (this fn) previously skipped
-    // this, letting type-subtyping invalid fixtures with a rec-group-
-    // distinct `ref.func` init (e.g. `(global (ref 4) (ref.func 0))` where
-    // func 0's type ≢ type 4) slip through. Conservative: undeterminable
-    // const-expr shapes pass (an incomplete evaluator must not reject valid
-    // modules).
+    // be a subtype of its declared type, under GC iso-recursive identity
+    // (ADR-0126). Rec-group identity is what makes this more than a tag
+    // comparison: `(global (ref 4) (ref.func 0))` is invalid when func 0's
+    // type is not identical to type 4, however similar their shapes.
     if (globals_owned) |g| {
-        // §3.3.7 — a defined global's init expr sees the imported globals plus
-        // the globals declared BEFORE it, never itself or a later one (the
-        // reference interpreter extends the context one global at a time in
-        // `check_global`). Anything this walker declines to judge falls back to
-        // the older subtype-only check, which is conservative by construction.
+        // §3.3.13.1 — a defined global's init expr sees the imported globals
+        // plus the globals declared BEFORE it, never itself or a later one
+        // (the reference interpreter extends the context one global at a time
+        // in `check_global`). `validateGlobalInits` below runs over every
+        // global regardless of the verdict here; the two are complementary,
+        // not a primary and a fallback.
         for (g.items, 0..) |gd, i| {
             const scope: validator.ConstExprScope = .{
                 .globals = global_entries[0 .. imp_global_count + i],
@@ -240,7 +230,7 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
             switch (validator.validateConstExpr(gd.init_expr, gd.valtype, scope)) {
                 .ok => {},
                 .invalid => {
-                    diagnostic.setDiag(.validate, .other, .unknown, "global init-expr is not a valid constant expression (§3.3.7)", .{});
+                    diagnostic.setDiag(.validate, .other, .unknown, "global init-expr is not a valid constant expression (§3.3.13.1)", .{});
                     return false;
                 },
                 .undeterminable => {},
@@ -265,10 +255,9 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         if (imports_decoded) |im| for (im.items) |it| {
             if (it.kind != .table) continue;
             // The import payload carries the table's real element type and
-            // index width, so use them. A synthesised permissive `funcref` /
-            // `.i32` here silently mistypes every check that reads the entry:
-            // an imported table64's elem offset is `i64`, and an imported
-            // `externref` table takes `externref` segments.
+            // index width. Both are load-bearing downstream: an imported
+            // table64's elem offset is typed `i64`, and an imported
+            // `externref` table accepts only `externref` segments.
             table_entries[cursor] = .{
                 .elem_type = it.payload.table.elem_type,
                 .idx_type = it.payload.table.idx_type,
@@ -283,22 +272,31 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         };
     }
 
-    // §3.3.7 `check_table` — a table's init expr is a constant expression of
+    // §3.4.5 `check_table` — a table's init expr is a constant expression of
     // the table's element type, and it runs BEFORE the globals are folded into
     // the context (`check_module` order: … memories → tables → globals), so it
     // may read only IMPORTED globals. A defined global is out of scope here
     // even though it is in scope for a data or elem offset further down.
     if (tables_owned) |t| {
         for (t.items) |entry| {
+            // An omitted init expr means the element type must be defaultable.
+            // That rule is not checked on this path yet — see #285, which
+            // tracks the `check_module` remainder — so skip rather than judge.
             if (entry.init_expr.len == 0) continue;
             const scope: validator.ConstExprScope = .{
                 .globals = global_entries[0..imp_global_count],
                 .func_type_indices = func_type_indices,
                 .types = &types_owned,
             };
-            if (validator.validateConstExpr(entry.init_expr, entry.elem_type, scope) == .invalid) {
-                diagnostic.setDiag(.validate, .other, .unknown, "table init expr is not a valid constant expression (§3.3.7)", .{});
-                return false;
+            switch (validator.validateConstExpr(entry.init_expr, entry.elem_type, scope)) {
+                .ok => {},
+                .invalid => {
+                    diagnostic.setDiag(.validate, .other, .unknown, "table init expr is not a valid constant expression (§3.3.13.1)", .{});
+                    return false;
+                },
+                // The GC type algebra this walker declines to enter; an
+                // untypeable shape must not be reported as invalid.
+                .undeterminable => {},
             }
         }
     }
@@ -403,8 +401,9 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // table.init (segment == table elem_type). Empty = legacy callers.
     var elem_types_validate: []zir.ValType = &.{};
     // Registered at the declaration, not after the block below: the segment
-    // checks in that block return early, and `frontendValidate` returns `bool`
-    // rather than an error union, so an `errdefer` would never fire for them.
+    // `frontendValidate` returns `bool`, not an error union, so the early
+    // `return false`s below are ordinary returns and only a `defer` reaching
+    // back to the declaration frees this.
     defer if (elem_types_validate.len != 0) alloc.free(elem_types_validate);
     if (module.find(.element)) |elem_section| {
         var elems = sections.decodeElement(alloc, elem_section.body) catch return false;
@@ -413,8 +412,11 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         elem_types_validate = alloc.alloc(zir.ValType, elems.items.len) catch return false;
         for (elems.items, 0..) |seg, i| {
             elem_types_validate[i] = seg.elem_type;
+            // `check_elemmode` constrains the active mode only: a passive or
+            // declarative segment names no table and carries no offset, so
+            // there is nothing at this level to check for it.
             if (seg.kind == .active) {
-                // §3.3.7 `check_elemmode` — the named table must exist, the
+                // §3.4.9 `check_elemmode` — the named table must exist, the
                 // segment's element type must be a SUBTYPE of the table's
                 // (not merely equal: a `funcref` segment does not fit a
                 // non-nullable `(ref func)` table), and the offset is a
@@ -422,12 +424,12 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
                 // the context holds every global, which is the window
                 // `check_elem` sees.
                 if (seg.tableidx >= table_entries.len) {
-                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment names a table that does not exist (§3.3.7)", .{});
+                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment names a table that does not exist (§3.4.9)", .{});
                     return false;
                 }
                 const tbl = table_entries[seg.tableidx];
                 if (!gc_subtype.gcValTypeSubtype(seg.elem_type, tbl.elem_type, &types_owned)) {
-                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment type is not a subtype of the table's element type (§3.3.7)", .{});
+                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment type is not a subtype of the table's element type (§3.4.9)", .{});
                     return false;
                 }
                 if (seg.offset_expr.len != 0) {
@@ -437,9 +439,14 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
                         .func_type_indices = func_type_indices,
                         .types = &types_owned,
                     };
-                    if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
-                        diagnostic.setDiag(.validate, .other, .unknown, "elem segment offset is not a valid constant expression (§3.3.7)", .{});
-                        return false;
+                    switch (validator.validateConstExpr(seg.offset_expr, want, scope)) {
+                        .ok => {},
+                        .invalid => {
+                            diagnostic.setDiag(.validate, .other, .unknown, "elem segment offset is not a valid constant expression (§3.3.13.1)", .{});
+                            return false;
+                        },
+                        // Untypeable by this walker, so not judged here.
+                        .undeterminable => {},
                     }
                 }
             }
@@ -504,7 +511,7 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         null;
     defer if (datas_owned) |*d| d.deinit();
     const data_count_validate: u32 = if (datas_owned) |d| @intCast(d.items.len) else 0;
-    // §3.3.7 `check_datamode` — an active segment names a memory that must
+    // §3.4.8 `check_datamode` — an active segment names a memory that must
     // exist, and its offset is a constant expression at THAT memory's index
     // type (a memory64 offset is `i64`; typing it as `i32` would reject valid
     // modules). `memory_idx_types` already spans imports-then-defined.
@@ -512,7 +519,7 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         for (d.items) |seg| {
             if (seg.kind != .active) continue;
             if (seg.memidx >= total_memory_count) {
-                diagnostic.setDiag(.validate, .other, .unknown, "data segment names a memory that does not exist (§3.3.7)", .{});
+                diagnostic.setDiag(.validate, .other, .unknown, "data segment names a memory that does not exist (§3.4.8)", .{});
                 return false;
             }
             if (seg.offset_expr.len == 0) continue;
@@ -522,9 +529,14 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
                 .func_type_indices = func_type_indices,
                 .types = &types_owned,
             };
-            if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
-                diagnostic.setDiag(.validate, .other, .unknown, "data segment offset is not a valid constant expression (§3.3.7)", .{});
-                return false;
+            switch (validator.validateConstExpr(seg.offset_expr, want, scope)) {
+                .ok => {},
+                .invalid => {
+                    diagnostic.setDiag(.validate, .other, .unknown, "data segment offset is not a valid constant expression (§3.3.13.1)", .{});
+                    return false;
+                },
+                // Untypeable by this walker, so not judged here.
+                .undeterminable => {},
             }
         }
     }
@@ -587,16 +599,6 @@ fn initExprRefFuncLocal(expr: []const u8) ?u32 {
     const idx = leb128.readUleb128(u32, expr, &pos) catch return null;
     if (pos >= expr.len or expr[pos] != 0x0B) return null;
     return idx;
-}
-
-pub fn validateNoCode(_: std.mem.Allocator, _: *Module) bool {
-    // No code section: nothing per-function to validate. The
-    // module's section-id ordering was already checked by
-    // parser.parse; section-body structural integrity is checked
-    // separately by `preDecodeSectionBodies` (called from
-    // `frontendValidate`'s top), so this helper is genuinely a
-    // no-op for modules with no code.
-    return true;
 }
 
 /// D-188 — pre-validation pass that decodes the body of each
@@ -1738,6 +1740,60 @@ test "frontendValidate: imported tag occupies the tag index space (10.E-xmodule-
         0x0a, 0x06, 0x01, 0x04, 0x00, 0x08, 0x00, 0x0b, // code: (throw 0) end
     };
     try testing.expect(frontendValidate(testing.allocator, &m));
+}
+
+test "frontendValidate: a module with no type and no code section is still validated" {
+    const H = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+
+    // global i32 = (f32.const 1.0) — the init-expr type does not match the
+    // declared type. There is no type section and no code section, so this is
+    // the shape whose only checks are the section-level ones.
+    const bad = H ++ [_]u8{
+        0x06, 0x09, 0x01, 0x7f, 0x00, // global: count 1, i32, immutable
+        0x43, 0x00, 0x00, 0x80, 0x3f, 0x0b, // f32.const 1.0; end
+    };
+    try testing.expect(!frontendValidate(testing.allocator, &bad));
+
+    // The same shape with a well-typed init must still pass — a check that
+    // only ever rejects is indistinguishable from one that rejects everything.
+    const good = H ++ [_]u8{
+        0x06, 0x06, 0x01, 0x7f, 0x00, // global: count 1, i32, immutable
+        0x41, 0x01, 0x0b, // i32.const 1; end
+    };
+    try testing.expect(frontendValidate(testing.allocator, &good));
+}
+
+test "frontendValidate: a function section with no code section is rejected" {
+    // §5.5.13 — one code entry per function entry. An absent code section
+    // means zero entries, which cannot agree with a function section of one.
+    const m = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type: () -> ()
+        0x03, 0x02, 0x01, 0x00, // function: 1 func, type 0
+    };
+    try testing.expect(!frontendValidate(testing.allocator, &m));
+}
+
+test "frontendValidate: a segment naming a table or memory that does not exist is rejected" {
+    const H = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00 };
+
+    // elem form 2 (explicit tableidx) pointing at table 5 of a module with no
+    // table section at all.
+    const elem = H ++ [_]u8{
+        0x09, 0x08, 0x01, 0x02, 0x05, // elem: count 1, flag 2, tableidx 5
+        0x41, 0x00, 0x0b, // offset: i32.const 0; end
+        0x00, 0x00, // elemkind funcref, 0 funcidxs
+    };
+    try testing.expect(!frontendValidate(testing.allocator, &elem));
+
+    // data form 2 (explicit memidx) pointing at memory 3 of a module with no
+    // memory section.
+    const data = H ++ [_]u8{
+        0x0b, 0x07, 0x01, 0x02, 0x03, // data: count 1, flag 2, memidx 3
+        0x41, 0x00, 0x0b, // offset: i32.const 0; end
+        0x00, // 0 bytes
+    };
+    try testing.expect(!frontendValidate(testing.allocator, &data));
 }
 
 test "evalConstExprValue: i32.const N; ref.i31; end produces an i31 ref (10.G cycle 130)" {

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -666,7 +666,23 @@ fn preDecodeSectionBodies(alloc: std.mem.Allocator, module: *Module) bool {
     }
     if (module.find(.import)) |s| {
         var im = sections.decodeImports(alloc, s.body) catch return false;
-        im.deinit();
+        defer im.deinit();
+        // An imported entity's declared type is carried through to the checks
+        // that read it — an imported table's element type reaches the elem
+        // segment subtype check, an imported global's valtype reaches the
+        // const-expr scope — so a concrete head naming a type that does not
+        // exist has to be rejected here. Out of range, `gcValTypeSubtype`
+        // reads the head as `.any` and the mistyped entity is accepted.
+        const ntypes: usize = if (module.find(.type)) |ts| blk: {
+            var ty = sections.decodeTypes(alloc, ts.body) catch break :blk 0;
+            defer ty.deinit();
+            break :blk ty.items.len;
+        } else 0;
+        for (im.items) |it| switch (it.kind) {
+            .table => if (!validRefTypeIdx(it.payload.table.elem_type, ntypes)) return false,
+            .global => if (!validRefTypeIdx(it.payload.global.valtype, ntypes)) return false,
+            else => {},
+        };
     }
     if (module.find(.table)) |s| {
         var t = sections.decodeTables(alloc, s.body) catch return false;
@@ -1761,6 +1777,22 @@ test "frontendValidate: a module with no type and no code section is still valid
         0x41, 0x01, 0x0b, // i32.const 1; end
     };
     try testing.expect(frontendValidate(testing.allocator, &good));
+}
+
+test "frontendValidate: an imported table's concrete element type is bounds-checked" {
+    // `(import "m" "t" (table 0 (ref null 1)))` in a module with no type
+    // section. The concrete head names type 1, which does not exist. Defined
+    // tables have always been bounds-checked here; an imported one reaches the
+    // same checks now that its declared element type is carried through.
+    const m = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x02, 0x0a, 0x01, // import: count 1
+        0x01, 0x6d, 0x01, 0x74, // "m" "t"
+        0x01, // kind: table
+        0x63, 0x01, // reftype (ref null 1)
+        0x00, 0x00, // limits: min 0, no max
+    };
+    try testing.expect(!frontendValidate(testing.allocator, &m));
 }
 
 test "frontendValidate: a function section with no code section is rejected" {

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -97,10 +97,27 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // present.
     if (!preDecodeSectionBodies(alloc, &module)) return false;
 
-    const type_section = module.find(.type) orelse return validateNoCode(alloc, &module);
-    const code_section = module.find(.code) orelse return true;
+    // A module with no type section still needs every section-level check
+    // below — global init-expr typing (§3.4.3), elem/data offset typing.
+    // This used to `return validateNoCode(...)`, a documented no-op, so a
+    // module holding only a global / data / elem section validated clean
+    // here while `compileWasm` rejected the same bytes. Decoding a
+    // synthetic empty type vector keeps ONE path for both shapes.
+    const empty_type_body = [_]u8{0x00}; // vec(typedef), count 0
+    // The code section is OPTIONAL here. It used to `orelse return true`,
+    // which skipped every section-level check below — global init-expr
+    // typing (§3.4.3), elem/data offset typing, the function/code length
+    // agreement (§5.5.15) — for any module without functions. The spec's
+    // `assert_invalid` corpus is full of exactly those modules, so 47 of
+    // them validated clean through this path while `compileWasm` rejected
+    // the same bytes (the #233 family: a check that lives on only one of
+    // the two validation paths is unenforced on the other).
+    const code_section_opt = module.find(.code);
 
-    var types_owned = sections.decodeTypes(alloc, type_section.body) catch return false;
+    var types_owned = (if (module.find(.type)) |ts|
+        sections.decodeTypes(alloc, ts.body)
+    else
+        sections.decodeTypes(alloc, &empty_type_body)) catch return false;
     defer types_owned.deinit();
 
     const func_section = module.find(.function);
@@ -110,10 +127,17 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         alloc.alloc(u32, 0) catch return false;
     defer alloc.free(defined_func_indices);
 
-    var codes_owned = sections.decodeCodes(alloc, code_section.body) catch return false;
-    defer codes_owned.deinit();
+    var codes_owned: ?sections.Codes = if (code_section_opt) |cs|
+        (sections.decodeCodes(alloc, cs.body) catch return false)
+    else
+        null;
+    defer if (codes_owned) |*c| c.deinit();
 
-    if (codes_owned.items.len != defined_func_indices.len) return false;
+    // §5.5.15 — the code section carries exactly one entry per function
+    // section entry. With the section absent this now rejects a function
+    // section that has no bodies, where the early return accepted it.
+    const code_items = if (codes_owned) |c| c.items else &.{};
+    if (code_items.len != defined_func_indices.len) return false;
 
     // `func_types` must span the full funcidx space (imports
     // first, then defined) — the validator's `call N` checks
@@ -201,6 +225,26 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // const-expr shapes pass (an incomplete evaluator must not reject valid
     // modules).
     if (globals_owned) |g| {
+        // §3.3.7 — a defined global's init expr sees the imported globals plus
+        // the globals declared BEFORE it, never itself or a later one (the
+        // reference interpreter extends the context one global at a time in
+        // `check_global`). Anything this walker declines to judge falls back to
+        // the older subtype-only check, which is conservative by construction.
+        for (g.items, 0..) |gd, i| {
+            const scope: validator.ConstExprScope = .{
+                .globals = global_entries[0 .. imp_global_count + i],
+                .func_type_indices = func_type_indices,
+                .types = &types_owned,
+            };
+            switch (validator.validateConstExpr(gd.init_expr, gd.valtype, scope)) {
+                .ok => {},
+                .invalid => {
+                    diagnostic.setDiag(.validate, .other, .unknown, "global init-expr is not a valid constant expression (§3.3.7)", .{});
+                    return false;
+                },
+                .undeterminable => {},
+            }
+        }
         if (!validator.validateGlobalInits(g.items, global_entries, func_type_indices, &types_owned)) {
             diagnostic.setDiag(.validate, .other, .unknown, "global init-expr type mismatch (§3.4.3)", .{});
             return false;
@@ -337,6 +381,22 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         elem_types_validate = alloc.alloc(zir.ValType, elems.items.len) catch return false;
         for (elems.items, 0..) |seg, i| {
             elem_types_validate[i] = seg.elem_type;
+            // §3.3.7 — an active segment's offset is a constant expression of
+            // the target table's index type. By this point the context holds
+            // every global (imports + defined), which is the window the
+            // reference interpreter's `check_elem` sees.
+            if (seg.kind == .active and seg.offset_expr.len != 0) {
+                const want: zir.ValType = if (seg.tableidx < table_entries.len and table_entries[seg.tableidx].idx_type == .i64) .i64 else .i32;
+                const scope: validator.ConstExprScope = .{
+                    .globals = global_entries,
+                    .func_type_indices = func_type_indices,
+                    .types = &types_owned,
+                };
+                if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
+                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment offset is not a valid constant expression (§3.3.7)", .{});
+                    return false;
+                }
+            }
             for (seg.funcidxs) |fidx| {
                 // ref.null entries encoded as maxInt(u32) per the
                 // element decoder; skip those.
@@ -399,6 +459,40 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         null;
     defer if (datas_owned) |*d| d.deinit();
     const data_count_validate: u32 = if (datas_owned) |d| @intCast(d.items.len) else 0;
+    // §3.3.7 — same rule for an active data segment's offset, at the memory's
+    // index type. The memory section is decoded here purely to read that
+    // width: a memory64 offset is an `i64` constant expression, and typing it
+    // as `i32` would reject valid modules.
+    if (datas_owned) |d| {
+        var mems_owned: ?sections.Memories = if (module.find(.memory)) |s|
+            sections.decodeMemory(alloc, s.body) catch return false
+        else
+            null;
+        defer if (mems_owned) |*m| m.deinit();
+        var imp_mem_count: usize = 0;
+        if (imports_decoded) |im| for (im.items) |it| {
+            if (it.kind == .memory) imp_mem_count += 1;
+        };
+        for (d.items) |seg| {
+            if (seg.kind != .active or seg.offset_expr.len == 0) continue;
+            const want: zir.ValType = blk: {
+                if (seg.memidx < imp_mem_count) break :blk .i32; // import width not threaded here
+                const def_i = seg.memidx - imp_mem_count;
+                const mems = if (mems_owned) |m| m.items else &.{};
+                if (def_i >= mems.len) break :blk .i32;
+                break :blk if (mems[def_i].idx_type == .i64) .i64 else .i32;
+            };
+            const scope: validator.ConstExprScope = .{
+                .globals = global_entries,
+                .func_type_indices = func_type_indices,
+                .types = &types_owned,
+            };
+            if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
+                diagnostic.setDiag(.validate, .other, .unknown, "data segment offset is not a valid constant expression (§3.3.7)", .{});
+                return false;
+            }
+        }
+    }
     // `data_count_section_present` defaults to `true` on the
     // Validator struct; `validateFunctionWithMemIdxAndTags` doesn't
     // override it. Modules using memory.init MUST declare a
@@ -408,7 +502,7 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
     // `data_count_section_present` boolean if a fixture surfaces a
     // miscompile around its absence.
 
-    for (codes_owned.items, defined_func_indices, 0..) |code, type_idx, def_idx| {
+    for (code_items, defined_func_indices, 0..) |code, type_idx, def_idx| {
         const sig = types_owned.items[type_idx];
         validator.validateFunctionWithMemIdxAndTags(
             sig,

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -37,6 +37,7 @@ const verifier_mod = @import("../../ir/verifier.zig");
 const parser = @import("../../parse/parser.zig");
 const sections = @import("../../parse/sections.zig");
 const validator = @import("../../validate/validator.zig");
+const gc_subtype = @import("../../validate/gc_subtype.zig");
 const zir = @import("../../ir/zir.zig");
 const leb128 = @import("../../support/leb128.zig");
 const testing = std.testing;
@@ -275,6 +276,26 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         };
     }
 
+    // §3.3.7 `check_table` — a table's init expr is a constant expression of
+    // the table's element type, and it runs BEFORE the globals are folded into
+    // the context (`check_module` order: … memories → tables → globals), so it
+    // may read only IMPORTED globals. A defined global is out of scope here
+    // even though it is in scope for a data or elem offset further down.
+    if (tables_owned) |t| {
+        for (t.items) |entry| {
+            if (entry.init_expr.len == 0) continue;
+            const scope: validator.ConstExprScope = .{
+                .globals = global_entries[0..imp_global_count],
+                .func_type_indices = func_type_indices,
+                .types = &types_owned,
+            };
+            if (validator.validateConstExpr(entry.init_expr, entry.elem_type, scope) == .invalid) {
+                diagnostic.setDiag(.validate, .other, .unknown, "table init expr is not a valid constant expression (§3.3.7)", .{});
+                return false;
+            }
+        }
+    }
+
     // Memory0's idx_type drives the validator's memory-op address
     // valtype (i32 vs i64). Wasm 3.0 memory64 modules declare a
     // memory section with flag bit 0x04 set; without threading
@@ -381,20 +402,40 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         elem_types_validate = alloc.alloc(zir.ValType, elems.items.len) catch return false;
         for (elems.items, 0..) |seg, i| {
             elem_types_validate[i] = seg.elem_type;
-            // §3.3.7 — an active segment's offset is a constant expression of
-            // the target table's index type. By this point the context holds
-            // every global (imports + defined), which is the window the
-            // reference interpreter's `check_elem` sees.
-            if (seg.kind == .active and seg.offset_expr.len != 0) {
-                const want: zir.ValType = if (seg.tableidx < table_entries.len and table_entries[seg.tableidx].idx_type == .i64) .i64 else .i32;
-                const scope: validator.ConstExprScope = .{
-                    .globals = global_entries,
-                    .func_type_indices = func_type_indices,
-                    .types = &types_owned,
-                };
-                if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
-                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment offset is not a valid constant expression (§3.3.7)", .{});
+            if (seg.kind == .active) {
+                // §3.3.7 `check_elemmode` — the named table must exist, the
+                // segment's element type must be a SUBTYPE of the table's
+                // (not merely equal: a `funcref` segment does not fit a
+                // non-nullable `(ref func)` table), and the offset is a
+                // constant expression at the table's index type. By this point
+                // the context holds every global, which is the window
+                // `check_elem` sees.
+                if (seg.tableidx >= table_entries.len) {
+                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment names a table that does not exist (§3.3.7)", .{});
                     return false;
+                }
+                const tbl = table_entries[seg.tableidx];
+                // An IMPORTED table's entry carries a synthesised permissive
+                // `funcref` (§A10 gives imports kind-only here), not its real
+                // element type, so the subtype rule has nothing truthful to
+                // compare against and is skipped for those slots.
+                if (seg.tableidx >= imp_table_count and
+                    !gc_subtype.gcValTypeSubtype(seg.elem_type, tbl.elem_type, &types_owned))
+                {
+                    diagnostic.setDiag(.validate, .other, .unknown, "elem segment type is not a subtype of the table's element type (§3.3.7)", .{});
+                    return false;
+                }
+                if (seg.offset_expr.len != 0) {
+                    const want: zir.ValType = if (tbl.idx_type == .i64) .i64 else .i32;
+                    const scope: validator.ConstExprScope = .{
+                        .globals = global_entries,
+                        .func_type_indices = func_type_indices,
+                        .types = &types_owned,
+                    };
+                    if (validator.validateConstExpr(seg.offset_expr, want, scope) == .invalid) {
+                        diagnostic.setDiag(.validate, .other, .unknown, "elem segment offset is not a valid constant expression (§3.3.7)", .{});
+                        return false;
+                    }
                 }
             }
             for (seg.funcidxs) |fidx| {
@@ -459,29 +500,19 @@ pub fn frontendValidate(alloc: std.mem.Allocator, binary: []const u8) bool {
         null;
     defer if (datas_owned) |*d| d.deinit();
     const data_count_validate: u32 = if (datas_owned) |d| @intCast(d.items.len) else 0;
-    // §3.3.7 — same rule for an active data segment's offset, at the memory's
-    // index type. The memory section is decoded here purely to read that
-    // width: a memory64 offset is an `i64` constant expression, and typing it
-    // as `i32` would reject valid modules.
+    // §3.3.7 `check_datamode` — an active segment names a memory that must
+    // exist, and its offset is a constant expression at THAT memory's index
+    // type (a memory64 offset is `i64`; typing it as `i32` would reject valid
+    // modules). `memory_idx_types` already spans imports-then-defined.
     if (datas_owned) |d| {
-        var mems_owned: ?sections.Memories = if (module.find(.memory)) |s|
-            sections.decodeMemory(alloc, s.body) catch return false
-        else
-            null;
-        defer if (mems_owned) |*m| m.deinit();
-        var imp_mem_count: usize = 0;
-        if (imports_decoded) |im| for (im.items) |it| {
-            if (it.kind == .memory) imp_mem_count += 1;
-        };
         for (d.items) |seg| {
-            if (seg.kind != .active or seg.offset_expr.len == 0) continue;
-            const want: zir.ValType = blk: {
-                if (seg.memidx < imp_mem_count) break :blk .i32; // import width not threaded here
-                const def_i = seg.memidx - imp_mem_count;
-                const mems = if (mems_owned) |m| m.items else &.{};
-                if (def_i >= mems.len) break :blk .i32;
-                break :blk if (mems[def_i].idx_type == .i64) .i64 else .i32;
-            };
+            if (seg.kind != .active) continue;
+            if (seg.memidx >= total_memory_count) {
+                diagnostic.setDiag(.validate, .other, .unknown, "data segment names a memory that does not exist (§3.3.7)", .{});
+                return false;
+            }
+            if (seg.offset_expr.len == 0) continue;
+            const want: zir.ValType = if (memory_idx_types[seg.memidx] == .i64) .i64 else .i32;
             const scope: validator.ConstExprScope = .{
                 .globals = global_entries,
                 .func_type_indices = func_type_indices,

--- a/src/validate/validator.zig
+++ b/src/validate/validator.zig
@@ -113,6 +113,9 @@ pub const GlobalEntry = helpers.GlobalEntry;
 pub const typeDefIsSubtype = helpers.typeDefIsSubtype;
 pub const constExprResultType = helpers.constExprResultType;
 pub const validateGlobalInits = helpers.validateGlobalInits;
+pub const ConstExprVerdict = helpers.ConstExprVerdict;
+pub const ConstExprScope = helpers.ConstExprScope;
+pub const validateConstExpr = helpers.validateConstExpr;
 pub const funcTypeImportCompatible = helpers.funcTypeImportCompatible;
 pub const validateTypeSection = helpers.validateTypeSection;
 

--- a/src/validate/validator_helpers.zig
+++ b/src/validate/validator_helpers.zig
@@ -10,6 +10,7 @@
 //! SIBLING-PUB: the `pub` symbols here are consumed only by the sibling
 //! `validator.zig` (which re-exports them) + its callers; the pub-ness is an
 //! extraction artifact, not a wide public API surface.
+const std = @import("std");
 const leb128 = @import("../support/leb128.zig");
 const zir = @import("../ir/zir.zig");
 const sections = @import("../parse/sections.zig");
@@ -170,4 +171,120 @@ pub fn validateTypeSection(types: *const sections.Types) bool {
         if (!typeDefIsSubtype(@intCast(i), s, types)) return false; // structural conformance
     }
     return true;
+}
+
+/// Wasm 3.0 §3.3.7 — the verdict of walking a constant expression.
+/// `undeterminable` is the conservative arm: the expression uses a shape this
+/// walker does not model (the GC `0xFB` family), so it must not be rejected.
+pub const ConstExprVerdict = enum { ok, invalid, undeterminable };
+
+/// The globals a constant expression may read, in index order (imports first).
+/// The window differs per position because the spec builds the validation
+/// context incrementally — reference interpreter `check_module`
+/// (`interpreter/valid/valid.ml`) folds the module in the order
+/// imports → tags → funcs → memories → tables → globals → datas → elems, so a
+/// table's init expr sees only imported globals, a defined global's init sees
+/// the globals declared before it, and data/elem offsets see all of them.
+pub const ConstExprScope = struct {
+    globals: []const GlobalEntry,
+    func_type_indices: []const u32,
+    types: *const sections.Types,
+};
+
+/// Wasm 3.0 §3.3.7 — type-check a constant expression against the type its
+/// position demands. Mirrors the reference interpreter's `is_const` +
+/// `check_const` pair: `is_const` fixes the admissible opcode set (including
+/// extended-const's `i32`/`i64` `add`/`sub`/`mul`, and `global.get` only for
+/// an IMMUTABLE global), and `check_const` then types the sequence as a block
+/// producing exactly `[expected]` — which is where arity, emptiness and
+/// subtyping are decided.
+pub fn validateConstExpr(
+    expr: []const u8,
+    expected: ValType,
+    scope: ConstExprScope,
+) ConstExprVerdict {
+    // Const exprs are tiny in every real module; a fixed stack keeps this
+    // allocation-free. An expression deep enough to overflow it is one this
+    // walker declines to judge rather than rejects.
+    var stack: [16]ValType = undefined;
+    var sp: usize = 0;
+    var pos: usize = 0;
+
+    while (pos < expr.len) {
+        const op = expr[pos];
+        pos += 1;
+        switch (op) {
+            0x0B => { // end — must be the last byte, leaving exactly [expected]
+                if (pos != expr.len) return .invalid;
+                if (sp != 1) return .invalid;
+                return if (gc_subtype.gcValTypeSubtype(stack[0], expected, scope.types)) .ok else .invalid;
+            },
+            0x41 => { // i32.const
+                _ = leb128.readSleb128(i32, expr, &pos) catch return .invalid;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = .i32;
+                sp += 1;
+            },
+            0x42 => { // i64.const
+                _ = leb128.readSleb128(i64, expr, &pos) catch return .invalid;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = .i64;
+                sp += 1;
+            },
+            0x43, 0x44 => { // f32.const / f64.const
+                const width: usize = if (op == 0x43) 4 else 8;
+                if (pos + width > expr.len) return .invalid;
+                pos += width;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = if (op == 0x43) .f32 else .f64;
+                sp += 1;
+            },
+            0xD0 => { // ref.null ht
+                const t = init_expr.readTypedRef(expr, &pos, true) catch return .invalid;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = t;
+                sp += 1;
+            },
+            0xD2 => { // ref.func i → non-null (ref <typeof i>)
+                const idx = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                if (idx >= scope.func_type_indices.len) return .invalid;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = .{ .ref = .{ .nullable = false, .heap_type = .{ .concrete = scope.func_type_indices[idx] } } };
+                sp += 1;
+            },
+            0x23 => { // global.get j — const only for an immutable global in scope
+                const idx = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                if (idx >= scope.globals.len) return .invalid;
+                if (scope.globals[idx].mutable) return .invalid;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = scope.globals[idx].valtype;
+                sp += 1;
+            },
+            0x6A, 0x6B, 0x6C, 0x7C, 0x7D, 0x7E => { // extended-const i32/i64 add/sub/mul
+                const want: std.meta.Tag(ValType) = if (op <= 0x6C) .i32 else .i64;
+                if (sp < 2) return .invalid;
+                // ValType is a tagged union (ref types carry a payload), so the
+                // operand check compares tags, not values.
+                if (std.meta.activeTag(stack[sp - 1]) != want) return .invalid;
+                if (std.meta.activeTag(stack[sp - 2]) != want) return .invalid;
+                sp -= 1; // two operands in, one result out
+            },
+            0xFD => { // v128.const is the only constant SIMD op
+                const sub = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                if (sub != 0x0C) return .invalid;
+                if (pos + 16 > expr.len) return .invalid;
+                pos += 16;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = .v128;
+                sp += 1;
+            },
+            // GC + extern-convert const forms (struct.new / array.new* /
+            // ref.i31 / any.convert_extern …). Admissible per `is_const`, but
+            // typing them needs the full GC type algebra — decline to judge
+            // rather than reject a valid module.
+            0xFB => return .undeterminable,
+            else => return .invalid, // not in `is_const`
+        }
+    }
+    return .invalid; // ran off the end without `end`
 }

--- a/src/validate/validator_helpers.zig
+++ b/src/validate/validator_helpers.zig
@@ -173,7 +173,7 @@ pub fn validateTypeSection(types: *const sections.Types) bool {
     return true;
 }
 
-/// Wasm 3.0 §3.3.7 — the verdict of walking a constant expression.
+/// Wasm 3.0 §3.3.13.1 — the verdict of walking a constant expression.
 /// `undeterminable` is the conservative arm: the expression uses a shape this
 /// walker does not model (the GC `0xFB` family), so it must not be rejected.
 pub const ConstExprVerdict = enum { ok, invalid, undeterminable };
@@ -191,7 +191,7 @@ pub const ConstExprScope = struct {
     types: *const sections.Types,
 };
 
-/// Wasm 3.0 §3.3.7 — type-check a constant expression against the type its
+/// Wasm 3.0 §3.3.13.1 — type-check a constant expression against the type its
 /// position demands. Mirrors the reference interpreter's `is_const` +
 /// `check_const` pair: `is_const` fixes the admissible opcode set (including
 /// extended-const's `i32`/`i64` `add`/`sub`/`mul`, and `global.get` only for
@@ -203,10 +203,13 @@ pub fn validateConstExpr(
     expected: ValType,
     scope: ConstExprScope,
 ) ConstExprVerdict {
-    // Const exprs are tiny in every real module; a fixed stack keeps this
-    // allocation-free. An expression deep enough to overflow it is one this
-    // walker declines to judge rather than rejects.
-    var stack: [16]ValType = undefined;
+    // A fixed stack keeps this allocation-free. Extended-const lets an
+    // expression push arbitrarily many operands before folding them
+    // (`i32.const` xN followed by `i32.add` xN-1 is valid at any N), so the
+    // bound is set far above any shape a producer emits rather than at the
+    // arity of a single instruction. Overflow yields `.undeterminable`, never
+    // `.invalid` — rejecting there would reject a valid module.
+    var stack: [256]ValType = undefined;
     var sp: usize = 0;
     var pos: usize = 0;
 
@@ -279,10 +282,11 @@ pub fn validateConstExpr(
                 sp += 1;
             },
             // GC + extern-convert const forms (struct.new / array.new* /
-            // ref.i31 / any.convert_extern …). Admissible per `is_const`, but
-            // typing them needs the full GC type algebra — decline to judge
-            // rather than reject a valid module.
-            0xFB => return .undeterminable,
+            // ref.i31 / any.convert_extern …). Every one of them yields a
+            // reference, so a numeric `expected` can never be satisfied and is
+            // an outright mismatch. Typing them against a reference needs the
+            // full GC type algebra, which this walker declines to judge.
+            0xFB => return if (expected == .ref) .undeterminable else .invalid,
             else => return .invalid, // not in `is_const`
         }
     }

--- a/src/validate/validator_helpers_tests.zig
+++ b/src/validate/validator_helpers_tests.zig
@@ -1,0 +1,100 @@
+//! Tests for the pure const-expr sub-language in `validator_helpers.zig`.
+//!
+//! Split from `validator_tests.zig` rather than raising that file's cap: these
+//! exercise the extracted helper module, not `Validator` state, so the sibling
+//! placement matches what they test (ADR-0099 P/N split over marker bump).
+
+const std = @import("std");
+const testing = std.testing;
+
+const validator = @import("validator.zig");
+const sections = @import("../parse/sections.zig");
+const zir = @import("../ir/zir.zig");
+const ValType = zir.ValType;
+const GlobalEntry = validator.GlobalEntry;
+
+test "validateConstExpr: is_const opcode set + arity + global.get mutability (§3.3.7)" {
+    var types: sections.Types = .{
+        .arena = std.heap.ArenaAllocator.init(testing.allocator),
+        .items = &.{},
+        .kinds = &.{},
+        .struct_defs = &.{},
+        .array_defs = &.{},
+        .supertypes = &.{},
+        .finals = &.{},
+        .rec_span = &.{},
+    };
+    defer types.deinit();
+
+    const globals = [_]GlobalEntry{
+        .{ .valtype = .i32, .mutable = false }, // 0: immutable
+        .{ .valtype = .i32, .mutable = true }, // 1: mutable
+    };
+    const fti = [_]u32{0};
+    const scope: validator.ConstExprScope = .{
+        .globals = &globals,
+        .func_type_indices = &fti,
+        .types = &types,
+    };
+
+    // Well-formed: i32.const 7; end
+    try testing.expectEqual(validator.ConstExprVerdict.ok, validator.validateConstExpr(&[_]u8{ 0x41, 0x07, 0x0B }, .i32, scope));
+    // extended-const: i32.const 20; i32.const 2; i32.mul; end
+    try testing.expectEqual(validator.ConstExprVerdict.ok, validator.validateConstExpr(&[_]u8{ 0x41, 0x14, 0x41, 0x02, 0x6C, 0x0B }, .i32, scope));
+    // global.get 0 (immutable) is const
+    try testing.expectEqual(validator.ConstExprVerdict.ok, validator.validateConstExpr(&[_]u8{ 0x23, 0x00, 0x0B }, .i32, scope));
+
+    // global.get 1 reads a MUTABLE global — `is_const` excludes it.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x23, 0x01, 0x0B }, .i32, scope));
+    // global.get 2 is out of the scope's window.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x23, 0x02, 0x0B }, .i32, scope));
+    // Empty expression produces nothing where one value is required.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{0x0B}, .i32, scope));
+    // Two values left on the stack.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x00, 0x41, 0x00, 0x0B }, .i32, scope));
+    // Result type mismatch: f32.const into an i32 slot.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x43, 0x00, 0x00, 0x00, 0x00, 0x0B }, .i32, scope));
+    // i32.add over i64 operands.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x42, 0x01, 0x42, 0x02, 0x6A, 0x0B }, .i64, scope));
+    // An opcode outside `is_const` (i32.eqz).
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x00, 0x45, 0x0B }, .i32, scope));
+    // ref.func with an out-of-range funcidx.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0xD2, 0x09, 0x0B }, ValType.funcref, scope));
+    // Trailing bytes after `end`.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x00, 0x0B, 0x41, 0x00 }, .i32, scope));
+
+    // The GC family is admissible per `is_const` but not typed here — it must
+    // come back undeterminable so an incomplete walker cannot reject a valid
+    // module (struct.new 3).
+    try testing.expectEqual(validator.ConstExprVerdict.undeterminable, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, .i32, scope));
+}
+
+test "validateConstExpr: the readable-global window is positional (§3.3.7 context order)" {
+    var types: sections.Types = .{
+        .arena = std.heap.ArenaAllocator.init(testing.allocator),
+        .items = &.{},
+        .kinds = &.{},
+        .struct_defs = &.{},
+        .array_defs = &.{},
+        .supertypes = &.{},
+        .finals = &.{},
+        .rec_span = &.{},
+    };
+    defer types.deinit();
+
+    const all = [_]GlobalEntry{
+        .{ .valtype = .i32, .mutable = false }, // 0: imported
+        .{ .valtype = .i32, .mutable = false }, // 1: defined
+    };
+    const fti = [_]u32{};
+    const get1 = [_]u8{ 0x23, 0x01, 0x0B }; // global.get 1; end
+
+    // A table init expr sees imports only — `check_module` folds tables before
+    // globals — so global 1 is out of scope there.
+    const imports_only: validator.ConstExprScope = .{ .globals = all[0..1], .func_type_indices = &fti, .types = &types };
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&get1, .i32, imports_only));
+
+    // A data or elem offset sees every global.
+    const everything: validator.ConstExprScope = .{ .globals = &all, .func_type_indices = &fti, .types = &types };
+    try testing.expectEqual(validator.ConstExprVerdict.ok, validator.validateConstExpr(&get1, .i32, everything));
+}

--- a/src/validate/validator_helpers_tests.zig
+++ b/src/validate/validator_helpers_tests.zig
@@ -13,7 +13,7 @@ const zir = @import("../ir/zir.zig");
 const ValType = zir.ValType;
 const GlobalEntry = validator.GlobalEntry;
 
-test "validateConstExpr: is_const opcode set + arity + global.get mutability (§3.3.7)" {
+test "validateConstExpr: is_const opcode set + arity + global.get mutability (§3.3.13.1)" {
     var types: sections.Types = .{
         .arena = std.heap.ArenaAllocator.init(testing.allocator),
         .items = &.{},
@@ -63,13 +63,20 @@ test "validateConstExpr: is_const opcode set + arity + global.get mutability (§
     // Trailing bytes after `end`.
     try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x00, 0x0B, 0x41, 0x00 }, .i32, scope));
 
-    // The GC family is admissible per `is_const` but not typed here — it must
-    // come back undeterminable so an incomplete walker cannot reject a valid
-    // module (struct.new 3).
-    try testing.expectEqual(validator.ConstExprVerdict.undeterminable, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, .i32, scope));
+    // The GC family is admissible per `is_const` but not typed here. Every one
+    // of its forms yields a reference, so the verdict splits on what the
+    // position expects: a reference is undeterminable (an incomplete walker
+    // must not reject a valid module), a numeric type is an outright mismatch.
+    try testing.expectEqual(validator.ConstExprVerdict.undeterminable, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, ValType.anyref, scope));
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, .i32, scope));
+
+    // An expression deeper than a single instruction's arity is typed, not
+    // waved through: extended-const can push many operands before folding.
+    try testing.expectEqual(validator.ConstExprVerdict.ok, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0x41, 0x02, 0x41, 0x03, 0x6A, 0x6A, 0x0B }, .i32, scope));
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0x42, 0x02, 0x6A, 0x0B }, .i32, scope));
 }
 
-test "validateConstExpr: the readable-global window is positional (§3.3.7 context order)" {
+test "validateConstExpr: the readable-global window is positional (§3.3.13.1 context order)" {
     var types: sections.Types = .{
         .arena = std.heap.ArenaAllocator.init(testing.allocator),
         .items = &.{},

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -384,6 +384,7 @@ test {
     _ = @import("parse/parser.zig");
     _ = @import("validate/validator.zig");
     _ = @import("validate/validator_tests.zig");
+    _ = @import("validate/validator_helpers_tests.zig");
     _ = @import("ir/lower.zig");
     _ = @import("ir/lower_tests.zig");
     _ = @import("parse/ctx.zig");


### PR DESCRIPTION
A module with no code section returned early from `frontendValidate`, so a
module holding only a global, data or element section was never checked — the
same bytes `compileWasm` rejects. This adds a general constant-expression
validator on that path, mirroring the reference interpreter's `is_const` /
`check_const`, and removes the early returns so every module shape reaches the
section-level rules.

Three further defects surfaced while tracing it, each harmless only because
nothing compared against the wrong value:

- an imported table's entry was synthesised as `funcref` with an `i32` index
  width instead of its declared ones, so an imported `externref` table refused
  `externref` segments and an imported table64 refused its own `i64` offsets;
- an element segment's type was recorded as nullable `funcref` for every form,
  though the spec assigns non-nullable `(ref func)` to the funcidx forms
  (0x00-0x03) and keeps the nullable one only for 0x04;
- a segment's target table or memory was not checked for existence;
- an imported table's element type and an imported global's valtype were never
  bounds-checked, so a concrete head naming a type that does not exist was read
  as `.any` by `gcValTypeSubtype` and the mistyped entity accepted. Defined
  tables and globals have always been checked here; the import section was
  decoded and dropped.

## Verdict handling

`validateConstExpr` returns `ok` / `invalid` / `undeterminable`. The GC and
extern-convert const forms all yield a reference, so a numeric position is an
outright mismatch and only a reference position stays undeterminable. Operand
depth is sized for extended-const, which may push arbitrarily many operands
before folding them; overflow yields `undeterminable`, never `invalid`, because
rejecting there would reject a valid module. Every call site switches on the
verdict rather than comparing against `invalid`, so an added verdict cannot
silently become "valid" (ADR-0174).

## Verification

`zig build test-all` green. Tests reach `frontendValidate` itself: a module with
neither a type nor a code section, in both directions; a function section with
no bodies; a segment naming a table or memory that does not exist. The element
decoder pins the element type of every form, including the 0x04 twin.

Both directions are checked, not just one — no valid module fails to compile
AND no `assert_invalid` module is accepted. Watching either alone hides the
other.

## Scope

`check_module` carries further rules still absent after this — exports, start,
imported entity types, elem items — tracked in #285. The extended-const corpus
that surfaced all of this is not here: it needs #282 first.

Resolves: https://github.com/zwasm/zwasm/issues/291
