### PR TITLE
test(wasi): say why the symlink cases may be skipped, not just that they are

### DIFF
--- a/src/wasi/path.zig
+++ b/src/wasi/path.zig
@@ -907,7 +907,10 @@ test "path_unlink_file: a trailing slash is the POSIX errno on every host, not a
             _ = root.statFile(testing.io, link, .{ .follow_symlinks = false }) catch
                 return error.SymlinkWasUnlinked;
         }
-    } else |_| {}
+    } else |_| {
+        // The host denies unprivileged symlink creation (Windows without
+        // Developer Mode); nothing above depends on these two shapes.
+    }
     // None of those deleted anything, and the same name without the trailing
     // slash still does.
     @memset(mem[0..32], 0);


### PR DESCRIPTION
`zig build lint` is gated on `ZWASM_CI_EXTENDED`, which `ci.yml` sets only on the
push to `main`. So the empty `else |_| {}` added in #313 never met the linter on
that PR — all three legs were green — and the merge red the push run on `main`:

```
error Empty if blocks are discouraged. If deliberately empty, include a comment
inside the block. [src/wasi/path.zig:910:16] no_empty_block
```

The two `require_exhaustive_enum_switch` findings in the same run are warnings,
present and non-fatal in the previous green push run. The error is the only new
one.

The rule's ask is the right one here — the branch is taken when the host denies
unprivileged symlink creation, and that is worth saying where the block is
empty. `zig build lint` is green locally with the comment in place (the two
pre-existing warnings remain).

This does not close #303 or #312. Those are why a lint error reached `main` at
all; this only clears it.
