### PR TITLE
fix(platform): install the fault handler before publishing it (#320)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1467,6 +1467,27 @@ pub fn build(b: *std.Build) void {
     const test_oob_trap_step = b.step("test-oob-elision", "Verify guard-page bounds elision traps oob (ADR-0202 D4/D5 / D-507)");
     test_oob_trap_step.dependOn(&run_oob_trap.step);
 
+    // Issue #320 — regression-run the fault-handler install/publish
+    // protocol (`signal.ensureInstalled` ordering + `markInstalled`
+    // stand-down). A standalone exe because the scenarios need a virgin
+    // process-global install flag per iteration, which no test inside a
+    // shared test binary can guarantee (any earlier in-process JIT
+    // invoke arms it); the runner forks one pristine child per
+    // scenario. Self-skips on Windows (fork).
+    const signal_install_runner_mod = createSanitizedModule(b, sanitize_opts, .{
+        .root_source_file = b.path("test/runners/signal_install_order_runner.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    signal_install_runner_mod.addImport("zwasm", zwasm_lib_mod);
+    const signal_install_runner_exe = b.addExecutable(.{
+        .name = "zwasm-signal-install-order",
+        .root_module = signal_install_runner_mod,
+    });
+    const run_signal_install = b.addRunArtifact(signal_install_runner_exe);
+    const test_signal_install_step = b.step("test-signal-install-order", "Regression-run the fault-handler install/publish ordering (issue #320; skips on Windows)");
+    test_signal_install_step.dependOn(&run_signal_install.step);
+
     // `zig build test-all` — aggregate all enabled test layers.
     // Phase 0: only `test`. Phase 1+ adds spec / e2e / realworld /
     // c_api / fuzz steps as they land. Each layer registers itself
@@ -1474,6 +1495,7 @@ pub fn build(b: *std.Build) void {
     const test_all_step = b.step("test-all", "Run all enabled test layers");
     test_all_step.dependOn(&run_internal_fault.step); // ADR-0166 B-core
     test_all_step.dependOn(&run_oob_trap.step); // ADR-0202 D4/D5 (D-507) guard-page elision
+    test_all_step.dependOn(&run_signal_install.step); // issue #320 install/publish ordering
     test_all_step.dependOn(&run_core_tests.step);
     test_all_step.dependOn(&run_cli_tests.step);
     test_all_step.dependOn(&run_spec_smoke.step);

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -232,7 +232,7 @@ inline fn invokeAndCheck(
     // hardware fault the production handler redirects to the oob stub. Any
     // JIT execution must therefore have a fault handler armed; this is the
     // single chokepoint (idempotent, skips when the CLI/embedding/spec-runner
-    // already installed one). Cheap atomic-bool fast path after the once.
+    // already installed one). Cheap atomic fast path after the once.
     signal.ensureInstalled();
     // ADR-0105 D1 — populate stack_limit per call for the prologue probe.
     rt.stack_limit = stack_limit_mod.computeStackLimit(stack_limit_mod.STACK_GUARD_HEADROOM);

--- a/src/platform/signal.zig
+++ b/src/platform/signal.zig
@@ -146,36 +146,90 @@ const win_impl = if (builtin.os.tag == .windows) struct {
     }
 } else struct {};
 
-/// Install the diagnostic-only internal-fault handler. Call once at CLI startup
-/// (production entry). No-op on wasi. NOT installed by the test harness — the spec
-/// runners own their own (recovery) handler; this is the production last-resort
-/// disposition.
-/// Set once SOME fault handler owns SIGSEGV/SIGBUS for this process —
-/// either this production handler OR the spec runner's recovery
-/// handler (which classifies guard faults first, then siglongjmp-
-/// recovers). `ensureInstalled` skips when set so the engine's
-/// auto-install (needed for elided JIT execution under plain
-/// `zig build test`) never clobbers a recovery handler.
-var handler_installed = std.atomic.Value(bool).init(false);
+/// Install protocol for the process-wide fault handler, folded into ONE
+/// atomic so the transient `installing` value doubles as the mutual-
+/// exclusion token (Zone 0: `std.atomic` only, no mutex dependency).
+///
+/// Ordering invariant (issue #320; enforced by the signal-install-order
+/// runner): a terminal value (`installed` / `external`) is published
+/// with a `.release` store only AFTER the install it describes is
+/// complete, and every reader loads with `.acquire` — so a caller that
+/// observes a terminal state and returns is guaranteed a complete
+/// install happened-before. A caller that observes `installing` waits
+/// it out (bounded by the installer's few syscalls) instead of
+/// returning handler-less into JIT code.
+const InstallState = enum(u8) {
+    /// No owner yet; the next `ensureInstalled` elects an installer.
+    uninstalled,
+    /// An install is in flight; other callers spin until terminal.
+    installing,
+    /// Our production handler is armed.
+    installed,
+    /// SOME external handler owns SIGSEGV/SIGBUS — the spec runner's
+    /// recovery handler (classifies guard faults first, then
+    /// siglongjmp-recovers) — so the engine's auto-install (needed for
+    /// elided JIT execution under plain `zig build test`) stands down
+    /// and never clobbers it.
+    external,
+};
+var install_state = std.atomic.Value(InstallState).init(.uninstalled);
 
 /// Idempotent auto-install for the JIT invoke path (ADR-0202 D4):
 /// guard-page elision REQUIRES a fault handler, so any JIT execution
 /// must have one armed. No-op if a handler is already installed
-/// (production CLI init, embedding init, or the spec runner).
+/// (production CLI init, embedding init, or the spec runner); briefly
+/// spin-waits while another thread's install is in flight, so a
+/// handler is ALWAYS armed by the time this returns.
 pub fn ensureInstalled() void {
-    if (handler_installed.swap(true, .monotonic)) return;
-    installInternalFaultHandler();
+    switch (install_state.load(.acquire)) {
+        .installed, .external => return,
+        .uninstalled => {
+            if (install_state.cmpxchgStrong(.uninstalled, .installing, .acquire, .monotonic) == null) {
+                installNow();
+                install_state.store(.installed, .release);
+                return;
+            }
+            // Lost the election — fall through and wait out the winner.
+        },
+        .installing => {},
+    }
+    while (install_state.load(.acquire) == .installing) std.atomic.spinLoopHint();
 }
 
 /// Mark SIGSEGV/SIGBUS as owned by an externally-installed handler
 /// (the spec runner's recovery handler) so `ensureInstalled` stands
-/// down. Called from `spec_assert_runner_base.installSigsegvHandler`.
+/// down. Call AFTER that handler is in place and before concurrent
+/// `ensureInstalled` traffic starts. Called from
+/// `spec_assert_runner_base.installSigsegvHandler`.
 pub fn markInstalled() void {
-    handler_installed.store(true, .monotonic);
+    install_state.store(.external, .release);
 }
 
+/// FORCE-install the diagnostic-only internal-fault handler NOW — the
+/// production last-resort disposition (ADR-0166). Called once at CLI
+/// startup (`cli/main.zig`) + embedding init + the fork-recovery
+/// tests; installs regardless of prior state, including a marked
+/// external owner. No-op install body on wasi. Serializes with any
+/// in-flight install and publishes `installed` only after its OWN
+/// complete install.
 pub fn installInternalFaultHandler() void {
-    handler_installed.store(true, .monotonic);
+    while (true) {
+        const s = install_state.load(.acquire);
+        if (s == .installing) {
+            std.atomic.spinLoopHint();
+            continue;
+        }
+        if (install_state.cmpxchgWeak(s, .installing, .acquire, .monotonic) == null) break;
+    }
+    installNow();
+    install_state.store(.installed, .release);
+}
+
+/// The platform install body — sigaltstack + sigaction (POSIX) or the
+/// VEH registration (Windows). Writes NO install state: the two pub
+/// installers above own the state machine and publish only after this
+/// returns.
+fn installNow() void {
     if (comptime builtin.os.tag == .windows) {
         win_impl.install();
         return;

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -681,7 +681,11 @@ fn preDecodeSectionBodies(alloc: std.mem.Allocator, module: *Module) bool {
         for (im.items) |it| switch (it.kind) {
             .table => if (!validRefTypeIdx(it.payload.table.elem_type, ntypes)) return false,
             .global => if (!validRefTypeIdx(it.payload.global.valtype, ntypes)) return false,
-            else => {},
+            // A memory import carries no type index at all; a func or tag
+            // import carries a typeidx, not a reftype, so this reftype-bounds
+            // rule has nothing to read on it. Bounding those typeidxs is a
+            // separate check_module rule this path still lacks (issue #285).
+            .func, .memory, .tag => {},
         };
     }
     if (module.find(.table)) |s| {

--- a/src/wasi/clocks.zig
+++ b/src/wasi/clocks.zig
@@ -234,7 +234,10 @@ fn fdReadiness(
             const size = (f.stat(io) catch return error.Io).size;
             break :blk if (size > slot.pos) size - slot.pos else 0;
         },
-        else => unreachable, // .stdout/.stderr/.dir/.closed rejected above
+        // Unreachable by the kind switch above: it fails the call for a
+        // closed slot, a directory and a read of stdout/stderr, so the only
+        // kinds that reach a read here are stdin and file.
+        .stdout, .stderr, .dir, .closed => unreachable,
     };
     // witx: nbytes is "the number of bytes available for reading". We know it
     // exactly for both readable kinds, so we report it. (wasmtime 47 computes

--- a/test/runners/signal_install_order_runner.zig
+++ b/test/runners/signal_install_order_runner.zig
@@ -158,7 +158,8 @@ pub fn main() u8 {
     };
     const stand_down = runOne(.stand_down);
     const force_install = runOne(.force_install);
-    if (stand_down == .infra or force_install == .infra) infra += 1;
+    if (stand_down == .infra) infra += 1;
+    if (force_install == .infra) infra += 1;
 
     std.debug.print(
         "signal-install-order: ensure-race {d}/{d} mixed-race {d}/{d} stand-down {s} force-install {s} infra {d}\n",

--- a/test/runners/signal_install_order_runner.zig
+++ b/test/runners/signal_install_order_runner.zig
@@ -1,0 +1,175 @@
+//! Regression runner for the fault-handler install/publish protocol of
+//! `src/platform/signal.zig` (issue #320).
+//!
+//! Contract under test: when `ensureInstalled` (or the force-install
+//! entry `installInternalFaultHandler`) returns, a complete handler
+//! install is observable — the SEGV/BUS dispositions are no longer the
+//! process-start baseline. A caller that returns while the baseline is
+//! still active has observed the publish-before-install window; that is
+//! the ordering defect behind the intermittent SIGBUS deaths under
+//! concurrent instantiation (guard-page elision REQUIRES an armed
+//! handler before any JIT execution, ADR-0202 D4).
+//!
+//! Why a standalone exe: the install flag is process-global and sticky,
+//! and any earlier in-process JIT invoke arms it via `ensureInstalled`
+//! — no test inside a shared test binary can rely on a virgin flag.
+//! Here the parent process never touches signal state and forks one
+//! child per scenario iteration, so every child inherits a pristine
+//! flag. Zig's own segfault handler is disabled below so the fork-time
+//! baseline disposition is SIG_DFL, not the std.debug handler.
+//!
+//! The race itself is intermittent, so scenario failures are amplified
+//! (N racer threads released by a spin barrier × ITERATIONS forks) and
+//! detection is by sigaction READBACK after each racer returns — any
+//! return-before-install is caught, fault or no fault. The stand-down
+//! and force-install scenarios are single-threaded and deterministic.
+//!
+//! Deliberately NOT asserted here: sigaltstack arming, which is
+//! per-thread and tracked separately (issue #321).
+//!
+//! Windows: fork is unavailable; the runner self-skips (exit 0). The
+//! publish-after-install path is shared with the win_impl branch but is
+//! not exercised here. fork/waitpid/_exit = ADR-0070 necessary
+//! (test-only), mirroring `signal.zig`'s fork test.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const signal = @import("zwasm").platform.signal;
+
+pub const std_options: std.Options = .{ .enable_segfault_handler = false };
+
+const RACERS = 4;
+const ITERATIONS = 40;
+
+const EXIT_OK = 0;
+const EXIT_VIOLATION = 9;
+const EXIT_INFRA = 12;
+
+const Scenario = enum { ensure_race, mixed_race, stand_down, force_install };
+const Outcome = enum { ok, violation, infra };
+
+/// Current disposition of `sig` as a comparable integer. The
+/// `.handler`/`.sigaction` union members alias the same storage in the
+/// C sigaction layout, so one read covers both forms.
+fn disposition(sig: std.posix.SIG) usize {
+    var old: std.posix.Sigaction = undefined;
+    std.posix.sigaction(sig, null, &old);
+    return @intFromPtr(old.handler.handler);
+}
+
+const RaceCtx = struct {
+    go: std.atomic.Value(bool),
+    violations: std.atomic.Value(u32),
+    base_segv: usize,
+    base_bus: usize,
+    mixed: bool,
+};
+
+fn racer(ctx: *RaceCtx, idx: usize) void {
+    while (!ctx.go.load(.acquire)) std.atomic.spinLoopHint();
+    if (ctx.mixed and idx == 0)
+        signal.installInternalFaultHandler()
+    else
+        signal.ensureInstalled();
+    // Readback AFTER return: the contract is "a handler is armed once
+    // this returns". Observing the fork-time baseline here means the
+    // call returned inside the publish-before-install window.
+    if (disposition(.SEGV) == ctx.base_segv or disposition(.BUS) == ctx.base_bus)
+        _ = ctx.violations.fetchAdd(1, .monotonic);
+}
+
+fn raceChild(mixed: bool) noreturn {
+    var ctx: RaceCtx = .{
+        .go = std.atomic.Value(bool).init(false),
+        .violations = std.atomic.Value(u32).init(0),
+        .base_segv = disposition(.SEGV),
+        .base_bus = disposition(.BUS),
+        .mixed = mixed,
+    };
+    var threads: [RACERS]std.Thread = undefined;
+    var spawned: usize = 0;
+    while (spawned < RACERS) : (spawned += 1) {
+        threads[spawned] = std.Thread.spawn(.{}, racer, .{ &ctx, spawned }) catch break;
+    }
+    // Release even on partial spawn so no racer spins forever; the
+    // partial run is discarded as an infra failure either way.
+    ctx.go.store(true, .release);
+    for (threads[0..spawned]) |t| t.join();
+    if (spawned != RACERS) std.c._exit(EXIT_INFRA);
+    std.c._exit(if (ctx.violations.load(.acquire) != 0) EXIT_VIOLATION else EXIT_OK);
+}
+
+fn standDownChild() noreturn {
+    const base = disposition(.SEGV);
+    signal.markInstalled();
+    signal.ensureInstalled();
+    // External ownership: ensureInstalled must NOT touch the disposition.
+    std.c._exit(if (disposition(.SEGV) != base) EXIT_VIOLATION else EXIT_OK);
+}
+
+fn forceChild() noreturn {
+    const base = disposition(.SEGV);
+    signal.markInstalled();
+    signal.installInternalFaultHandler();
+    // The direct entry stays a FORCE install (CLI startup semantics),
+    // even after an external owner was marked.
+    std.c._exit(if (disposition(.SEGV) == base) EXIT_VIOLATION else EXIT_OK);
+}
+
+fn runOne(scenario: Scenario) Outcome {
+    const pid = std.c.fork();
+    if (pid == -1) return .infra;
+    if (pid == 0) {
+        switch (scenario) {
+            .ensure_race => raceChild(false),
+            .mixed_race => raceChild(true),
+            .stand_down => standDownChild(),
+            .force_install => forceChild(),
+        }
+    }
+    var status: c_int = 0;
+    _ = std.c.waitpid(pid, &status, 0);
+    const ustatus: u32 = @bitCast(status);
+    if (!std.posix.W.IFEXITED(ustatus)) return .infra;
+    return switch (std.posix.W.EXITSTATUS(ustatus)) {
+        EXIT_OK => .ok,
+        EXIT_VIOLATION => .violation,
+        else => .infra,
+    };
+}
+
+pub fn main() u8 {
+    if (comptime builtin.os.tag == .windows) {
+        std.debug.print("signal-install-order: SKIP (fork unavailable on Windows; shared publish path unexercised here)\n", .{});
+        return 0;
+    }
+    var ensure_v: u32 = 0;
+    var mixed_v: u32 = 0;
+    var infra: u32 = 0;
+    for (0..ITERATIONS) |_| switch (runOne(.ensure_race)) {
+        .violation => ensure_v += 1,
+        .infra => infra += 1,
+        .ok => {},
+    };
+    for (0..ITERATIONS) |_| switch (runOne(.mixed_race)) {
+        .violation => mixed_v += 1,
+        .infra => infra += 1,
+        .ok => {},
+    };
+    const stand_down = runOne(.stand_down);
+    const force_install = runOne(.force_install);
+    if (stand_down == .infra or force_install == .infra) infra += 1;
+
+    std.debug.print(
+        "signal-install-order: ensure-race {d}/{d} mixed-race {d}/{d} stand-down {s} force-install {s} infra {d}\n",
+        .{
+            ensure_v,             ITERATIONS,
+            mixed_v,              ITERATIONS,
+            @tagName(stand_down), @tagName(force_install),
+            infra,
+        },
+    );
+    const failed = ensure_v != 0 or mixed_v != 0 or
+        stand_down != .ok or force_install != .ok or infra != 0;
+    return if (failed) 1 else 0;
+}


### PR DESCRIPTION
Closes #320.

`ensureInstalled` swapped the installed flag to true BEFORE installing, so a
second thread arriving in that window returned handler-less and its first
guard fault killed the process — the intermittent SIGBUS the rust-sdk test
suite hit on macOS aarch64. `installInternalFaultHandler` (the CLI entry) had
the same publish-first shape, on the Windows branch too.

## The fix (`src/platform/signal.zig`)

One atomic install state instead of the bool, four values: `uninstalled` /
`installing` / `installed` / `external`, where the transient `installing`
doubles as the mutual-exclusion token (Zone 0 keeps to `std.atomic`).
Installers elect via CAS, run the platform install body — the Windows branch
moved inside it, so its publish is ordered too — then publish `.installed`
with a `.release` store strictly after it completes; readers `.acquire`-load
and wait out an in-flight install, so nobody returns before a complete
install is observable. The JIT invoke fast path becomes a plain load (it was
an RMW swap per call). `markInstalled` still parks the state at `external`
(spec-runner recovery handler ownership); `installInternalFaultHandler` still
force-installs.

## Regression coverage

`test/runners/signal_install_order_runner.zig` (new; in test-all; self-skips
on Windows — fork): one pristine forked child per iteration races
`ensureInstalled` (plus the mixed CLI-entry case) behind a spin barrier, then
readback-checks the SEGV/BUS dispositions after each racer returns — a
publish-before-install return is caught without landing a fault in the
window. Pre-fix on Linux x86_64: ensure-race 32/40 iterations violated,
mixed-race 22/40; post-fix 0/40 both. The deterministic stand-down and
force-install scenarios pin the `markInstalled` semantics a plain `Once`
would have broken.

## Also here: two lint findings

`zig build lint` runs only in the extended CI leg (push to main), so two
`require_exhaustive_enum_switch` findings sat on main unseen while the full
local `scripts/gate_commit.sh` stayed red for everyone. Both switches now
name the tags their `else` arm always covered, and neither changes what it
accepts: the import walk's `.func` / `.memory` / `.tag` carry no reftype for
that bounds rule to read — bounding the func and tag typeidxs is a
check_module rule the validate path still lacks (#285) — and the poll
readiness `unreachable` covers exactly the kinds the switch above it already
failed the call for.

Not touched: per-thread sigaltstack arming (#321), the multi-result thunk
arming gap (#302).

Verified on Linux x86_64: fmt, lint, test-all, test-spec, ReleaseSafe build,
and the full `gate_commit.sh`. The original macOS aarch64 symptom is not
reproducible on this host; the 3-OS CI gate is the first real macOS/Windows
check.
