### PR TITLE
ci: the gate log reports each step's own wall time

### DIFF
--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -34,7 +34,13 @@ zig fmt --check bench/latency/
 zig fmt --check --exclude tools/lint/zig-pkg tools/
 
 echo "[ci_gate] (2/3) zig build test-all"
-zig build test-all
+# `--summary all` prints each step's own wall time (zig records
+# `result_duration_ns` and reports it in the summary tree). Without it a CI log
+# gives no step-level timing at all, and `test-all` is ~98% of the macOS leg —
+# so every question about where that leg's time goes had to be answered by
+# inferring from gaps between log lines, which produced a wrong answer twice.
+# Costs no runtime and ~200 lines on a ~58k-line log (measured 0.36%).
+zig build test-all --summary all
 
 # ADR-0209 — compile-only. `bench-latency` is a measurement and stays out of
 # test-all, but without SOMETHING building it, public-API drift would break the


### PR DESCRIPTION
One flag on `ci_gate.sh`'s `test-all` invocation, plus the comment saying why.

**What it buys.** Zig records `result_duration_ns` per step and prints it under
`--summary all`. Today a gate log has none of that, so the only way to ask
"where does the macOS leg's 30 minutes go" is to diff timestamps between
adjacent log lines — which measures when output was *flushed*, not when work
*happened*.

That inference has been wrong twice in the last three days:

- it read a silent window as a single ~795 s block;
- a later retraction, reading a summary from a since-deleted branch, claimed the
  slowest step in the whole run was 41 s. The same summary actually shows
  840 s / 480 s / 360 s, with 41 s at rank six.

Both readings drove decisions. The second one is currently recorded as a
correction in a private note; the first shipped as an estimate in an issue
comment that has been held back pending this flag.

**Cost.** No runtime cost — the flag changes reporting, not scheduling.
Measured on a real macOS gate log: the summary tree is ~206 lines against
~57,961, i.e. **0.36%**.

**Scope.** Only the `test-all` invocation, which is ~98% of the leg. The
extended-leg steps are left alone; if they ever need the same treatment it can
be a separate change.

### Verification

- `bash -n scripts/ci_gate.sh` passes.
- Ran `zig build test-all --summary all` locally and confirmed the three lanes
  this was added to measure now report their own durations:

```
+- run exe zwasm-realworld-diff-runner success 1m
+- run exe zwasm-aot-process-diff success 1m
+- run exe zwasm-realworld-run-jit-runner success 25s
```

- Diff is 7 added lines in one file, 6 of them comment.

Not verified here: the macOS numbers themselves. This PR's own core-gate run is
where they arrive — `ci_gate.sh` runs from the checked-out branch, so no merge
is needed to collect them.

They are worth collecting because the figures currently in circulation
(`aot_process_diff` 840 s, 54% of the leg) come from a `workflow_dispatch` run
of a since-deleted branch that had flipped that very step's stdio to `.check`,
so it did less I/O than the shipped form. Same gate class — both core, both
`--summary all` — but not the same step.
