### PR TITLE
fix(jit): the mixed multi-result thunks survive optimisation

### DIFF
--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -871,8 +871,10 @@ any `Frame` field the emit's `Label` has but liveness pins to a constant
 ## Recipe 23 — Debug-passes / optimised-fails in a host→JIT thunk
 
 **Trigger.** A lane is green at the default optimize level and fails at
-`-Doptimize=Release*`. CI runs `test-all` without an optimize flag, so this
-whole class is invisible to it while releases are built ReleaseSafe.
+`-Doptimize=Release*`. `ci_gate.sh` runs `test-all` at the default optimize
+level; the one ReleaseSafe build it does run, `check_jit_releasesafe.sh`, sits
+in the `ZWASM_CI_EXTENDED` leg, which fires on the push to `main` and not on a
+PR. So this class reaches `main` before any lane sees it.
 
 **First: settle whether it is the optimizer or the mode.** Run all four.
 Debug-only-green with every Release mode failing identically points at the
@@ -910,8 +912,9 @@ mixed multi-result thunks (`entry.zig` `callI32f64NoArgs` and siblings):
 
 2. **The JIT's register cohort not saved.** The JIT allocates from the host's
    callee-saved registers and its prologue saves only one, so every host→JIT
-   call must bracket the branch. `invokeAndCheckVoid` carries the canonical
-   save on each target; a thunk added later can silently omit it. Symptom: a
+   call must bracket the branch. `invokeAndCheckVoid` carries the save for
+   aarch64 and SysV; it has no Windows branch and falls through to
+   `jitTrampolineVoid`. A thunk added later can silently omit the save. Symptom: a
    result comes back holding a pointer, or the host faults after returning.
 
 **Verify a new gate leg is a guard, not a passing command.** Revert the fix,

--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -928,5 +928,6 @@ first explanation written for this bug claimed x0 held an sret pointer for a
 16-byte struct return. The callee was declared to return `void`, so there was
 no struct return in the call at all; and AAPCS64 returns a 16-byte non-HFA
 composite in x0+x1 directly, putting the indirect-return pointer in x8 when it
-uses one (`~/Documents/OSS/wasmtime/cranelift/codegen/src/isa/aarch64/abi.rs`).
+uses one — cross-checked against cranelift's aarch64 ABI lowering
+(`cranelift/codegen/src/isa/aarch64/abi.rs` in `bytecodealliance/wasmtime`).
 Read the callee's declared type first, then the ABI, then the disassembly.

--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -867,3 +867,63 @@ enclosing frame's vreg.
 `sim_len >= <arity>` that should be `sim_len >= entry_depth + <arity>`, and
 any `Frame` field the emit's `Label` has but liveness pins to a constant
 (`param_arity = 0` was pinned for block/loop frames).
+
+## Recipe 23 — Debug-passes / optimised-fails in a host→JIT thunk
+
+**Trigger.** A lane is green at the default optimize level and fails at
+`-Doptimize=Release*`. CI runs `test-all` without an optimize flag, so this
+whole class is invisible to it while releases are built ReleaseSafe.
+
+**First: settle whether it is the optimizer or the mode.** Run all four.
+Debug-only-green with every Release mode failing identically points at the
+host↔JIT boundary, not at a Release-specific miscompile.
+
+```sh
+for m in Debug ReleaseSafe ReleaseFast ReleaseSmall; do
+  zig build install ${m:+-Doptimize=$m} >/dev/null 2>&1
+  ./zig-out/bin/<runner> <corpus> >/dev/null 2>&1; echo "$m exit=$?"
+done
+```
+
+**Then bisect the manifest, not the code.** Truncating a manifest is far
+cheaper than reading codegen, and lands on the directive:
+
+```sh
+lo=1; hi=$(wc -l < full.txt)
+while [ $lo -lt $hi ]; do
+  mid=$(( (lo + hi) / 2 )); head -$mid full.txt > manifest.txt
+  ./zig-out/bin/<runner> <corpus> >/dev/null 2>&1
+  if [ $? -ne 0 ]; then hi=$mid; else lo=$((mid+1)); fi
+done
+```
+
+**Two failure modes live at this boundary.** Both were found together in the
+mixed multi-result thunks (`entry.zig` `callI32f64NoArgs` and siblings):
+
+1. **An operand named as both input and output of one `asm`.** `"{x0}"` in and
+   `"={x0}"` out are untied, so the allocator may place the output's def before
+   the input's use. Debug happened to allocate elsewhere. Symptom: the callee
+   runs with a garbage first argument, faulting at a small constant address (a
+   field offset off that garbage). Fix: take the value in a different register
+   and `mov` it into place inside the asm; pin every operand to a named
+   register — `"r"` is free to pick the one a neighbouring line just wrote.
+
+2. **The JIT's register cohort not saved.** The JIT allocates from the host's
+   callee-saved registers and its prologue saves only one, so every host→JIT
+   call must bracket the branch. `invokeAndCheckVoid` carries the canonical
+   save on each target; a thunk added later can silently omit it. Symptom: a
+   result comes back holding a pointer, or the host faults after returning.
+
+**Verify a new gate leg is a guard, not a passing command.** Revert the fix,
+rebuild at the optimised level, confirm the leg fails, restore, confirm it
+passes. Check the restore by content (`git status --porcelain`, or an md5), not
+by trusting that the revert command did what was asked — a `git stash` that
+silently matched nothing once produced a confident "the guard does not work".
+
+**Do not trust an inline-asm comment about the ABI without checking it.** The
+first explanation written for this bug claimed x0 held an sret pointer for a
+16-byte struct return. The callee was declared to return `void`, so there was
+no struct return in the call at all; and AAPCS64 returns a 16-byte non-HFA
+composite in x0+x1 directly, putting the indirect-return pointer in x8 when it
+uses one (`~/Documents/OSS/wasmtime/cranelift/codegen/src/isa/aarch64/abi.rs`).
+Read the callee's declared type first, then the ABI, then the disassembly.

--- a/.claude/skills/debug_jit_auto/SKILL.md
+++ b/.claude/skills/debug_jit_auto/SKILL.md
@@ -103,6 +103,7 @@ to the heading.
 | 20 | **Operand-stack-pressure sweep** | any | JIT-only wrong result/trap where each op passes in isolation → spilled operand |
 | 21 | **Differential probe by re-exporting a guest's internals** | any | **A toolchain-built `.wasm` aborts under `--engine jit` only** — too big to read |
 | 22 | **liveness sim vs emit `pushed_vregs` drift** | any | Stale block/if result AND `regverify` reports no overlap |
+| 23 | **Debug-passes / optimised-fails in a host→JIT thunk** | any | **A lane is green at the default optimize level and fails at `-Doptimize=Release*`** — CI never runs the optimised build, releases do |
 
 
 ## When to invoke each recipe (decision tree)

--- a/scripts/check_jit_releasesafe.sh
+++ b/scripts/check_jit_releasesafe.sh
@@ -39,3 +39,29 @@ else
     echo "[check_jit_releasesafe] FAIL (exit $rc) — runI32Export crashed/mismatched in ReleaseSafe; D-245 RESULT-path preservation regressed (see src/engine/codegen/shared/entry.zig jitTrampoline / invokeAndCheck)." >&2
     exit 1
 fi
+
+# 2026-08-25 — the two legs above cover the VOID path and the i32 RESULT path.
+# They do not reach the MIXED multi-result thunks (`(i32, f64)`, `(f64, i32)`,
+# `(f64, f32)`), which have their own hand-written asm and had the same defect
+# this gate exists for: they never bracketed the JIT call with a save of
+# X19-X28, so an optimised host lost live values there. They also claimed x0 as
+# both an input and an output while AAPCS64 was using it for the indirect
+# return of the 16-byte result struct.
+#
+# The corpus that reaches them is `call_indirect`, whose `type-all-i32-f64` and
+# siblings return mixed pairs. Debug passes it either way — the whole point is
+# that only an optimised build shows the fault — so this runs the real runner
+# against the real corpus at ReleaseSafe. Every optimisation mode failed
+# identically when the defect was live, so ReleaseSafe alone is a faithful
+# probe.
+echo "[check_jit_releasesafe] mixed multi-result thunks at ReleaseSafe ..."
+MIXED_DIR=$(mktemp -d)
+trap 'rm -rf "$MIXED_DIR"' EXIT
+cp -r test/spec/wasm-2.0-assert/call_indirect "$MIXED_DIR/"
+if zig-out/bin/zwasm-spec-wasm-2-0-assert "$MIXED_DIR" >/dev/null 2>&1; then
+    echo "[check_jit_releasesafe] OK — mixed int/float multi-result returns survive optimisation."
+else
+    rc=$?
+    echo "[check_jit_releasesafe] FAIL (exit $rc) — the aarch64 mixed-result thunks regressed in ReleaseSafe; see src/engine/codegen/shared/entry.zig callI32f64NoArgs / callF64i32NoArgs / callF64f32NoArgs (x0 is the sret pointer; X19-X28 must be saved around the BLR)." >&2
+    exit 1
+fi

--- a/scripts/check_jit_releasesafe.sh
+++ b/scripts/check_jit_releasesafe.sh
@@ -62,6 +62,6 @@ if zig-out/bin/zwasm-spec-wasm-2-0-assert "$MIXED_DIR" >/dev/null 2>&1; then
     echo "[check_jit_releasesafe] OK — mixed int/float multi-result returns survive optimisation."
 else
     rc=$?
-    echo "[check_jit_releasesafe] FAIL (exit $rc) — the aarch64 mixed-result thunks regressed in ReleaseSafe; see src/engine/codegen/shared/entry.zig callI32f64NoArgs / callF64i32NoArgs / callF64f32NoArgs (x0 must not be both an input and an output of the asm; X19-X28 must be saved around the BLR)." >&2
+    echo "[check_jit_releasesafe] FAIL (exit $rc) — the mixed-result thunks regressed in ReleaseSafe (this leg runs on whichever host builds it — aarch64 and x86_64 alike); see src/engine/codegen/shared/entry.zig callI32f64NoArgs / callF64i32NoArgs / callF64f32NoArgs (x0 must not be both an input and an output of the asm; X19-X28 must be saved around the BLR)." >&2
     exit 1
 fi

--- a/scripts/check_jit_releasesafe.sh
+++ b/scripts/check_jit_releasesafe.sh
@@ -10,6 +10,14 @@
 # Build ReleaseSafe + run a SIMD `_start` via `--engine=jit` (the interp has no
 # SIMD, so this forces the JIT execute path). A non-zero exit = the
 # callee-saved-clobber SEGV regressed. Cheap to read, ~minutes to build.
+#
+# Where this runs: `ci_gate.sh` invokes it inside the ZWASM_CI_EXTENDED leg,
+# which fires on the push to `main` and NOT on a pull request. A regression in
+# this class therefore reaches `main` before any lane reports it — the same
+# shape of gap that let the original defect ship. The cost is the reason: this
+# is a full cold ReleaseSafe build, and the PR gate is already the slowest
+# thing in the loop. Promoting it to the core leg is the fix if that cost ever
+# becomes affordable.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 

--- a/scripts/check_jit_releasesafe.sh
+++ b/scripts/check_jit_releasesafe.sh
@@ -44,9 +44,9 @@ fi
 # They do not reach the MIXED multi-result thunks (`(i32, f64)`, `(f64, i32)`,
 # `(f64, f32)`), which have their own hand-written asm and had the same defect
 # this gate exists for: they never bracketed the JIT call with a save of
-# X19-X28, so an optimised host lost live values there. They also claimed x0 as
-# both an input and an output while AAPCS64 was using it for the indirect
-# return of the 16-byte result struct.
+# X19-X28, so an optimised host lost live values there. They also named x0 as
+# both an untied input and an output of the same asm, which lets the allocator
+# place the output's def ahead of the input's use.
 #
 # The corpus that reaches them is `call_indirect`, whose `type-all-i32-f64` and
 # siblings return mixed pairs. Debug passes it either way — the whole point is
@@ -62,6 +62,6 @@ if zig-out/bin/zwasm-spec-wasm-2-0-assert "$MIXED_DIR" >/dev/null 2>&1; then
     echo "[check_jit_releasesafe] OK — mixed int/float multi-result returns survive optimisation."
 else
     rc=$?
-    echo "[check_jit_releasesafe] FAIL (exit $rc) — the aarch64 mixed-result thunks regressed in ReleaseSafe; see src/engine/codegen/shared/entry.zig callI32f64NoArgs / callF64i32NoArgs / callF64f32NoArgs (x0 is the sret pointer; X19-X28 must be saved around the BLR)." >&2
+    echo "[check_jit_releasesafe] FAIL (exit $rc) — the aarch64 mixed-result thunks regressed in ReleaseSafe; see src/engine/codegen/shared/entry.zig callI32f64NoArgs / callF64i32NoArgs / callF64f32NoArgs (x0 must not be both an input and an output of the asm; X19-X28 must be saved around the BLR)." >&2
     exit 1
 fi

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -1,4 +1,4 @@
-// FILE-SIZE-EXEMPT: uniform-pattern catalog (127 callXX_yy per-shape entry helpers; monotonic growth with Wasm signature shapes — +8 D-467 multi-scalar→v128 + 2 D-467 load/store-lane (i32,v128)→v128/i64; 2026-08-25 +110 for the host→JIT register-cohort save that every mixed multi-result thunk was missing on all three targets — the sequence is pasted per call site because Zig inline asm takes a single string and folding it into shared constants was tried and reverted as more fragile than the duplication) (cap=3450) (per ADR-0063 + ADR-0099 Revision 2026-05-24)
+// FILE-SIZE-EXEMPT: uniform-pattern catalog (125 callXX_yy per-shape entry helpers; monotonic growth with Wasm signature shapes — +8 D-467 multi-scalar→v128 + 2 D-467 load/store-lane (i32,v128)→v128/i64; 2026-08-25 +175 for the host→JIT register-cohort save every mixed multi-result thunk needs on all three targets — the sequence is pasted per call site because Zig inline asm takes a single string, so it cannot be folded into a shared constant) (cap=3450) (per ADR-0063 + ADR-0099 Revision 2026-05-24)
 // Comptime generation is a follow-up; see ADR-0063 Alternative B + debt ledger.
 
 //! JIT entry frame (ADR-0017).
@@ -119,9 +119,9 @@ const x86_64_sysv_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and buil
 /// caller-saved (volatile) GPR + XMM0–XMM5. XMM6–XMM15 are non-volatile
 /// under Win64 and the JIT does NOT preserve them: its pool takes xmm8-xmm13
 /// with xmm14/xmm15 as the spill stage (`x86_64/abi.zig`), and
-/// `x86_64/prologue.zig` emits no XMM save at all. Tracked separately; listing
-/// them here would only tell the compiler they are destroyed, which is true
-/// but does not restore a host value the guest already overwrote.
+/// `x86_64/prologue.zig` emits no XMM save at all. Listing them here is what
+/// would make the compiler preserve a host value held in one across the asm;
+/// they are omitted, so that exposure is open. Tracked in #286.
 const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) .{
         .rax = true,
@@ -145,16 +145,15 @@ const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and bui
 
 /// D-245 — the callee-saved GPRs the JIT prologue clobbers.
 /// The prologue MOV-installs the pinned cohort (arm64 X19/X24-X28; x86_64
-/// RBX/R12-R15) from `rt` WITHOUT stack-saving the caller's values, so a plain
+/// RBX/R12-R14 plus the reserved R15) from `rt` WITHOUT stack-saving the caller's values, so a plain
 /// host→JIT `@call` lets ReleaseSafe's optimized host lose any live value it
 /// kept there → heap-corruption SEGV. `jitTrampoline` clobber-lists this set
 /// so ITS prologue/epilogue saves & restores the cohort around the call,
-/// masking the JIT's clobber. Two claims that used to sit here are false and
-/// are tracked separately: the JIT does not preserve win64 XMM6-15 (no XMM
-/// save exists in `x86_64/prologue.zig`), and the x86_64 arm is NOT identical
-/// across the two ABIs — `win64.allocatable_gprs` also holds RDI and RSI,
-/// neither of which this list names. The SysV/AAPCS64 FP cohort being
-/// caller-saved does hold.
+/// masking the JIT's clobber. Two exposures this list does not cover: Win64
+/// XMM6-15 are non-volatile and the JIT saves none of them (#286), and
+/// `win64.allocatable_gprs` also holds RDI and RSI, which this list omits
+/// (#287). The SysV/AAPCS64 FP cohort is caller-saved, so it needs nothing
+/// here.
 pub const jit_cohort_clobbers: if (builtin.target.cpu.arch == .aarch64 or builtin.target.cpu.arch == .x86_64) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .aarch64) .{
         .x19 = true,
@@ -286,35 +285,18 @@ inline fn invokeAndCheckVoid(
             \\ ldp x27, x28, [sp, #64]
             \\ ldp x19, x20, [sp], #80
             :
-            // x0 is not an operand of this asm.
-            //
-            // It used to be both: an input `"{x0}"` carrying the runtime and an
-            // output `"={x0}"` reading a result. The two are untied, so the
-            // allocator may materialise the output's def before the input's use —
-            // and under optimisation it did, leaving `blr` to enter the JIT body
-            // with x0 holding whatever the output slot had been given rather than
-            // the runtime. The fault address was a small constant: a field offset
-            // read off that garbage. Debug allocated differently and never showed
-            // it.
-            //
-            // The runtime now arrives in x10 and is placed in x0 by the asm itself;
-            // results come back through x11/x12/x13. Every operand is pinned to a
-            // named register — `"r"` was free to pick x0, or to pick the register a
-            // neighbouring line had just written.
-            //
-            // Those registers are also in the clobber list. The note at the head
-            // of this file sanctions that overlap for OUTPUTS; the inputs here
-            // go beyond it. Both are consumed before the `blr`, so nothing the
-            // callee destroys is still needed — but this leans on LLVM
-            // tolerating a shape GCC rejects, not on the documented rule.
+            // rt arrives in x10 and is moved to x0 inside the asm, so x0 is not
+            // an operand of this block.
+            // Every operand is pinned to a named register: `"r"` is free to pick
+            // x0, or the register a neighbouring line has just written.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows and args.len == 0) {
-        // D-245 (x86_64 SysV): the JIT uses an all-callee-saved regalloc pool
-        // (RBX/R12-R15) and only the prologue's PUSH R15 is saved — R12-R14/RBX
-        // are clobbered without restore, so a plain `@call` lets ReleaseSafe's
-        // host lose its live values there → SEGV. Save/restore them around the
+        // D-245 (x86_64 SysV): the JIT's pool is RBX/R12-R14 and R15 is reserved
+        // for the runtime pointer the prologue installs. The epilogue restores
+        // none of them, so a plain `@call` lets ReleaseSafe's host lose its live
+        // values there → SEGV. Save/restore them around the
         // CALL (callee in RAX, rt in RDI). 5 pushes (40B) + sub $8 keep the
         // pre-CALL RSP 16-aligned (callee sees %16==8 per SysV), assuming the
         // inlined call site's incoming RSP is 16-aligned (as `@call` would need).
@@ -1413,38 +1395,23 @@ pub fn callI32f64NoArgs(
             \\ fmov x12, d0
             : [r0_out] "={x11}" (r0_raw),
               [r1_bits] "={x12}" (r1_raw),
-              // x0 is not an operand of this asm.
-              //
-              // It used to be both: an input `"{x0}"` carrying the runtime and an
-              // output `"={x0}"` reading a result. The two are untied, so the
-              // allocator may materialise the output's def before the input's use —
-              // and under optimisation it did, leaving `blr` to enter the JIT body
-              // with x0 holding whatever the output slot had been given rather than
-              // the runtime. The fault address was a small constant: a field offset
-              // read off that garbage. Debug allocated differently and never showed
-              // it.
-              //
-              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
-              // results come back through x11/x12/x13. Every operand is pinned to a
-              // named register — `"r"` was free to pick x0, or to pick the register a
-              // neighbouring line had just written.
-              //
-              // Those registers are also in the clobber list. The note at the head
-              // of this file sanctions that overlap for OUTPUTS; the inputs here go
-              // beyond it. Both are consumed before the `blr`, so nothing the callee
-              // destroys is still needed — but this leans on LLVM tolerating a shape
-              // GCC rejects, not on the documented rule.
+              // rt arrives in x10 and is moved to x0 inside the asm, so x0 is not
+              // an operand of this block.
+              // Results are pinned to x11/x12/x13.
+              // Every operand is pinned to a named register: `"r"` is free to pick
+              // x0, or the register a neighbouring line has just written.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = r0_raw, .r1 = @bitCast(r1_raw) };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows) {
-        // The JIT allocates from RBX/R12-R15 and its prologue saves only R15,
-        // so a plain Zig call lets an optimised host lose whatever it had live
-        // in the other four — the same defect D-245 fixed for the void path,
-        // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
-        // that exercises these shapes faulted before this bracket existed.
+        // The JIT's pool is RBX/R12-R14 (`x86_64/abi.zig`); R15 is reserved as
+        // the runtime pointer, which the prologue overwrites. Its epilogue
+        // restores none of them, so a plain Zig call lets an optimised host lose
+        // whatever it had live in all five — the D-245 defect class. Measured on
+        // x86_64-linux at ReleaseSafe: the corpus that exercises these shapes
+        // faulted without this bracket.
         // rt in RDI; the callee register is left to the allocator, which is
         // safe here because `push` does not destroy it. 5 pushes + `sub $8`
         // keep the pre-CALL RSP 16-aligned the way SysV wants it.
@@ -1474,8 +1441,11 @@ pub fn callI32f64NoArgs(
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = r0_raw, .r1 = r1_raw };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) {
-        // Win64 (D-161): rt in RCX, 32 B shadow + 8 B alignment via
-        // `sub $40`, CALL, capture RAX (i32) + XMM0 (f64).
+        // Win64 (D-161): rt in RCX, CALL, capture RAX (i32) + XMM0 (f64).
+        // `sub $40` reserves the 32 B shadow space contiguously at rsp+0..31
+        // — the pushes precede it, so they do not split it. Alignment: 7
+        // pushes (56 B) + 40 = 96 ≡ 0 mod 16, so the incoming parity is
+        // preserved and the pre-CALL RSP stays where the ABI wants it.
         const Fn = *const fn (rt: *const JitRuntime) callconv(.c) void;
         const f = module.entry(func_idx, Fn);
         var r0_raw: u64 = undefined;
@@ -1547,38 +1517,23 @@ pub fn callF64i32NoArgs(
             \\ fmov x12, d0
             : [r0_bits] "={x12}" (r0_raw),
               [r1_out] "={x11}" (r1_raw),
-              // x0 is not an operand of this asm.
-              //
-              // It used to be both: an input `"{x0}"` carrying the runtime and an
-              // output `"={x0}"` reading a result. The two are untied, so the
-              // allocator may materialise the output's def before the input's use —
-              // and under optimisation it did, leaving `blr` to enter the JIT body
-              // with x0 holding whatever the output slot had been given rather than
-              // the runtime. The fault address was a small constant: a field offset
-              // read off that garbage. Debug allocated differently and never showed
-              // it.
-              //
-              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
-              // results come back through x11/x12/x13. Every operand is pinned to a
-              // named register — `"r"` was free to pick x0, or to pick the register a
-              // neighbouring line had just written.
-              //
-              // Those registers are also in the clobber list. The note at the head
-              // of this file sanctions that overlap for OUTPUTS; the inputs here go
-              // beyond it. Both are consumed before the `blr`, so nothing the callee
-              // destroys is still needed — but this leans on LLVM tolerating a shape
-              // GCC rejects, not on the documented rule.
+              // rt arrives in x10 and is moved to x0 inside the asm, so x0 is not
+              // an operand of this block.
+              // Results are pinned to x11/x12/x13.
+              // Every operand is pinned to a named register: `"r"` is free to pick
+              // x0, or the register a neighbouring line has just written.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = @bitCast(r0_raw), .r1 = r1_raw };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows) {
-        // The JIT allocates from RBX/R12-R15 and its prologue saves only R15,
-        // so a plain Zig call lets an optimised host lose whatever it had live
-        // in the other four — the same defect D-245 fixed for the void path,
-        // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
-        // that exercises these shapes faulted before this bracket existed.
+        // The JIT's pool is RBX/R12-R14 (`x86_64/abi.zig`); R15 is reserved as
+        // the runtime pointer, which the prologue overwrites. Its epilogue
+        // restores none of them, so a plain Zig call lets an optimised host lose
+        // whatever it had live in all five — the D-245 defect class. Measured on
+        // x86_64-linux at ReleaseSafe: the corpus that exercises these shapes
+        // faulted without this bracket.
         // rt in RDI; the callee register is left to the allocator, which is
         // safe here because `push` does not destroy it. 5 pushes + `sub $8`
         // keep the pre-CALL RSP 16-aligned the way SysV wants it.
@@ -1689,27 +1644,11 @@ pub fn callF64f32NoArgs(
             \\ ldp x19, x20, [sp], #80
             : [r0_bits] "={x12}" (r0_raw),
               [r1_bits] "={x13}" (r1_raw),
-              // x0 is not an operand of this asm.
-              //
-              // It used to be both: an input `"{x0}"` carrying the runtime and an
-              // output `"={x0}"` reading a result. The two are untied, so the
-              // allocator may materialise the output's def before the input's use —
-              // and under optimisation it did, leaving `blr` to enter the JIT body
-              // with x0 holding whatever the output slot had been given rather than
-              // the runtime. The fault address was a small constant: a field offset
-              // read off that garbage. Debug allocated differently and never showed
-              // it.
-              //
-              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
-              // results come back through x11/x12/x13. Every operand is pinned to a
-              // named register — `"r"` was free to pick x0, or to pick the register a
-              // neighbouring line had just written.
-              //
-              // Those registers are also in the clobber list. The note at the head
-              // of this file sanctions that overlap for OUTPUTS; the inputs here go
-              // beyond it. Both are consumed before the `blr`, so nothing the callee
-              // destroys is still needed — but this leans on LLVM tolerating a shape
-              // GCC rejects, not on the documented rule.
+              // rt arrives in x10 and is moved to x0 inside the asm, so x0 is not
+              // an operand of this block.
+              // Results are pinned to x11/x12/x13.
+              // Every operand is pinned to a named register: `"r"` is free to pick
+              // x0, or the register a neighbouring line has just written.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1721,8 +1660,8 @@ pub fn callF64f32NoArgs(
         const f = module.entry(func_idx, Fn);
         var r0_raw: f64 = undefined;
         var r1_raw: f32 = undefined;
-        // Same cohort save as the sibling SysV thunks — the JIT allocates from
-        // RBX/R12-R15 and restores only R15.
+        // Same cohort save as the sibling SysV thunks: pool RBX/R12-R14 plus the
+        // reserved runtime-pointer R15, none of them restored by the epilogue.
         asm volatile (
             \\ pushq %%rbx
             \\ pushq %%r12

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -271,6 +271,7 @@ inline fn invokeAndCheckVoid(
             \\ stp x23, x24, [sp, #32]
             \\ stp x25, x26, [sp, #48]
             \\ stp x27, x28, [sp, #64]
+            \\ mov x0, x10
             \\ blr %[callee]
             \\ ldp x21, x22, [sp, #16]
             \\ ldp x23, x24, [sp, #32]
@@ -278,8 +279,20 @@ inline fn invokeAndCheckVoid(
             \\ ldp x27, x28, [sp, #64]
             \\ ldp x19, x20, [sp], #80
             :
-            : [callee] "r" (f),
-              [rt_arg] "{x0}" (rt),
+            // Neither input asks for x0. These thunks return a 16-byte
+            // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
+            // caller's result buffer for the whole call, so it is not the
+            // compiler's to hand out. `"{x0}"` put a second claim on it; under
+            // optimisation the sret pointer won and the argument setup was
+            // dropped, so `blr` ran the JIT body with a result buffer where the
+            // runtime should be — a small constant fault address, a field
+            // offset read off a pointer that was never the runtime. Debug
+            // allocated differently and never showed it.
+            //
+            // x9 and x10 are both in the clobber list, so the callee is free to
+            // destroy them and the compiler keeps nothing live there.
+            : [callee] "{x9}" (f),
+              [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows and args.len == 0) {
         // D-245 (x86_64 SysV): the JIT uses an all-callee-saved regalloc pool
@@ -1368,12 +1381,36 @@ pub fn callI32f64NoArgs(
         var r0_raw: u64 = undefined;
         var r1_raw: u64 = undefined;
         asm volatile (
+            \\ stp x19, x20, [sp, #-80]!
+            \\ stp x21, x22, [sp, #16]
+            \\ stp x23, x24, [sp, #32]
+            \\ stp x25, x26, [sp, #48]
+            \\ stp x27, x28, [sp, #64]
+            \\ mov x0, x10
             \\ blr %[callee]
-            \\ fmov %[r1_bits], d0
-            : [r0_out] "={x0}" (r0_raw),
-              [r1_bits] "=r" (r1_raw),
-            : [callee] "r" (f),
-              [rt_arg] "{x0}" (rt),
+            \\ mov x11, x0
+            \\ ldp x21, x22, [sp, #16]
+            \\ ldp x23, x24, [sp, #32]
+            \\ ldp x25, x26, [sp, #48]
+            \\ ldp x27, x28, [sp, #64]
+            \\ ldp x19, x20, [sp], #80
+            \\ fmov x12, d0
+            : [r0_out] "={x11}" (r0_raw),
+              [r1_bits] "={x12}" (r1_raw),
+              // Neither input asks for x0. These thunks return a 16-byte
+              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
+              // caller's result buffer for the whole call, so it is not the
+              // compiler's to hand out. `"{x0}"` put a second claim on it; under
+              // optimisation the sret pointer won and the argument setup was
+              // dropped, so `blr` ran the JIT body with a result buffer where the
+              // runtime should be — a small constant fault address, a field
+              // offset read off a pointer that was never the runtime. Debug
+              // allocated differently and never showed it.
+              //
+              // x9 and x10 are both in the clobber list, so the callee is free to
+              // destroy them and the compiler keeps nothing live there.
+            : [callee] "{x9}" (f),
+              [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = r0_raw, .r1 = @bitCast(r1_raw) };
@@ -1427,12 +1464,36 @@ pub fn callF64i32NoArgs(
         var r0_raw: u64 = undefined;
         var r1_raw: u64 = undefined;
         asm volatile (
+            \\ stp x19, x20, [sp, #-80]!
+            \\ stp x21, x22, [sp, #16]
+            \\ stp x23, x24, [sp, #32]
+            \\ stp x25, x26, [sp, #48]
+            \\ stp x27, x28, [sp, #64]
+            \\ mov x0, x10
             \\ blr %[callee]
-            \\ fmov %[r0_bits], d0
-            : [r0_bits] "=r" (r0_raw),
-              [r1_out] "={x0}" (r1_raw),
-            : [callee] "r" (f),
-              [rt_arg] "{x0}" (rt),
+            \\ mov x11, x0
+            \\ ldp x21, x22, [sp, #16]
+            \\ ldp x23, x24, [sp, #32]
+            \\ ldp x25, x26, [sp, #48]
+            \\ ldp x27, x28, [sp, #64]
+            \\ ldp x19, x20, [sp], #80
+            \\ fmov x12, d0
+            : [r0_bits] "={x12}" (r0_raw),
+              [r1_out] "={x11}" (r1_raw),
+              // Neither input asks for x0. These thunks return a 16-byte
+              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
+              // caller's result buffer for the whole call, so it is not the
+              // compiler's to hand out. `"{x0}"` put a second claim on it; under
+              // optimisation the sret pointer won and the argument setup was
+              // dropped, so `blr` ran the JIT body with a result buffer where the
+              // runtime should be — a small constant fault address, a field
+              // offset read off a pointer that was never the runtime. Debug
+              // allocated differently and never showed it.
+              //
+              // x9 and x10 are both in the clobber list, so the callee is free to
+              // destroy them and the compiler keeps nothing live there.
+            : [callee] "{x9}" (f),
+              [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = @bitCast(r0_raw), .r1 = r1_raw };
@@ -1494,13 +1555,36 @@ pub fn callF64f32NoArgs(
         var r0_raw: u64 = undefined;
         var r1_raw: u64 = undefined;
         asm volatile (
+            \\ stp x19, x20, [sp, #-80]!
+            \\ stp x21, x22, [sp, #16]
+            \\ stp x23, x24, [sp, #32]
+            \\ stp x25, x26, [sp, #48]
+            \\ stp x27, x28, [sp, #64]
+            \\ mov x0, x10
             \\ blr %[callee]
-            \\ fmov %[r0_bits], d0
-            \\ fmov %[r1_bits], d1
-            : [r0_bits] "=r" (r0_raw),
-              [r1_bits] "=r" (r1_raw),
-            : [callee] "r" (f),
-              [rt_arg] "{x0}" (rt),
+            \\ fmov x12, d0
+            \\ fmov x13, d1
+            \\ ldp x21, x22, [sp, #16]
+            \\ ldp x23, x24, [sp, #32]
+            \\ ldp x25, x26, [sp, #48]
+            \\ ldp x27, x28, [sp, #64]
+            \\ ldp x19, x20, [sp], #80
+            : [r0_bits] "={x12}" (r0_raw),
+              [r1_bits] "={x13}" (r1_raw),
+              // Neither input asks for x0. These thunks return a 16-byte
+              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
+              // caller's result buffer for the whole call, so it is not the
+              // compiler's to hand out. `"{x0}"` put a second claim on it; under
+              // optimisation the sret pointer won and the argument setup was
+              // dropped, so `blr` ran the JIT body with a result buffer where the
+              // runtime should be — a small constant fault address, a field
+              // offset read off a pointer that was never the runtime. Debug
+              // allocated differently and never showed it.
+              //
+              // x9 and x10 are both in the clobber list, so the callee is free to
+              // destroy them and the compiler keeps nothing live there.
+            : [callee] "{x9}" (f),
+              [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
         const r1_f32: f32 = @bitCast(@as(u32, @truncate(r1_raw)));

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -279,18 +279,25 @@ inline fn invokeAndCheckVoid(
             \\ ldp x27, x28, [sp, #64]
             \\ ldp x19, x20, [sp], #80
             :
-            // Neither input asks for x0. These thunks return a 16-byte
-            // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
-            // caller's result buffer for the whole call, so it is not the
-            // compiler's to hand out. `"{x0}"` put a second claim on it; under
-            // optimisation the sret pointer won and the argument setup was
-            // dropped, so `blr` ran the JIT body with a result buffer where the
-            // runtime should be — a small constant fault address, a field
-            // offset read off a pointer that was never the runtime. Debug
-            // allocated differently and never showed it.
+            // x0 is not an operand of this asm.
             //
-            // x9 and x10 are both in the clobber list, so the callee is free to
-            // destroy them and the compiler keeps nothing live there.
+            // It used to be both: an input `"{x0}"` carrying the runtime and an
+            // output `"={x0}"` reading a result. The two are untied, so the
+            // allocator may materialise the output's def before the input's use —
+            // and under optimisation it did, leaving `blr` to enter the JIT body
+            // with x0 holding whatever the output slot had been given rather than
+            // the runtime. The fault address was a small constant: a field offset
+            // read off that garbage. Debug allocated differently and never showed
+            // it.
+            //
+            // The runtime now arrives in x10 and is placed in x0 by the asm itself;
+            // results come back through x11/x12/x13. Every operand is pinned to a
+            // named register — `"r"` was free to pick x0, or to pick the register a
+            // neighbouring line had just written.
+            //
+            // Those registers are also in the clobber list. That overlap is the
+            // tolerance the note at the head of this file already records; it is not
+            // the reason this is correct.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1397,18 +1404,25 @@ pub fn callI32f64NoArgs(
             \\ fmov x12, d0
             : [r0_out] "={x11}" (r0_raw),
               [r1_bits] "={x12}" (r1_raw),
-              // Neither input asks for x0. These thunks return a 16-byte
-              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
-              // caller's result buffer for the whole call, so it is not the
-              // compiler's to hand out. `"{x0}"` put a second claim on it; under
-              // optimisation the sret pointer won and the argument setup was
-              // dropped, so `blr` ran the JIT body with a result buffer where the
-              // runtime should be — a small constant fault address, a field
-              // offset read off a pointer that was never the runtime. Debug
-              // allocated differently and never showed it.
+              // x0 is not an operand of this asm.
               //
-              // x9 and x10 are both in the clobber list, so the callee is free to
-              // destroy them and the compiler keeps nothing live there.
+              // It used to be both: an input `"{x0}"` carrying the runtime and an
+              // output `"={x0}"` reading a result. The two are untied, so the
+              // allocator may materialise the output's def before the input's use —
+              // and under optimisation it did, leaving `blr` to enter the JIT body
+              // with x0 holding whatever the output slot had been given rather than
+              // the runtime. The fault address was a small constant: a field offset
+              // read off that garbage. Debug allocated differently and never showed
+              // it.
+              //
+              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
+              // results come back through x11/x12/x13. Every operand is pinned to a
+              // named register — `"r"` was free to pick x0, or to pick the register a
+              // neighbouring line had just written.
+              //
+              // Those registers are also in the clobber list. That overlap is the
+              // tolerance the note at the head of this file already records; it is not
+              // the reason this is correct.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1480,18 +1494,25 @@ pub fn callF64i32NoArgs(
             \\ fmov x12, d0
             : [r0_bits] "={x12}" (r0_raw),
               [r1_out] "={x11}" (r1_raw),
-              // Neither input asks for x0. These thunks return a 16-byte
-              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
-              // caller's result buffer for the whole call, so it is not the
-              // compiler's to hand out. `"{x0}"` put a second claim on it; under
-              // optimisation the sret pointer won and the argument setup was
-              // dropped, so `blr` ran the JIT body with a result buffer where the
-              // runtime should be — a small constant fault address, a field
-              // offset read off a pointer that was never the runtime. Debug
-              // allocated differently and never showed it.
+              // x0 is not an operand of this asm.
               //
-              // x9 and x10 are both in the clobber list, so the callee is free to
-              // destroy them and the compiler keeps nothing live there.
+              // It used to be both: an input `"{x0}"` carrying the runtime and an
+              // output `"={x0}"` reading a result. The two are untied, so the
+              // allocator may materialise the output's def before the input's use —
+              // and under optimisation it did, leaving `blr` to enter the JIT body
+              // with x0 holding whatever the output slot had been given rather than
+              // the runtime. The fault address was a small constant: a field offset
+              // read off that garbage. Debug allocated differently and never showed
+              // it.
+              //
+              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
+              // results come back through x11/x12/x13. Every operand is pinned to a
+              // named register — `"r"` was free to pick x0, or to pick the register a
+              // neighbouring line had just written.
+              //
+              // Those registers are also in the clobber list. That overlap is the
+              // tolerance the note at the head of this file already records; it is not
+              // the reason this is correct.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1571,18 +1592,25 @@ pub fn callF64f32NoArgs(
             \\ ldp x19, x20, [sp], #80
             : [r0_bits] "={x12}" (r0_raw),
               [r1_bits] "={x13}" (r1_raw),
-              // Neither input asks for x0. These thunks return a 16-byte
-              // `FuncRet_*`, and AAPCS64 returns that indirectly: x0 carries the
-              // caller's result buffer for the whole call, so it is not the
-              // compiler's to hand out. `"{x0}"` put a second claim on it; under
-              // optimisation the sret pointer won and the argument setup was
-              // dropped, so `blr` ran the JIT body with a result buffer where the
-              // runtime should be — a small constant fault address, a field
-              // offset read off a pointer that was never the runtime. Debug
-              // allocated differently and never showed it.
+              // x0 is not an operand of this asm.
               //
-              // x9 and x10 are both in the clobber list, so the callee is free to
-              // destroy them and the compiler keeps nothing live there.
+              // It used to be both: an input `"{x0}"` carrying the runtime and an
+              // output `"={x0}"` reading a result. The two are untied, so the
+              // allocator may materialise the output's def before the input's use —
+              // and under optimisation it did, leaving `blr` to enter the JIT body
+              // with x0 holding whatever the output slot had been given rather than
+              // the runtime. The fault address was a small constant: a field offset
+              // read off that garbage. Debug allocated differently and never showed
+              // it.
+              //
+              // The runtime now arrives in x10 and is placed in x0 by the asm itself;
+              // results come back through x11/x12/x13. Every operand is pinned to a
+              // named register — `"r"` was free to pick x0, or to pick the register a
+              // neighbouring line had just written.
+              //
+              // Those registers are also in the clobber list. That overlap is the
+              // tolerance the note at the head of this file already records; it is not
+              // the reason this is correct.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -116,8 +116,12 @@ const x86_64_sysv_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and buil
 /// via hidden RCX pointer when > 8 bytes). The thunk performs the
 /// CALL in inline-asm, passes rt in RCX (Win64 first int arg), and
 /// captures the result registers directly. Lists every Win64
-/// caller-saved (volatile) GPR + XMM0–XMM5 (XMM6–XMM15 are
-/// non-volatile under Win64 and the JIT prologue preserves them).
+/// caller-saved (volatile) GPR + XMM0–XMM5. XMM6–XMM15 are non-volatile
+/// under Win64 and the JIT does NOT preserve them: its pool takes xmm8-xmm13
+/// with xmm14/xmm15 as the spill stage (`x86_64/abi.zig`), and
+/// `x86_64/prologue.zig` emits no XMM save at all. Tracked separately; listing
+/// them here would only tell the compiler they are destroyed, which is true
+/// but does not restore a host value the guest already overwrote.
 const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) .{
         .rax = true,
@@ -145,9 +149,12 @@ const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and bui
 /// host→JIT `@call` lets ReleaseSafe's optimized host lose any live value it
 /// kept there → heap-corruption SEGV. `jitTrampoline` clobber-lists this set
 /// so ITS prologue/epilogue saves & restores the cohort around the call,
-/// masking the JIT's clobber. XMM/FP is omitted — the JIT already preserves
-/// win64 XMM6-15, and the SysV/AAPCS64 FP cohort is caller-saved. The x86_64
-/// arm is identical for SysV and Windows (same JIT regalloc pool).
+/// masking the JIT's clobber. Two claims that used to sit here are false and
+/// are tracked separately: the JIT does not preserve win64 XMM6-15 (no XMM
+/// save exists in `x86_64/prologue.zig`), and the x86_64 arm is NOT identical
+/// across the two ABIs — `win64.allocatable_gprs` also holds RDI and RSI,
+/// neither of which this list names. The SysV/AAPCS64 FP cohort being
+/// caller-saved does hold.
 pub const jit_cohort_clobbers: if (builtin.target.cpu.arch == .aarch64 or builtin.target.cpu.arch == .x86_64) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .aarch64) .{
         .x19 = true,
@@ -295,9 +302,11 @@ inline fn invokeAndCheckVoid(
             // named register — `"r"` was free to pick x0, or to pick the register a
             // neighbouring line had just written.
             //
-            // Those registers are also in the clobber list. That overlap is the
-            // tolerance the note at the head of this file already records; it is not
-            // the reason this is correct.
+            // Those registers are also in the clobber list. The note at the head
+            // of this file sanctions that overlap for OUTPUTS; the inputs here
+            // go beyond it. Both are consumed before the `blr`, so nothing the
+            // callee destroys is still needed — but this leans on LLVM
+            // tolerating a shape GCC rejects, not on the documented rule.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1420,9 +1429,11 @@ pub fn callI32f64NoArgs(
               // named register — `"r"` was free to pick x0, or to pick the register a
               // neighbouring line had just written.
               //
-              // Those registers are also in the clobber list. That overlap is the
-              // tolerance the note at the head of this file already records; it is not
-              // the reason this is correct.
+              // Those registers are also in the clobber list. The note at the head
+              // of this file sanctions that overlap for OUTPUTS; the inputs here go
+              // beyond it. Both are consumed before the `blr`, so nothing the callee
+              // destroys is still needed — but this leans on LLVM tolerating a shape
+              // GCC rejects, not on the documented rule.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1434,8 +1445,9 @@ pub fn callI32f64NoArgs(
         // in the other four — the same defect D-245 fixed for the void path,
         // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
         // that exercises these shapes faulted before this bracket existed.
-        // Callee in RAX, rt in RDI; 5 pushes + `sub $8` keep the pre-CALL RSP
-        // 16-aligned the way SysV wants it.
+        // rt in RDI; the callee register is left to the allocator, which is
+        // safe here because `push` does not destroy it. 5 pushes + `sub $8`
+        // keep the pre-CALL RSP 16-aligned the way SysV wants it.
         const Fn = *const fn (rt: *const JitRuntime) callconv(.c) void;
         const f = module.entry(func_idx, Fn);
         var r0_raw: u64 = undefined;
@@ -1551,9 +1563,11 @@ pub fn callF64i32NoArgs(
               // named register — `"r"` was free to pick x0, or to pick the register a
               // neighbouring line had just written.
               //
-              // Those registers are also in the clobber list. That overlap is the
-              // tolerance the note at the head of this file already records; it is not
-              // the reason this is correct.
+              // Those registers are also in the clobber list. The note at the head
+              // of this file sanctions that overlap for OUTPUTS; the inputs here go
+              // beyond it. Both are consumed before the `blr`, so nothing the callee
+              // destroys is still needed — but this leans on LLVM tolerating a shape
+              // GCC rejects, not on the documented rule.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);
@@ -1565,8 +1579,9 @@ pub fn callF64i32NoArgs(
         // in the other four — the same defect D-245 fixed for the void path,
         // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
         // that exercises these shapes faulted before this bracket existed.
-        // Callee in RAX, rt in RDI; 5 pushes + `sub $8` keep the pre-CALL RSP
-        // 16-aligned the way SysV wants it.
+        // rt in RDI; the callee register is left to the allocator, which is
+        // safe here because `push` does not destroy it. 5 pushes + `sub $8`
+        // keep the pre-CALL RSP 16-aligned the way SysV wants it.
         const Fn = *const fn (rt: *const JitRuntime) callconv(.c) void;
         const f = module.entry(func_idx, Fn);
         var r0_raw: f64 = undefined;
@@ -1690,9 +1705,11 @@ pub fn callF64f32NoArgs(
               // named register — `"r"` was free to pick x0, or to pick the register a
               // neighbouring line had just written.
               //
-              // Those registers are also in the clobber list. That overlap is the
-              // tolerance the note at the head of this file already records; it is not
-              // the reason this is correct.
+              // Those registers are also in the clobber list. The note at the head
+              // of this file sanctions that overlap for OUTPUTS; the inputs here go
+              // beyond it. Both are consumed before the `blr`, so nothing the callee
+              // destroys is still needed — but this leans on LLVM tolerating a shape
+              // GCC rejects, not on the documented rule.
             : [callee] "{x9}" (f),
               [rt_arg] "{x10}" (rt),
             : aarch64_blr_clobbers);

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -1,4 +1,4 @@
-// FILE-SIZE-EXEMPT: uniform-pattern catalog (127 callXX_yy per-shape entry helpers; monotonic growth with Wasm signature shapes — +8 D-467 multi-scalar→v128 + 2 D-467 load/store-lane (i32,v128)→v128/i64) (cap=3200) (per ADR-0063 + ADR-0099 Revision 2026-05-24)
+// FILE-SIZE-EXEMPT: uniform-pattern catalog (127 callXX_yy per-shape entry helpers; monotonic growth with Wasm signature shapes — +8 D-467 multi-scalar→v128 + 2 D-467 load/store-lane (i32,v128)→v128/i64; 2026-08-25 +110 for the host→JIT register-cohort save that every mixed multi-result thunk was missing on all three targets — the sequence is pasted per call site because Zig inline asm takes a single string and folding it into shared constants was tried and reverted as more fragile than the duplication) (cap=3450) (per ADR-0063 + ADR-0099 Revision 2026-05-24)
 // Comptime generation is a follow-up; see ADR-0063 Alternative B + debt ledger.
 
 //! JIT entry frame (ADR-0017).
@@ -1429,11 +1429,38 @@ pub fn callI32f64NoArgs(
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = r0_raw, .r1 = @bitCast(r1_raw) };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows) {
-        const Fn = *const fn (rt: *const JitRuntime) callconv(.c) FuncRet_i32f64;
+        // The JIT allocates from RBX/R12-R15 and its prologue saves only R15,
+        // so a plain Zig call lets an optimised host lose whatever it had live
+        // in the other four — the same defect D-245 fixed for the void path,
+        // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
+        // that exercises these shapes faulted before this bracket existed.
+        // Callee in RAX, rt in RDI; 5 pushes + `sub $8` keep the pre-CALL RSP
+        // 16-aligned the way SysV wants it.
+        const Fn = *const fn (rt: *const JitRuntime) callconv(.c) void;
         const f = module.entry(func_idx, Fn);
-        const result = f(rt);
+        var r0_raw: u64 = undefined;
+        var r1_raw: f64 = undefined;
+        asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
+            \\ subq $8, %%rsp
+            \\ callq *%[callee]
+            \\ addq $8, %%rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rbx
+            : [r0_out] "={rax}" (r0_raw),
+              [r1_out] "={xmm0}" (r1_raw),
+            : [callee] "r" (f),
+              [rt_arg] "{rdi}" (rt),
+            : x86_64_sysv_call_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
-        return result;
+        return .{ .r0 = r0_raw, .r1 = r1_raw };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) {
         // Win64 (D-161): rt in RCX, 32 B shadow + 8 B alignment via
         // `sub $40`, CALL, capture RAX (i32) + XMM0 (f64).
@@ -1442,9 +1469,23 @@ pub fn callI32f64NoArgs(
         var r0_raw: u64 = undefined;
         var r1_raw: f64 = undefined;
         asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%rsi
+            \\ pushq %%rdi
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
             \\ subq $40, %rsp
             \\ callq *%[callee]
             \\ addq $40, %rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rdi
+            \\ popq %%rsi
+            \\ popq %%rbx
             : [r0_out] "={rax}" (r0_raw),
               [r1_out] "={xmm0}" (r1_raw),
             : [callee] "r" (f),
@@ -1519,11 +1560,38 @@ pub fn callF64i32NoArgs(
         if (rt.trap_flag != 0) return Error.Trap;
         return .{ .r0 = @bitCast(r0_raw), .r1 = r1_raw };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag != .windows) {
-        const Fn = *const fn (rt: *const JitRuntime) callconv(.c) FuncRet_f64i32;
+        // The JIT allocates from RBX/R12-R15 and its prologue saves only R15,
+        // so a plain Zig call lets an optimised host lose whatever it had live
+        // in the other four — the same defect D-245 fixed for the void path,
+        // still open here. Measured on x86_64-linux at ReleaseSafe: the corpus
+        // that exercises these shapes faulted before this bracket existed.
+        // Callee in RAX, rt in RDI; 5 pushes + `sub $8` keep the pre-CALL RSP
+        // 16-aligned the way SysV wants it.
+        const Fn = *const fn (rt: *const JitRuntime) callconv(.c) void;
         const f = module.entry(func_idx, Fn);
-        const result = f(rt);
+        var r0_raw: f64 = undefined;
+        var r1_raw: u64 = undefined;
+        asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
+            \\ subq $8, %%rsp
+            \\ callq *%[callee]
+            \\ addq $8, %%rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rbx
+            : [r0_out] "={xmm0}" (r0_raw),
+              [r1_out] "={rax}" (r1_raw),
+            : [callee] "r" (f),
+              [rt_arg] "{rdi}" (rt),
+            : x86_64_sysv_call_clobbers);
         if (rt.trap_flag != 0) return Error.Trap;
-        return result;
+        return .{ .r0 = r0_raw, .r1 = r1_raw };
     } else if (comptime builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) {
         // Win64 (D-161): same shadow-space pattern as
         // `callI32f64NoArgs`; capture XMM0 (f64) + RAX (i32).
@@ -1532,9 +1600,23 @@ pub fn callF64i32NoArgs(
         var r0_raw: f64 = undefined;
         var r1_raw: u64 = undefined;
         asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%rsi
+            \\ pushq %%rdi
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
             \\ subq $40, %rsp
             \\ callq *%[callee]
             \\ addq $40, %rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rdi
+            \\ popq %%rsi
+            \\ popq %%rbx
             : [r0_out] "={xmm0}" (r0_raw),
               [r1_out] "={rax}" (r1_raw),
             : [callee] "r" (f),
@@ -1622,8 +1704,22 @@ pub fn callF64f32NoArgs(
         const f = module.entry(func_idx, Fn);
         var r0_raw: f64 = undefined;
         var r1_raw: f32 = undefined;
+        // Same cohort save as the sibling SysV thunks — the JIT allocates from
+        // RBX/R12-R15 and restores only R15.
         asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
+            \\ subq $8, %%rsp
             \\ callq *%[callee]
+            \\ addq $8, %%rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rbx
             : [r0_out] "={xmm0}" (r0_raw),
               [r1_out] "={xmm1}" (r1_raw),
             : [callee] "r" (f),
@@ -1639,9 +1735,23 @@ pub fn callF64f32NoArgs(
         var r0_raw: f64 = undefined;
         var r1_raw: f32 = undefined;
         asm volatile (
+            \\ pushq %%rbx
+            \\ pushq %%rsi
+            \\ pushq %%rdi
+            \\ pushq %%r12
+            \\ pushq %%r13
+            \\ pushq %%r14
+            \\ pushq %%r15
             \\ subq $40, %rsp
             \\ callq *%[callee]
             \\ addq $40, %rsp
+            \\ popq %%r15
+            \\ popq %%r14
+            \\ popq %%r13
+            \\ popq %%r12
+            \\ popq %%rdi
+            \\ popq %%rsi
+            \\ popq %%rbx
             : [r0_out] "={xmm0}" (r0_raw),
               [r1_out] "={xmm1}" (r1_raw),
             : [callee] "r" (f),


### PR DESCRIPTION
The host→JIT entry thunks for mixed multi-result functions fault in every
optimised build and pass in Debug. The JIT installs its pinned register cohort
from `rt` and its epilogue restores none of it, so a thunk that keeps a live
value in one of those registers across the call loses it. Debug simply
allocated elsewhere.

The fix brackets each call with a save and restore of that cohort, on all three
targets: X19-X28 on aarch64, RBX/R12-R14 plus the reserved runtime-pointer R15
on SysV, and those plus RDI/RSI on Win64.

The aarch64 arms also stop passing the runtime in x0. `x0` was an untied input
and output at once, so the allocator could materialise the output's definition
before the input's use — and under optimisation it did, entering the JIT body
with x0 holding the output slot rather than the runtime. The runtime now
arrives in x10 and is moved to x0 inside the asm; results are pinned to
x11/x12/x13.

## Alignment

Each arm keeps the incoming 16-byte parity: aarch64 `#-80`; SysV 5 pushes (40)
plus `sub $8` = 48; Win64 7 pushes (56) plus `sub $40` = 96. On Win64 the
pushes precede the `sub`, so the 32-byte shadow space stays contiguous at
`rsp+0..31`.

## Regression gate

`scripts/check_jit_releasesafe.sh` gains a third leg that runs the real runner
over the mixed multi-result shapes at ReleaseSafe. Verified as a guard by
reverting the fix and watching it go red.

One caveat worth stating plainly: that script sits in the `ZWASM_CI_EXTENDED`
leg, which fires on the push to `main` and not on a pull request. So this
defect class still reaches the trunk before a lane reports it — the same gap
that let the original ship. The cost of a cold ReleaseSafe build is the reason,
and the script header now says so.

## Not in scope

Two further exposures on the same surface, each with its own issue: Win64
XMM6-XMM15 are non-volatile and the JIT saves none of them (#286), and
`win64.allocatable_gprs` holds RDI/RSI which `jit_cohort_clobbers` omits
(#287).

## Verification

`zig build test-all` green. `scripts/check_jit_releasesafe.sh` green on all
three legs, including the new one.

Resolves: https://github.com/zwasm/zwasm/issues/289
