### PR TITLE
test: plumb ZWASM_DEBUG into every runner that owns a main (#268)

### DIFF
--- a/test/api/zig_facade_runner.zig
+++ b/test/api/zig_facade_runner.zig
@@ -33,6 +33,7 @@ const std = @import("std");
 const zwasm = @import("zwasm");
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/edge_cases/runner.zig
+++ b/test/edge_cases/runner.zig
@@ -20,6 +20,7 @@ const zwasm = @import("zwasm");
 const run_wasm = zwasm.engine.runner;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/fuzz/fuzz_exec.zig
+++ b/test/fuzz/fuzz_exec.zig
@@ -323,6 +323,7 @@ fn processModule(
 }
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/fuzz/fuzz_loader.zig
+++ b/test/fuzz/fuzz_loader.zig
@@ -32,6 +32,7 @@ const parser = zwasm.parse.parser;
 const engine_runner = zwasm.engine.runner;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/realworld/diff_runner.zig
+++ b/test/realworld/diff_runner.zig
@@ -131,6 +131,7 @@ const interp_deadline_ms: u64 = 120_000;
 const interp_all_deadline_ms: u64 = 480_000;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/realworld/run_runner.zig
+++ b/test/realworld/run_runner.zig
@@ -57,6 +57,7 @@ const cli_run = zwasm.cli.run;
 const parser = zwasm.parse.parser;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/realworld/run_runner_jit.zig
+++ b/test/realworld/run_runner_jit.zig
@@ -50,6 +50,7 @@ const zwasm = @import("zwasm");
 const engine_runner = zwasm.engine.runner;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/realworld/runner.zig
+++ b/test/realworld/runner.zig
@@ -30,6 +30,7 @@ const zwasm = @import("zwasm");
 const parser = zwasm.parse.parser;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/runners/wast_runtime_runner.zig
+++ b/test/runners/wast_runtime_runner.zig
@@ -124,6 +124,7 @@ const ActiveModule = struct {
 };
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/component_model_assert_runner.zig
+++ b/test/spec/component_model_assert_runner.zig
@@ -64,6 +64,7 @@ const Current = union(enum) {
 };
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/jit_compile_runner.zig
+++ b/test/spec/jit_compile_runner.zig
@@ -24,6 +24,7 @@ const zwasm = @import("zwasm");
 const run_wasm = zwasm.engine.runner;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/runner.zig
+++ b/test/spec/runner.zig
@@ -20,6 +20,7 @@ const sections = zwasm.parse.sections;
 const validator = zwasm.validate.validator;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/simd_assert_runner.zig
+++ b/test/spec/simd_assert_runner.zig
@@ -47,6 +47,7 @@ const entry = zwasm.engine.codegen.shared.entry;
 const base = @import("spec_assert_runner_base.zig");
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     base.initHostDispatchStubs();
     // ADR-0202 D5 — JIT-executes against the bespoke non-guarded
     // `base.growable_memory` array → explicit bounds checks mandatory

--- a/test/spec/spec_assert_runner.zig
+++ b/test/spec/spec_assert_runner.zig
@@ -26,6 +26,7 @@ const runner_mod = zwasm.engine.runner;
 const entry = zwasm.engine.codegen.shared.entry;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     // ADR-0202 D5 — this runner JIT-executes against a bespoke non-guarded
     // `scratch_memory` buffer, so it MUST compile with explicit bounds checks
     // (guard-page elision would read past the buffer instead of faulting,

--- a/test/spec/spec_assert_runner_non_simd.zig
+++ b/test/spec/spec_assert_runner_non_simd.zig
@@ -61,6 +61,7 @@ pub const std_options: std.Options = .{
 };
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -415,6 +415,7 @@ fn recordJitRunErr(
 }
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     // ADR-0202 D5 — JIT-executes via base's bespoke non-guarded memory →
     // explicit bounds checks mandatory (binding-time soundness). D-515.
     zwasm.engine.runner.setBoundsChecks(.explicit);

--- a/test/spec/wast_runner.zig
+++ b/test/spec/wast_runner.zig
@@ -36,6 +36,7 @@ const sections = zwasm.parse.sections;
 const validator = zwasm.validate.validator;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/wasi/official_runner.zig
+++ b/test/wasi/official_runner.zig
@@ -116,6 +116,7 @@ fn isTestVerdict(err: anyerror) bool {
 }
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 

--- a/test/wasi/runner.zig
+++ b/test/wasi/runner.zig
@@ -18,6 +18,7 @@ const zwasm = @import("zwasm");
 const cli_run = zwasm.cli.run;
 
 pub fn main(init: std.process.Init) !void {
+    zwasm.support.dbg.initFromEnv(init.environ_map.get("ZWASM_DEBUG"));
     const io = init.io;
     const gpa = init.gpa;
 


### PR DESCRIPTION
Closes #268. What #268 also named is split out rather than dropped: the
unit-test lane's test-order dependence is #327, the triage of what `liveverify`
reports once it is reachable is #326, and narrowing `dbg.anyActive()` so an AOT
lane can carry a channel is parked with its ADR drafted — it buys no coverage
today (see "Scoping the channel per lane" below). Nothing in #268 is left with
this merged.

`dbg.initFromEnv` had two call sites — `cli/main.zig` and
`api/instance.zig:wasm_engine_new` — and no test runner called either from its
own `main`, so `liveverify` (D-596) and `regverify` (D-489) were off in every
lane that does not route through `cli/run.zig`. One line per runner, the same
plumbing `cli/main.zig` already does.

## What this makes reachable, and what it does not

`test/` has 25 entry points with a `pub fn main`. 19 are changed. The other 6
are not, for reasons that do not move: `runners/eh_frequency_runner.zig` and
`runners/gc_stress_runner.zig` are `addTest` targets whose `main` never runs;
`runners/signal_install_order_runner.zig` and `jit/releasesafe_result_probe.zig`
take no `std.process.Init` to read env from; `realworld/d489_repro.zig` is a
manual harness in no lane; `aot/aot_process_diff.zig` imports no `zwasm` module
and spawns the real CLI, which reads `ZWASM_DEBUG` itself.

**`zig build test` is untouched by this change** — unit-test binaries have no
`main` to plumb. That lane is not dark: it reaches `initFromEnv` through
`wasm_engine_new` → `std.c.getenv`, so channels come on partway through the run
and which tests see them depends on test order. Measured with `ZWASM_DEBUG='*'`:
1,200,148 diagnostic lines, of which `[jit.dump]` is 12 — six functions compiled
after the whitelist was populated — and `[liveverify]` / `[regverify]` are 0.
**That order-dependence is out of scope here and tracked in #327**; it is not
reachable from `test/`.

## Measured (x86_64-linux, `d3373b36b`)

`ZWASM_DEBUG=liveverify zig build test-all`, liveverify events 3 → 158:
`test-spec-wasm-2.0-assert` 0→132, `test-spec-assert` 0→14, `test-edge-cases`
0→8, every other lane unchanged. The 3 that already fired are in the realworld
lanes, which reach `initFromEnv` through `cli/run.zig:runWasmCapturedFull` →
`wasm_engine_new`, not through the runner.

`ZWASM_DEBUG=regverify`: 0 events. `ZWASM_DEBUG='*'`, where
`dbg.on("regverify")` cannot be false, is also 0 — the verifier ran over every
JIT-compiled function and reported nothing.

`-Doptimize=ReleaseSafe` gives the same counts on the two lanes re-run there
(132 and 8); `ReleaseFast` / `ReleaseSmall` are 0, comptime-stripped as
`dbg.zig` documents. Every lane's pass/fail verdict is unchanged, and
`zig build test-all` with no channel is green.

## Scoping the channel per lane

`ZWASM_DEBUG` is set per lane, not once for `test-all`: the 6 lanes above take
it; `zig build test` and `test-aot-diff` do not. Those two are the only lanes
that fail under any channel value — `dbg.anyActive()` makes
`produceFromCompiledWasm` refuse — and they are also the only two that report 0
`liveverify` and 0 `regverify`, so scoping them out costs no coverage.

The 158 events are not 158 defects; triage is in #326.

No guard catches the 20th runner that forgets this line. There is no shared
pre-`main` helper to hang it on, so the 19 copies are unavoidable; the exposure
is that a fix for silently-disabled diagnostics can itself go silently
incomplete. Tracked in #329 — it changes a gate definition, so it is not
in this PR.
