### PR TITLE
docs: paths in tracked files name no operating-system account

### DIFF
--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -435,8 +435,8 @@ Windows Error Reporting auto-drops a `.dmp` file to
 
 ```bash
 ssh windowsmini "bash -lc '
-  ls -la /c/Users/shota/AppData/Local/CrashDumps/
-  lldb -c /c/Users/shota/AppData/Local/CrashDumps/zwasm-spec-runner.exe.<pid>.dmp \
+  ls -la ~/AppData/Local/CrashDumps/
+  lldb -c ~/AppData/Local/CrashDumps/zwasm-spec-runner.exe.<pid>.dmp \
     -o \"thread backtrace all\" \
     -o \"register read\" \
     -o \"quit\"

--- a/.dev/archive/phase9/phase9_13_0_close_plan.md
+++ b/.dev/archive/phase9/phase9_13_0_close_plan.md
@@ -36,7 +36,7 @@ the same install path).
 
 ```sh
 ssh windowsmini "powershell -NoLogo -NoProfile -ExecutionPolicy Bypass \
-    -File C:\\Users\\shota\\Documents\\MyProducts\\zwasm_from_scratch\\scripts\\windows\\install_tools.ps1"
+    -File %USERPROFILE%\\Documents\\MyProducts\\zwasm_from_scratch\\scripts\\windows\\install_tools.ps1"
 ```
 
 The PS1 is idempotent — tools already at the pinned version

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -682,9 +682,15 @@ entries:
           align the runbook to the env vars, and note the reference clones are
           absent even locally (spec re-vendor is maintainer-only; the baked corpora
           under test/spec/ ship in the clone).
-      (8) OPEN — [cleanup] `scripts/win64_debug/attach_dump.sh` +
-          `.claude/skills/debug_jit_auto/RECIPES.md` hardcode literal
-          `Documents/MyProducts/zwasm` / `/c/Users/shota/…` with no override.
+      (8) FIXED 2026-08-25 — [cleanup] no tracked file names a maintainer
+          account any more. `RECIPES.md`'s crash-dump recipe reads
+          `~/AppData/Local/CrashDumps`, and the same sweep reached
+          ADR-0105, the SIGSEGV-flake lesson, `orbstack_setup.md` and the
+          archived phase-9 close plan. The half of this row naming
+          `attach_dump.sh` was stale: it takes `ZWASM_REMOTE_DIR` and
+          `ZWASM_WINDOWS_HOST`, and hardcodes no path. Home-relative
+          `~/Documents/MyProducts/…` remains throughout, which is the
+          working-dir convention CLAUDE.md sets and carries no account name.
       WORKS (fair): Zig 0.16.0 pinned coherently (flake.nix / versions.lock /
       README); the build needs exactly one tool beyond Zig (wasm-tools, pinned);
       committed spec corpus + realworld fixtures run with NO external clone; git

--- a/.dev/decisions/0105_jit_prologue_stack_probe.md
+++ b/.dev/decisions/0105_jit_prologue_stack_probe.md
@@ -44,8 +44,8 @@ testsuite) established:
      `error.StackOverflow` (from the trap stub) to clean spec-
      compliant `Trap`.
    - v1's `guard.zig` Windows handler only filters
-     `EXCEPTION_ACCESS_VIOLATION` (`/Users/shota.508/Documents/
-     MyProducts/zwasm/src/guard.zig:289-309`); hardware
+     `EXCEPTION_ACCESS_VIOLATION` (`src/guard.zig:289-309` at tag
+     `v1.11.1`); hardware
      EXCEPTION_STACK_OVERFLOW path is **bypassed by design**.
 
 2. **wasmtime uses path (b)**:

--- a/.dev/lessons/2026-05-16-zig-sigsegv-recovery-flake.md
+++ b/.dev/lessons/2026-05-16-zig-sigsegv-recovery-flake.md
@@ -138,10 +138,10 @@ no such change has landed.
 
 ```sh
 orb run -m my-ubuntu-amd64 bash -c '
-  cd /Users/shota.508/Documents/MyProducts/zwasm_from_scratch
+  cd ~/Documents/MyProducts/zwasm_from_scratch
   zig build test-spec-wasm-2.0-assert
   BIN=$(find .zig-cache -name "zwasm-spec-wasm-2-0-assert" -type f | head -1)
-  for i in 1 2 3 4 5; do "$BIN" /Users/shota.508/Documents/MyProducts/zwasm_from_scratch/test/spec/wasm-2.0-assert > /dev/null; echo "run $i exit=$?"; done
+  for i in 1 2 3 4 5; do "$BIN" ~/Documents/MyProducts/zwasm_from_scratch/test/spec/wasm-2.0-assert > /dev/null; echo "run $i exit=$?"; done
 '
 ```
 

--- a/.dev/orbstack_setup.md
+++ b/.dev/orbstack_setup.md
@@ -69,7 +69,7 @@ From Mac, in `zwasm_from_scratch/`:
 
 ```bash
 orb run -m my-ubuntu-amd64 bash -c '
-  cd /Users/shota.508/Documents/MyProducts/zwasm_from_scratch &&
+  cd ~/Documents/MyProducts/zwasm_from_scratch &&
   zig build &&
   zig build test
 '


### PR DESCRIPTION
Several tracked files spelled out an absolute path containing a maintainer's
operating-system account name — macOS and Windows both. They sat in a debug
recipe, an ADR citation, a lesson's repro block, the retired OrbStack setup
doc, and an archived phase plan.

None were load-bearing: each illustrates a command or cites a file, and reads
the same with the account elided. A command naming someone else's home
directory does not run for anyone else, so this is a reproducibility defect as
much as a hygiene one.

## Scope

Only the account-name occurrences. Home-relative `~/Documents/MyProducts/…`
stays throughout — it is the working-directory convention `.claude/CLAUDE.md`
sets, and it names no account.

The crash-dump recipe now reads `~/AppData/Local/CrashDumps`, which is also
what the prose two lines above it already said the location was.

## Debt row

`.dev/debt.yaml` row (8) under the reproducibility entry is discharged. The
half of it naming `scripts/win64_debug/attach_dump.sh` was stale: that script
takes `ZWASM_REMOTE_DIR` and `ZWASM_WINDOWS_HOST` and hardcodes no path.

Row (7), which covers `~/Documents/OSS/…` in the spec re-vendor runbook, is a
different concern and is untouched.

## Verification

Docs-only. `git grep` for either account name across tracked files returns
nothing.

Resolves: https://github.com/zwasm/zwasm/issues/293
