### PR TITLE
docs: two public texts that no longer match the code (#309, #220)

### DIFF
--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -5,10 +5,12 @@
  * surface follows the upstream wasm-c-api interface.
  *
  * Instance-level sandboxing setters: per-instance budgets are set
- * post-instantiate and are mutable mid-workload (fuel, memory/table
- * ceilings, interrupt). The C API creates interpreter-backed instances
- * (the hardened default engine); JIT budgets are driven via the CLI.
- * All functions are null-tolerant (a null instance is a no-op).
+ * post-instantiate and are mutable mid-workload (fuel, memory ceiling,
+ * interrupt). wasm_instance_new compiles the module with the JIT and
+ * instantiates the interpreter only when the JIT declines it, so each
+ * setter routes to whichever engine ended up backing the instance —
+ * see ZWASM_ENGINE_AUTO below. All functions are null-tolerant (a null
+ * instance is a no-op).
  *
  * The WASI config family (zwasm_wasi_config_*, zwasm_store_set_wasi) is
  * declared in wasi.h; zwasm_instance_get_func is declared below.
@@ -25,7 +27,13 @@
 extern "C" {
 #endif
 
-/* ── Fuel (deterministic budget; interp units = instructions) ────────── */
+/* ── Fuel (deterministic budget) ─────────────────────────────────────── */
+
+/* Fuel units are engine-specific: interpreter = instructions executed;
+ * JIT = poll-site crossings (function entry + loop back-edges). A budget
+ * armed on an instance whose engine you did not force therefore has no
+ * portable unit — pin the engine with zwasm_instance_new_ex when the
+ * exact count matters. */
 
 /* Arm (or re-arm) the fuel budget. Exhaustion traps with kind
  * ZWASM_TRAP_OUT_OF_FUEL ("all fuel consumed"). */
@@ -87,11 +95,14 @@ WASM_API_EXTERN wasm_func_t* zwasm_instance_get_func(wasm_instance_t*, uint32_t 
 
 /* ── Engine selection ────────────────────────────────────────────────── */
 
-/* Per-instance engine kind for zwasm_instance_new_ex. AUTO resolves to the
- * runtime's choice (currently the interpreter until the JIT host-import/WASI
- * bridge lands; documented to change without an API break). JIT forces the
- * native JIT (an explicit JIT on a JIT-less arch fails instantiation, returning
- * NULL — no silent downgrade). INTERP forces the interpreter. */
+/* Per-instance engine kind for zwasm_instance_new_ex. AUTO — what stock
+ * wasm_instance_new passes — compiles the module with the JIT and instantiates
+ * the interpreter only for a module the JIT declines (an import outside the
+ * JIT's host-func bridge, or a body it cannot compile). JIT forces the native
+ * JIT: a declined module fails instantiation, returning NULL — no silent
+ * downgrade. INTERP forces the interpreter, which unlike the other two rejects
+ * a module importing wasi_snapshot_preview1 when no WASI host is configured on
+ * the store. */
 #define ZWASM_ENGINE_AUTO 0
 #define ZWASM_ENGINE_JIT 1
 #define ZWASM_ENGINE_INTERP 2

--- a/scripts/check_engine_default_claims.sh
+++ b/scripts/check_engine_default_claims.sh
@@ -8,11 +8,16 @@
 # rots, and this one rotted twice. Same class as the D-312 compiler-rt lie
 # (lesson 2026-08-03-ungated-negative-doc-claim-rotted-into-a-lie.md).
 #
-# Two assertions:
+# Three assertions:
 #   1. ANCHOR — the CLI usage text still says the default is `auto`. If the
 #      default legitimately changes, this fires first and forces the sweep
 #      below to be redone rather than silently inverted.
-#   2. SWEEP — no live tracked file claims the interpreter is the default.
+#   2. SWEEP — no live tracked file claims the interpreter is the default, on
+#      any single line.
+#   3. SPAN SWEEP — the same claim spread across two comment lines. #309 was
+#      missed because `include/zwasm.h` wrapped "interpreter-backed instances"
+#      and "(the hardened default engine)" onto separate lines, and a
+#      line-oriented grep cannot see a claim that straddles the wrap.
 #
 # Modes:
 #   bash scripts/check_engine_default_claims.sh          # informational, exit 0
@@ -37,7 +42,22 @@ EXEMPT_RE='^(bench/|CHANGELOG\.md$|\.dev/archive/|\.dev/lessons/|\.dev/decisions
 # always carry. Kept literal and narrow — a loose pattern here produces false
 # positives on true statements about comparator runtimes, which is how a gate
 # gets disabled.
-CLAIM_RE='interp(reter)?[`*]*[[:space:]]*\((the )?default[,)]|interpreter by default|default[[:space:]]+engine[[:space:]]+is[[:space:]]+(the[[:space:]]+)?[`*]*interp|interp(reter)?/default engine'
+#
+# The `currently|for now` and `auto (= interp` / `auto resolves to interp` arms
+# were added for #309: both phrasings assert the interpreter is what you get
+# today without ever writing "interpreter is the default".
+CLAIM_RE='interp(reter)?[`*]*[[:space:]]*\((the )?default[,)]|interpreter by default|default[[:space:]]+engine[[:space:]]+is[[:space:]]+(the[[:space:]]+)?[`*]*interp|interp(reter)?/default engine|(currently|for now)[[:space:]]+(the[[:space:]]+)?[`*]*interp(reter)?\b|auto[`*.]*[[:space:]]*(\(=[[:space:]]*|resolves to[[:space:]]+)[`*]*(the[[:space:]]+)?interp(reter)?\b'
+
+# Pass 3 operates on the file with comment leaders and newlines flattened to
+# spaces, so a claim that wraps is one string. Necessarily broader than
+# CLAIM_RE, so each match is re-tested against TRUE_MARKER_RE: a window that
+# also names `auto` / the JIT / a fallback is describing the real default
+# ("auto — prefers the JIT, interpreter fallback — is the default engine") and
+# is not a claim that the interpreter is it. A match that the file wraps in
+# quotation marks is likewise skipped: a quoted claim is being cited (as
+# ci.yml cites the #163 one), not made.
+SPAN_CLAIM_RE='interp(reter)?[a-z-]*[^.]{0,60}default engine'
+TRUE_MARKER_RE='auto|jit|fallback|not the default|no longer the default'
 
 fail=0
 
@@ -64,6 +84,22 @@ while IFS= read -r f; do
     printf '%s' "$line" | grep -qiE 'wasmedge|wasmer|wazero|wasmtime|zwasm v1|\bv1\b' && continue
     hits+=("$f: $line")
   done < <(grep -niE "$CLAIM_RE" "$f" 2>/dev/null || true)
+done < <(git ls-files -- '*.md' '*.yml' '*.yaml' '*.zig' '*.sh' '*.h' '*.c' '*.rs' 2>/dev/null)
+
+# --- 3. span sweep (claims that wrap across comment lines) -----------------
+while IFS= read -r f; do
+  [[ -f "$f" ]] || continue
+  [[ "$f" =~ $EXEMPT_RE ]] && continue
+  # Cheap pre-filter: the span pattern always ends in "default engine".
+  grep -qiF 'default engine' "$f" || continue
+  joined="$(sed -E 's#^[[:space:]]*(///|//|\*/|/\*|\*|\#)[[:space:]]*##' "$f" | tr '\n' ' ')"
+  while IFS= read -r m; do
+    [[ -n "$m" ]] || continue
+    printf '%s' "$m" | grep -qiE "$TRUE_MARKER_RE" && continue
+    printf '%s' "$m" | grep -qiE 'wasmedge|wasmer|wazero|wasmtime|zwasm v1|\bv1\b' && continue
+    printf '%s' "$joined" | grep -qF "\"$m\"" && continue
+    hits+=("$f: (spans lines) $m")
+  done < <(printf '%s' "$joined" | grep -oiE "$SPAN_CLAIM_RE" 2>/dev/null || true)
 done < <(git ls-files -- '*.md' '*.yml' '*.yaml' '*.zig' '*.sh' '*.h' '*.c' '*.rs' 2>/dev/null)
 
 if [[ ${#hits[@]} -gt 0 ]]; then

--- a/scripts/check_engine_default_claims.sh
+++ b/scripts/check_engine_default_claims.sh
@@ -90,9 +90,10 @@ done < <(git ls-files -- '*.md' '*.yml' '*.yaml' '*.zig' '*.sh' '*.h' '*.c' '*.r
 while IFS= read -r f; do
   [[ -f "$f" ]] || continue
   [[ "$f" =~ $EXEMPT_RE ]] && continue
-  # Cheap pre-filter: the span pattern always ends in "default engine".
-  grep -qiF 'default engine' "$f" || continue
   joined="$(sed -E 's#^[[:space:]]*(///|//|\*/|/\*|\*|\#)[[:space:]]*##' "$f" | tr '\n' ' ')"
+  # Pre-filter AFTER joining: the phrase itself may straddle the wrap, and a
+  # raw-file filter would then skip the file this pass exists to catch.
+  printf '%s' "$joined" | grep -qiE 'default[[:space:]]+engine' || continue
   while IFS= read -r m; do
     [[ -n "$m" ]] || continue
     printf '%s' "$m" | grep -qiE "$TRUE_MARKER_RE" && continue

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -629,8 +629,8 @@ pub export fn wasm_instance_new(
     imports: ?*const anyopaque,
     trap_out: ?*?*Trap,
 ) callconv(.c) ?*Instance {
-    // Stock wasm-c-api: engine is `.auto` (= interp until the JIT host-import
-    // bridge lands). The `zwasm_instance_new_ex` extension selects per-instance.
+    // Stock wasm-c-api: engine is `.auto` — JIT-first, interp only for a module
+    // the JIT declines (D-496). `zwasm_instance_new_ex` selects per-instance.
     return instanceNewWithEngine(s, m, imports, trap_out, .auto);
 }
 
@@ -665,10 +665,11 @@ pub fn instanceNewWithEngine(
 /// that threads per-instance runtime budgets (ADR-0179). Mirrors
 /// `wasm_instance_new` with a null imports vector but accepts `limits` so fuel /
 /// memory caps are armed before the start function and the initial allocation.
-/// ADR-0200 — per-instance engine selection. `auto` lets the runtime pick
-/// (eventually JIT-default, interp fallback on a JIT-less arch); `jit` /
-/// `interp` force one. The fork is centralised in `instantiateInternal` so
-/// every entry point (facade / `wasm_instance_new` / linker) honours it.
+/// ADR-0200 / D-496 — per-instance engine selection. `auto` tries the JIT and
+/// falls back to the interp for a module the JIT declines; `jit` / `interp`
+/// force one (a forced `jit` fails rather than downgrading). The fork is
+/// centralised in `instantiateInternal` so every entry point (facade /
+/// `wasm_instance_new` / linker) honours it.
 pub const EngineKind = enum { auto, jit, interp };
 
 pub fn instantiateFacade(store: *Store, module: *const Module, trap_out: ?*?*Trap, limits: InstantiateLimits, engine: EngineKind) ?*Instance {
@@ -2771,7 +2772,7 @@ test "ADR-0200 C-path JIT: wasm_instance_exports + wasm_func_call on a JIT insta
     const m = wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
     defer wasm_module_delete(m);
     // Force the JIT engine via the facade entry; stock `wasm_instance_new`
-    // hardcodes `.auto` (= interp) — the C `zwasm_instance_new_ex` knob is next.
+    // hardcodes `.auto` — the C `zwasm_instance_new_ex` knob is next.
     const inst = instantiateFacade(s, m, null, .{}, .jit) orelse return error.InstanceAllocFailed;
     defer wasm_instance_delete(inst);
 

--- a/src/api/zwasm_ext.zig
+++ b/src/api/zwasm_ext.zig
@@ -111,9 +111,9 @@ pub export fn zwasm_instance_clear_interrupt(i: ?*Instance) callconv(.c) void {
 /// ADR-0200 — per-instance engine selection for the C ABI. Stock
 /// `wasm_instance_new` has no engine param; this extension mirrors it with a
 /// trailing `engine_kind` (`ZWASM_ENGINE_AUTO=0` / `JIT=1` / `INTERP=2`; unknown
-/// → auto). `auto` resolves to interp until the JIT host-import/WASI bridge lands
-/// (documented to change without an API break). An explicit `jit` on a JIT-less
-/// arch fails instantiation (returns null) rather than silently downgrading.
+/// → auto). D-496: `auto` compiles with the JIT and instantiates the interp only
+/// for a module the JIT declines. An explicit `jit` on a module the JIT declines
+/// fails instantiation (returns null) rather than silently downgrading.
 pub export fn zwasm_instance_new_ex(
     s: ?*capi.Store,
     m: ?*const capi.Module,

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -515,10 +515,13 @@ fn resolveLenientEntryIdx(allocator: Allocator, wasm_bytes: []const u8) Error!?u
 /// → `main` → first func export, else INSTANTIATE-ONLY (exit 0, wasmtime-aligned)
 /// — instead of strict `_start`-only → ExportNotFound on no-`_start` modules
 /// (D-284 nbody). A void entry runs via `callVoidNoArgs` (proc_exit code flows
-/// through the host); a no-arg `() -> i32` entry runs via `callI32NoArgs` (i32 →
-/// exit, AOT-aligned). Other default-entry shapes (params / non-i32 result) have
-/// no args to supply → instantiate-only. `--invoke` of an unsupported sig keeps
-/// the existing UnsupportedEntrySignature contract.
+/// through the host); a no-arg `() -> i32` entry runs via `callI32NoArgs` and its
+/// i32 lands in `result_out` — it is NOT an exit status. The returned u32 is
+/// `JitRuntime.jit_executed_flag` on every path, so the process exit code comes
+/// from `proc_exit` (or 0), never from the entry's result (#220 (c)). Other
+/// default-entry shapes (params / non-i32 result) have no args to supply →
+/// instantiate-only. `--invoke` of an unsupported sig keeps the existing
+/// UnsupportedEntrySignature contract.
 /// ADR-0179 #3a-4 / D-314 — sandboxing limits the CLI threads into the JIT
 /// run path (the facade stays interp-only by design, so the JIT runner arms
 /// its JitRuntime directly). All optional; defaults = unmetered/uncapped.

--- a/src/runtime/runtime.zig
+++ b/src/runtime/runtime.zig
@@ -401,8 +401,10 @@ pub const Runtime = struct {
     /// fuel, decremented once per executed interp instruction; trap `OutOfFuel`
     /// at 0. `null` = unmetered (zero hot-path cost: one predictable optional
     /// unwrap per instruction). Set/read via the facade `Instance.setFuel`/
-    /// `fuelRemaining`. Interp-engine only (the default engine); JIT-engine
-    /// fuel is a documented post-v0.1 enhancement (handover).
+    /// `fuelRemaining`. This field is the INTERP engine's cell; the JIT keeps
+    /// its own (`JitRuntime.fuel_cell`, armed via `JitInstance.setFuel`, units =
+    /// poll-site crossings). The facade and `zwasm_instance_set_fuel` route to
+    /// whichever engine backs the instance, so both are reachable from a host.
     fuel: ?u64 = null,
 
     /// Optional per-instruction trace hook (Phase 6 / §9.6 / 6.A


### PR DESCRIPTION
Two false public texts, comment/docstring only — no code line changes. `Refs
#309`, `Refs #220`; neither is closed here. No `.dev/` change (both are defects
with issues; per #264 the ledger records conditions, issues record defects).

## 1. `include/zwasm.h` on the default engine (#309)

I read `instantiateInternal` rather than take the issue's wording, then
measured through the public C ABI — a scratch C program against `zig build
static-lib`, x86_64-linux, Debug:

| module | stock `wasm_instance_new` (AUTO) | forced INTERP | forced JIT |
| --- | --- | --- | --- |
| a `v128` body | runs, `lane0() == 42` | instantiates, call traps | — |
| imports `wasi_snapshot_preview1.fd_write`, no WASI host | instantiates | NULL | instantiates |
| imports a 5-i32-param host func | instantiates, `call5() == 15` | — | NULL |

Rows 1-2 say the stock entry point is the JIT. Row 3 is the fallback and the
no-downgrade contract at once: the JIT host-func bridge covers arity ≤ 4
(`jit_host_bridge.dispatchPtrFor`), so a forced JIT fails there while AUTO
falls back and the call still reaches the host. Row 2 is the divergence an
embedder is most likely to hit and the issue does not mention, so the new text
names it; it is deliberate (D-451/D-496, pinned at `src/api/instance.zig:2570`).

Three edits in the same block go beyond the two sites the issue names, flagging
them because they widen the diff: the setter list said "memory/table ceilings"
and no table setter is declared here; the fuel header asserted "interp units =
instructions", complete while instances were interp-backed but a hole once the
header admits either engine, so the JIT's unit is named beside it; and "an
explicit JIT on a JIT-less arch fails instantiation" describes a state that
cannot exist (`compile.zig:46` is a `@compileError` off aarch64/x86_64), so it
is rewritten to the reachable case, which is row 3.

Five in-tree comments carried the same claim and are fixed in the same commit —
three in `src/api/instance.zig`, one in `src/api/zwasm_ext.zig` (the header's
mirror), and `src/runtime/runtime.zig:404`, which also called JIT fuel
unimplemented (fuel 16 on a stock instance traps `ZWASM_TRAP_OUT_OF_FUEL`).
`zig build test-c-api-conformance` passes.

## 2. The gate that missed it (#309) — separate commit

`zwasm.h` is tracked and not exempt, so it was swept; `CLAIM_RE` just holds the
four phrasings from #163. One of the header's two is invisible to a
line-oriented grep at all — the wrap put "interpreter-backed instances" and
"(the hardened default engine)" on separate lines.

Two narrow arms cover the single-line phrasings. A third pass covers the wrap:
flatten comment leaders and newlines, match a broader pattern, then discard any
window that also names auto / the JIT / a fallback, or that the file wraps in
quotation marks — the quote rule is what keeps `ci.yml:102` green, where the
#163 claim is cited, not made. Against the pre-fix text it reports all six
sites and skips ci.yml; against the fixed tree it is green. ~7 s over 2409
files (the third pass pre-filters on a literal `default engine`: 12 files).

`src/api/instance.zig:669` is corrected in commit 1 but is **not** gated — it
asserts the flip is pending without naming the interpreter as the default, and
I found no pattern for that which does not fire on true prose.

## 3. `runWasiLenient`'s exit contract (#220 (c))

Re-derived: every non-error return in `runWasiLenientArgsCore` is
`JitRuntime.jit_executed_flag` (7 sites), the i32 goes to `result_out`, and
`src/cli/run.zig:193` discards the return. Measured: a module exporting `main`
as `() -> i32` returning 42 exits 0 under `--engine jit`, `interp`, `auto` and
the default; `--invoke main` prints `42`, so the value is reachable, just never
as the status.

**(a) and (b) are not touched**: no exit plumbing is wired, and the scope half
of the same docstring (params / non-i32 result → instantiate-only), which (b)
cites as the JIT's documented bound, is unchanged. (d) is a string literal in a
code line — out of scope. (a), (b), (d) remain open.

## Running vs reading

Running: the table above, the fuel trap, the exit codes and `--invoke` output,
the widened gate against pre-fix and fixed text, `test-c-api-conformance`, and
`scripts/gate_commit.sh` (no `--fast`) before each commit.

Reading: that AUTO's fallback is unconditional for any JIT rejection (the
fall-through, plus the `jit_trap` early return that stops a real `(start)` trap
being re-run); which import shapes `collectHostFuncTargets` rejects beyond the
arity case I measured; and that a JIT-less arch cannot be built. #309 exists
because a claim survived on nobody re-deriving it, so the split matters here.
