### PR TITLE
fix(wasi): path_unlink_file aborts the host on a trailing slash (#310)

### DIFF
--- a/src/wasi/fd.zig
+++ b/src/wasi/fd.zig
@@ -1204,6 +1204,8 @@ pub fn pathUnlinkFile(host: *Host, mem: []u8, dirfd: p1.Fd, path_ptr: u32, path_
     const dir_handle = dir_slot.host_handle orelse return .notdir;
     const io = host.io orelse return .nosys;
     const dir: std.Io.Dir = .{ .handle = dir_handle };
+    const trailing = path_mod.unlinkTrailingSlashErrno(dir, io, path);
+    if (trailing != .success) return trailing;
     dir.deleteFile(io, path) catch |err| return mapOpenError(err);
     return .success;
 }

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -136,9 +136,12 @@ fn finalComponentIs(path: []const u8, which: DottedFinal) bool {
 /// issues, with STATUS_OBJECT_NAME_INVALID, which `std.Io` classifies as a
 /// programmer bug and panics on. So on Windows the errno is decided here.
 ///
-/// The classifying stat does NOT follow the final symlink, because `unlink`
-/// does not: a trailing slash on a symlink is ENOTDIR whatever the link points
-/// at, and ENOTDIR rather than ENOENT when it dangles.
+/// The classifying stat does NOT follow the final symlink. The two POSIX hosts
+/// disagree about a trailing slash over one — Linux does not follow it and
+/// answers ENOTDIR, macOS follows and answers EPERM, which maps to `isdir` —
+/// and the official corpus never unlinks a symlink with a trailing slash, so
+/// there is no host answer to match. Not following keeps the guard from
+/// resolving a link it is about to refuse.
 pub fn unlinkTrailingSlashErrno(dir: std.Io.Dir, io: std.Io, path: []const u8) p1.Errno {
     if (comptime builtin.os.tag != .windows) return .success;
     if (path.len == 0 or path[path.len - 1] != '/') return .success;
@@ -886,21 +889,23 @@ test "path_unlink_file: a trailing slash is the POSIX errno on every host, not a
         try testing.expectEqual(c.want, unlinkFile(&h, &mem, dirfd, 0, @intCast(c.p.len)));
     }
 
-    // A trailing slash does NOT follow the final symlink: the last component is
-    // a symlink, not a directory, so it is `notdir` even when the link points at
-    // one, and `notdir` rather than `noent` when it dangles. Measured on
-    // x86_64-linux; a guard that classifies with a following stat answers
-    // `isdir` and `noent` here instead. Skipped where the host denies
-    // unprivileged symlink creation — nothing above depends on these.
+    // A trailing slash over a symlink is the one shape the two POSIX hosts do not
+    // agree on: Linux does not follow the final link and answers `notdir`, macOS
+    // follows it and answers `isdir`. Both were measured, and the official corpus
+    // never unlinks a symlink with a trailing slash, so no single errno is
+    // pinnable — only the invariant is: the call fails, and the link survives.
+    // Skipped where the host denies unprivileged symlink creation; nothing above
+    // depends on these.
     if (root.symLink(testing.io, "d", "ld", .{})) |_| {
         try root.symLink(testing.io, "nowhere", "ln", .{});
-        for ([_]struct { p: []const u8, want: p1.Errno }{
-            .{ .p = "ld/", .want = .notdir },
-            .{ .p = "ln/", .want = .notdir },
-        }) |c| {
+        for ([_][]const u8{ "ld/", "ln/" }) |p| {
             @memset(mem[0..32], 0);
-            writeGuestPath(&mem, 0, c.p);
-            try testing.expectEqual(c.want, unlinkFile(&h, &mem, dirfd, 0, @intCast(c.p.len)));
+            writeGuestPath(&mem, 0, p);
+            try testing.expect(unlinkFile(&h, &mem, dirfd, 0, @intCast(p.len)) != .success);
+        }
+        for ([_][]const u8{ "ld", "ln" }) |link| {
+            _ = root.statFile(testing.io, link, .{ .follow_symlinks = false }) catch
+                return error.SymlinkWasUnlinked;
         }
     } else |_| {}
     // None of those deleted anything, and the same name without the trailing

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -129,15 +129,21 @@ fn finalComponentIs(path: []const u8, which: DottedFinal) bool {
 ///
 /// A trailing `/` means "this must resolve to a directory", so `unlink` on one
 /// is EISDIR and on anything else ENOTDIR — never a delete. Linux and macOS
-/// answer that themselves. NT does not: it rejects the trailing backslash on
-/// the non-directory open `deleteFile` issues, with STATUS_OBJECT_NAME_INVALID,
-/// which `std.Io` classifies as a programmer bug and panics on. So on Windows
-/// the errno is decided here and the host is never asked.
+/// answer that themselves and are left to: macOS returns EPERM for a directory,
+/// which `dirDeleteFilePosix` re-stats into `error.IsDir`, so neither host
+/// reaches the EINVAL arm that panics. NT does not answer it at all — it
+/// rejects the trailing backslash on the non-directory open `deleteFile`
+/// issues, with STATUS_OBJECT_NAME_INVALID, which `std.Io` classifies as a
+/// programmer bug and panics on. So on Windows the errno is decided here.
+///
+/// The classifying stat does NOT follow the final symlink, because `unlink`
+/// does not: a trailing slash on a symlink is ENOTDIR whatever the link points
+/// at, and ENOTDIR rather than ENOENT when it dangles.
 pub fn unlinkTrailingSlashErrno(dir: std.Io.Dir, io: std.Io, path: []const u8) p1.Errno {
     if (comptime builtin.os.tag != .windows) return .success;
     if (path.len == 0 or path[path.len - 1] != '/') return .success;
     const named = std.mem.trimEnd(u8, path, "/");
-    const st = dir.statFile(io, named, .{}) catch |err| return mapDirErr(err);
+    const st = dir.statFile(io, named, .{ .follow_symlinks = false }) catch |err| return mapDirErr(err);
     return if (st.kind == .directory) .isdir else .notdir;
 }
 
@@ -873,11 +879,30 @@ test "path_unlink_file: a trailing slash is the POSIX errno on every host, not a
         .{ .p = "d//", .want = .isdir },
         .{ .p = "f/", .want = .notdir },
         .{ .p = "./", .want = .isdir },
+        .{ .p = "gone/", .want = .noent },
     }) |c| {
         @memset(mem[0..32], 0);
         writeGuestPath(&mem, 0, c.p);
         try testing.expectEqual(c.want, unlinkFile(&h, &mem, dirfd, 0, @intCast(c.p.len)));
     }
+
+    // A trailing slash does NOT follow the final symlink: the last component is
+    // a symlink, not a directory, so it is `notdir` even when the link points at
+    // one, and `notdir` rather than `noent` when it dangles. Measured on
+    // x86_64-linux; a guard that classifies with a following stat answers
+    // `isdir` and `noent` here instead. Skipped where the host denies
+    // unprivileged symlink creation — nothing above depends on these.
+    if (root.symLink(testing.io, "d", "ld", .{})) |_| {
+        try root.symLink(testing.io, "nowhere", "ln", .{});
+        for ([_]struct { p: []const u8, want: p1.Errno }{
+            .{ .p = "ld/", .want = .notdir },
+            .{ .p = "ln/", .want = .notdir },
+        }) |c| {
+            @memset(mem[0..32], 0);
+            writeGuestPath(&mem, 0, c.p);
+            try testing.expectEqual(c.want, unlinkFile(&h, &mem, dirfd, 0, @intCast(c.p.len)));
+        }
+    } else |_| {}
     // None of those deleted anything, and the same name without the trailing
     // slash still does.
     @memset(mem[0..32], 0);

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -850,6 +850,10 @@ test "path_unlink_file: a trailing slash is the POSIX errno on every host, not a
     // same NT call with DIRECTORY_FILE set and does NOT abort, which is why
     // `path_remove_directory` needs no guard of this shape.
     //
+    // macOS is not the Windows case and is deliberately left to the host: its
+    // `unlink` answers EPERM for a trailing slash on a directory, which
+    // `dirDeleteFilePosix` re-stats into `error.IsDir`, and ENOTDIR otherwise.
+    //
     // As in the `#265` probe above, the load-bearing part is that the call
     // RETURNS at all: a host that panics takes its whole CI leg down.
     var tmp = std.testing.tmpDir(.{});

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -124,6 +124,23 @@ fn finalComponentIs(path: []const u8, which: DottedFinal) bool {
     return which == .dot_or_dotdot and std.mem.eql(u8, last, "..");
 }
 
+/// The errno POSIX gives `unlink` for a guest path written with a trailing
+/// separator, or `.success` when the call must reach the host unchanged.
+///
+/// A trailing `/` means "this must resolve to a directory", so `unlink` on one
+/// is EISDIR and on anything else ENOTDIR — never a delete. Linux and macOS
+/// answer that themselves. NT does not: it rejects the trailing backslash on
+/// the non-directory open `deleteFile` issues, with STATUS_OBJECT_NAME_INVALID,
+/// which `std.Io` classifies as a programmer bug and panics on. So on Windows
+/// the errno is decided here and the host is never asked.
+pub fn unlinkTrailingSlashErrno(dir: std.Io.Dir, io: std.Io, path: []const u8) p1.Errno {
+    if (comptime builtin.os.tag != .windows) return .success;
+    if (path.len == 0 or path[path.len - 1] != '/') return .success;
+    const named = std.mem.trimEnd(u8, path, "/");
+    const st = dir.statFile(io, named, .{}) catch |err| return mapDirErr(err);
+    return if (st.kind == .directory) .isdir else .notdir;
+}
+
 const Resolved = struct { dir: std.Io.Dir, sub: []const u8 };
 
 /// Resolve `(dirfd, path_ptr, path_len)` to a host `Dir` + bounded guest path,

--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -821,3 +821,45 @@ test "path_rename: a dotted final component is inval on every host (#265)" {
     writeGuestPath(&mem, 0, "a/../t2");
     try testing.expectEqual(p1.Errno.success, pathRename(&h, &mem, dirfd, 16, 1, dirfd, 0, 7));
 }
+
+test "path_unlink_file: a trailing slash is the POSIX errno on every host, not a host panic" {
+    // POSIX gives a trailing `/` the meaning "this path must resolve to a
+    // directory", so `unlink` on one is EISDIR, on anything else ENOTDIR, and
+    // never a delete. NT instead rejects the trailing backslash on the
+    // non-directory open `deleteFile` issues, with OBJECT_NAME_INVALID, which
+    // `std.Io` classifies as a programmer bug and panics on — so a guest with a
+    // preopen aborted the runtime with one `path_unlink_file("dir/", …)`, and
+    // the in-process official-corpus runner died with it. `deleteDir` takes the
+    // same NT call with DIRECTORY_FILE set and does NOT abort, which is why
+    // `path_remove_directory` needs no guard of this shape.
+    //
+    // As in the `#265` probe above, the load-bearing part is that the call
+    // RETURNS at all: a host that panics takes its whole CI leg down.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var h = try Host.init(testing.allocator);
+    defer h.deinit();
+    h.io = testing.io;
+    const dirfd = try h.addPreopen(tmp.dir.handle, "/sandbox");
+    const root: std.Io.Dir = .{ .handle = tmp.dir.handle };
+    try root.createDir(testing.io, "d", std.Io.File.Permissions.default_dir);
+    try root.writeFile(testing.io, .{ .sub_path = "f", .data = "x" });
+
+    const unlinkFile = @import("fd.zig").pathUnlinkFile;
+    var mem: [64]u8 = @splat(0);
+    for ([_]struct { p: []const u8, want: p1.Errno }{
+        .{ .p = "d/", .want = .isdir },
+        .{ .p = "d//", .want = .isdir },
+        .{ .p = "f/", .want = .notdir },
+        .{ .p = "./", .want = .isdir },
+    }) |c| {
+        @memset(mem[0..32], 0);
+        writeGuestPath(&mem, 0, c.p);
+        try testing.expectEqual(c.want, unlinkFile(&h, &mem, dirfd, 0, @intCast(c.p.len)));
+    }
+    // None of those deleted anything, and the same name without the trailing
+    // slash still does.
+    @memset(mem[0..32], 0);
+    writeGuestPath(&mem, 0, "f");
+    try testing.expectEqual(p1.Errno.success, unlinkFile(&h, &mem, dirfd, 0, 1));
+}


### PR DESCRIPTION
Closes #310, with a different mechanism than the issue states.

## What aborts the host

`path_unlink_file(dirfd, "dir/")`. `std.Io.Dir.deleteFile` opens the name with
NON_DIRECTORY_FILE; NT rejects a trailing backslash on that open with
STATUS_OBJECT_NAME_INVALID, which `std.Io` calls a programmer bug and panics on.
`test/wasi/official_runner.zig` runs in-process, so the corpus test
`unlink_file_trailing_slashes` kills the runner — `error: process exited with
error code 3`, no summary line — and the advisory step's `continue-on-error`
reports the leg as green anyway. **No Windows number from that lane is a
measurement.**

## Not the dotted final component

`a/.` and `a/..` are normalized away before NT sees the name, and the `#265`
probe in `src/wasi/path.zig` already asserts `pathUnlinkFile` returns for both
on all three legs. Adding the siblings' dot guard here would turn today's
correct `isdir` into `inval` and fix nothing.

`path_remove_directory` reaches the same NT call with DIRECTORY_FILE set, where
a trailing backslash is legal — measured differentially in the same run, it
clears the corpus on Windows while unlink dies. That is why only unlink is
guarded.

## The guard

POSIX makes a trailing `/` mean "must resolve to a directory": `unlink` is
EISDIR on one, ENOTDIR on anything else, and never a delete. Windows computes
that from a stat instead of asking the host. Linux and macOS are unchanged.

The stat does not follow the final symlink. Across the six non-symlink shapes
the test pins, no-follow matches the Linux host on all of them and a following
stat on four. Over a symlink the two POSIX hosts disagree — Linux answers
ENOTDIR, macOS follows the link and answers EPERM — and the corpus never
unlinks a symlink with a trailing slash, so no answer is pinned there.

## Verification

Measured on x86_64-linux: the errnos the test pins are what Linux already
returns, so **the new test cannot be red here** — it passes with and without
the guard. Windows is the oracle, as it was for #267.

Local, all green: `zig fmt --check src/`, `zig build test-all`,
`zig build -Doptimize=ReleaseSafe`, and `zig build -Dtarget=x86_64-windows`
(the guard's live branch is comptime-dead on Linux, so only the cross-compile
typechecks it). `zig build test-wasi-p1-official` reports 72/72 on both engines.
**No macOS or Windows host available locally; neither was run.**

Unverified: the two symlink cases (`ld/`, `ln/`) skip themselves where the host
denies unprivileged symlink creation, and the skip is silent, so whether the
Windows leg ran them cannot be read off the log. They assert only that the call
fails and the link survives; the official corpus never unlinks a symlink with a
trailing slash — its only trailing-slash arguments to `path_unlink_file` are
`"dir/"` and `"file/"`.

