### PR TITLE
fix(capi): a WASI host outlives the instances that captured it

### DIFF
--- a/.dev/decisions/0219_captured_wasi_host_lifetime.md
+++ b/.dev/decisions/0219_captured_wasi_host_lifetime.md
@@ -122,6 +122,27 @@ defect requires, because the store cannot see an instance's imports. Its own
 doc names this issue and says the refusal can go once zwasm defers the free.
 It now can. The SDK change is separate work.
 
+**The verification is asymmetric across the OS gate, by construction.** The
+direct evidence that a retained host is retained is a descriptor: a released
+host closes its preopen directory fd, so the conformance case compares the
+descriptor `open` hands out before and after the swap. Nothing about the
+allocator enters that check, and it is the only observation that speaks to
+this decision directly. Windows has no equivalent — zwasm's directory handles
+there are not CRT descriptors — so the Windows leg falls back to the probe
+check, whose `recycled` count is structurally `0/64` once the host is retained
+and was `0/64` for one of its four cases before the fix as well. The same
+number before and after means the Windows leg cannot detect a regression in
+this behaviour; Linux and macOS are what guard it. The case does not hide
+this: it prints `recycled` per case, and its header states how to read a zero
+on each platform. Closing the gap needs a Windows-side equivalent of the
+descriptor observation — counting process handles — which is not attempted
+here, because an OS-specific path added to the merge gate without a host to
+validate it trades a false pass for a false failure.
+
+This asymmetry is deliberately recorded here and not in `.dev/debt.yaml` or as
+an issue. The test declares it itself, and a second copy would drift from the
+first (ADR-0216).
+
 ## References
 
 - Issue #314.

--- a/.dev/decisions/0219_captured_wasi_host_lifetime.md
+++ b/.dev/decisions/0219_captured_wasi_host_lifetime.md
@@ -1,0 +1,133 @@
+# 0219 — A captured WASI host outlives the instances that captured it
+
+- **Status**: Accepted
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, wasi, lifetime, store
+
+## Context
+
+`zwasm_store_set_wasi` freed the previously installed host unconditionally,
+while instantiation had already recorded that host's address in state that
+outlives the call. A C host that installed a config, instantiated, and then
+installed a second config left its guest calling into released memory — and
+left the preopened directories the guest was still entitled to use already
+closed. Issue #314.
+
+Two sites capture the address; measured on `5d56a3991`, and they are all of
+them:
+
+| site | what it records | reachable until |
+|---|---|---|
+| `buildBindings` (`src/api/instance.zig`) | each `wasi_snapshot_preview1` import's `host_call.ctx` | **store teardown** |
+| `instantiateJit` (`src/api/instance.zig`) | `jit.owned.rt.wasi_host` | instance delete, or store teardown |
+
+The interp row is the one that decides the shape. `wasm_instance_delete` does
+not free the arena the bindings live in — it parks the runtime + arena on
+`store.zombies` precisely so the instance's funcs stay callable through
+cross-module funcrefs (ADR-0014 §2.1 / 6.K.2 sub-change 4). So "no live
+instance" does not mean "no captor", and the last reference dies with the
+store, not with the instance.
+
+Paths that do NOT capture the store's host, checked rather than assumed: AOT
+(`wasm_module_deserialize` yields an ordinary `Module` and goes through the
+same two sites), the component surface (`src/api/component.zig` `open` takes
+`host: *wasi_host.Host` as an argument, and that file has no `export fn` at
+all), and the Zig facade `Linker`, which owns its own host and says so at
+`src/zwasm/linker.zig:594`.
+
+What made this a defect rather than a documented sharp edge: `include/wasi.h`
+described the ownership transfer and nothing else. It said neither that a
+second call is constrained nor that instantiation records the address. A C
+host writing exactly what the header describes hits the use-after-free.
+
+## Decision
+
+**Release stays immediate while nothing has captured the host; a captured
+host retires and is freed with the Store.**
+
+`Store` gains `wasi_host_captured: bool`, set at the two sites above, and
+`retired_wasi_hosts`, walked and freed by `wasm_store_delete` beside
+`wasi_host`. `zwasm_store_set_wasi` frees the displaced host when the flag is
+clear and retires it when it is set; installing a host clears the flag.
+Passing `null` follows the same rule.
+
+The flag is deliberately never cleared by instance deletion. Clearing it there
+would be wrong for the interp row above: the zombie's parked bindings still
+name the host.
+
+`include/wasi.h` states both halves — that an instance keeps using the config
+that was installed when it was created, and that the config's preopened
+directories stay open until the Store is deleted, so a Store that preopens per
+run should take a new Store per configuration.
+
+## Alternatives considered
+
+**Defer every host to store teardown.** One line shorter and needs no flag.
+Rejected: it retains hosts that no runtime can ever reach. The sequence it
+penalises — install a config, notice it is wrong, install a corrected one,
+*then* instantiate — is the ordinary one, and it is what
+`src/api/instance.zig`'s `zwasm_store_set_wasi(*store, null)` test asserts.
+What it retains there is memory, not fds (see Consequences), but it retains
+it for nothing and it changes what that test means. One bool buys keeping
+both.
+
+**Reference counting.** Correct, and it cannot release any earlier than the
+flag does. The last reference in the interp case is held by the parked zombie
+arena, which `wasm_store_delete` is the only thing that frees — so a refcount's
+release point *is* store teardown, reached through a count on every instance
+create/delete plus a drop path in the zombie reaper. Same lifetime, more
+machinery. Rejected on that ratio, not on correctness. Worth revisiting only
+if the zombie list ever gains a reaper that runs before store teardown.
+
+**Refuse the second call.** `zwasm_store_set_wasi` returns `void`, so there is
+no way to report the refusal; adding a return value breaks the ABI. Reporting
+it out of band would still leave the C host holding a config it must now free
+itself, contradicting the ownership rule the header states, and it would break
+callers that legitimately reconfigure before instantiating — the sequence that
+works today.
+
+## Consequences
+
+**A retired host holds its preopen directory fds until the Store is deleted.**
+Measured on Linux with one `zwasm_wasi_config_preopen_dir` per config, each
+swap followed by an instantiation: the retained-fd count tracks the swap count
+one for one and returns to baseline at `wasm_store_delete`. One fd per preopen
+directory per retired host, linear. The header's "take a new Store per
+configuration" is the advice that follows from it, and it is the reason that
+advice is in the header rather than only here.
+
+This cost is not what distinguishes the decision from the rejected first
+alternative, and the obvious guess about it is wrong: preopens are opened by
+`materializePendingPreopens` at instantiation, and instantiation is exactly
+what captures. An uncaptured host therefore holds no fds at all, and a config
+that never calls `preopen_dir` retires none either way — stdio 0/1/2 are `kind`
+tags in the fd table, not host handles.
+
+**The flag over-marks, and nothing compensates for it.** `buildBindings` also
+runs on the throwaway arena inside `collectHostFuncTargets`, and
+`instantiateJit` sets the flag before `runStart`, which can still fail the
+instantiation. Both leave the flag set with no surviving captor. Over-marking
+only defers a free; it can never produce a dangling pointer, so the correct
+response is to say so at the sites rather than to unwind it.
+
+**An OOM appending to the retire list takes the leak.** `catch {}`, marked
+`EXEMPT-FALLBACK`, on the same reasoning and in the same shape as
+`parkAsZombie`: a leak at store scope is preferable to a use-after-free.
+
+**The downstream workaround can go.** `zwasm/zwasm-rust-sdk`'s
+`Store::set_wasi` and `Store::unset_wasi` refuse after any instantiation, and
+the refusal is permanent for the store's life — deliberately blunter than the
+defect requires, because the store cannot see an instance's imports. Its own
+doc names this issue and says the refusal can go once zwasm defers the free.
+It now can. The SDK change is separate work.
+
+## References
+
+- Issue #314.
+- ADR-0184 — the engine-owned `Host.io` wiring that `zwasm_store_set_wasi`
+  performs alongside the release decided here.
+- ADR-0014 §2.1 / 6.K.2 sub-change 4 — the zombie list, which is why the
+  interp capture outlives its instance.
+- `src/runtime/store.zig` — the `wasi_host` / `wasi_host_captured` /
+  `retired_wasi_hosts` ownership comments carry the rule at the field.

--- a/build.zig
+++ b/build.zig
@@ -1309,6 +1309,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/jit_start.c", .name = "jit_start" }, // D-478 start function under JIT
         .{ .src = "test/c_api_conformance/jit_wasi.c", .name = "jit_wasi" }, // ADR-0200/D-478 WASI host-fn under JIT
         .{ .src = "test/c_api_conformance/wasi_exit_code.c", .name = "wasi_exit_code" }, // a C host reads a WASI exit status
+        .{ .src = "test/c_api_conformance/wasi_host_lifetime.c", .name = "wasi_host_lifetime" }, // a captured WASI host outlives its instances
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/include/wasi.h
+++ b/include/wasi.h
@@ -113,9 +113,17 @@ WASM_API_EXTERN bool zwasm_wasi_config_preopen_dir(
  * config — the C host must not call `zwasm_wasi_config_delete`
  * on the same pointer afterwards.
  *
- * Calling twice on the same Store replaces the previous setup
- * (the old config is freed by the binding). Pass `NULL` to
- * uninstall WASI hosting on a Store.
+ * Calling twice on the same Store replaces the previous setup.
+ * Pass `NULL` to uninstall WASI hosting on a Store.
+ *
+ * An instance created while a config was installed keeps using
+ * THAT config for the rest of its life — instantiation records
+ * the config's address. Replacing or removing the config
+ * therefore does not free it once any instance has been created
+ * since it was installed; it is freed with the Store instead.
+ * Directories it preopened stay open until then, so a long-lived
+ * Store that preopens per run should take a new Store per
+ * configuration rather than re-setting the config.
  */
 WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -290,6 +290,15 @@ pub export fn wasm_store_delete(s: ?*Store) callconv(.c) void {
         host.deinit();
         alloc.destroy(host);
     }
+    // Hosts a `zwasm_store_set_wasi` could not free because an instance
+    // had captured them. Nothing can reach them now: every runtime that
+    // held one is gone with the instances + zombies reaped above.
+    for (handle.retired_wasi_hosts.items) |host_opaque| {
+        const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
+        host.deinit();
+        std.heap.c_allocator.destroy(host);
+    }
+    handle.retired_wasi_hosts.deinit(std.heap.c_allocator);
     alloc.destroy(handle);
 }
 
@@ -323,15 +332,27 @@ fn parkAsZombie(
 /// host on a Store. Ownership of the Host transfers to the
 /// Store; the C host must not call `zwasm_wasi_config_delete`
 /// on the same pointer afterwards. Calling twice on the same
-/// Store frees the previous Host first. Pass `null` to detach
-/// + free the existing Host.
+/// Store frees the previous Host first — UNLESS an instantiation
+/// has already captured it, in which case it retires and is freed
+/// by `wasm_store_delete` (a live instance, or a zombie's parked
+/// bindings, still holds its address). Pass `null` to detach the
+/// existing Host under the same rule.
 pub export fn zwasm_store_set_wasi(s: ?*Store, h: ?*wasi_host.Host) callconv(.c) void {
     const store = s orelse return;
     if (store.wasi_host) |old_opaque| {
-        const old: *wasi_host.Host = @ptrCast(@alignCast(old_opaque));
-        old.deinit();
-        std.heap.c_allocator.destroy(old);
+        if (store.wasi_host_captured) {
+            // EXEMPT-FALLBACK: an append OOM accepts the leak over the
+            // UAF, mirroring parkAsZombie. `c_allocator` is what
+            // `zwasm_wasi_config_new` used for every host this list can
+            // hold, and what `wasm_store_delete` frees them with.
+            store.retired_wasi_hosts.append(std.heap.c_allocator, old_opaque) catch {};
+        } else {
+            const old: *wasi_host.Host = @ptrCast(@alignCast(old_opaque));
+            old.deinit();
+            std.heap.c_allocator.destroy(old);
+        }
     }
+    store.wasi_host_captured = false;
     if (h) |hp| {
         // ADR-0184: hand the engine-owned io to the host so fs
         // syscalls (path_open, preopen materialization) work from
@@ -466,6 +487,12 @@ fn buildBindings(
             if (it.kind != .func) return error.UnsupportedWasiImport;
             const thunk = wasi.lookupWasiThunk(it.name) orelse return error.UnsupportedWasiImport;
             const wasi_host_ptr = store.wasi_host orelse return error.WasiNotConfigured;
+            // The binding outlives this call — and outlives the instance
+            // too, since `wasm_instance_delete` parks the arena holding it
+            // on `store.zombies`. May over-mark (this also runs on the
+            // throwaway arena in `collectHostFuncTargets`); over-marking
+            // only defers a free, so nothing compensates for it.
+            store.wasi_host_captured = true;
             bindings[idx] = .{ .func = .{
                 .host_call = .{ .fn_ptr = thunk, .ctx = wasi_host_ptr },
                 .source = .wasi,
@@ -778,6 +805,9 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
         };
     }
     jit.owned.rt.wasi_host = store.wasi_host;
+    // Captured for the JitInstance's life. May over-mark (this runs before
+    // `runStart`, which can still fail the instantiation) — see buildBindings.
+    if (store.wasi_host != null) store.wasi_host_captured = true;
 
     // Wasm §4.5.4 — run the `(start)` function AFTER setup initialised globals /
     // memory / tables, BEFORE the instance is surfaced. A start trap fails

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -341,10 +341,10 @@ pub export fn zwasm_store_set_wasi(s: ?*Store, h: ?*wasi_host.Host) callconv(.c)
     const store = s orelse return;
     if (store.wasi_host) |old_opaque| {
         if (store.wasi_host_captured) {
-            // EXEMPT-FALLBACK: an append OOM accepts the leak over the
-            // UAF, mirroring parkAsZombie. `c_allocator` is what
-            // `zwasm_wasi_config_new` used for every host this list can
-            // hold, and what `wasm_store_delete` frees them with.
+            // `c_allocator` is what `zwasm_wasi_config_new` used for every
+            // host this list can hold, and what `wasm_store_delete` frees
+            // them with.
+            // EXEMPT-FALLBACK: ADR-0014 — an append OOM accepts the leak over the UAF, mirroring parkAsZombie.
             store.retired_wasi_hosts.append(std.heap.c_allocator, old_opaque) catch {};
         } else {
             const old: *wasi_host.Host = @ptrCast(@alignCast(old_opaque));

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -41,9 +41,25 @@ pub const Store = struct {
     /// Zone 1 (`runtime/`) does not need to import Zone 2
     /// (`wasi/`). The C ABI binding casts back to `*wasi.Host`.
     /// Set via `zwasm_store_set_wasi`; ownership transfers to
-    /// the Store and is freed in `wasm_store_delete`. Null when
-    /// the store has no WASI hosting configured.
+    /// the Store. Freed by `wasm_store_delete`, or by the next
+    /// `zwasm_store_set_wasi` while no instantiation has captured
+    /// it (see `wasi_host_captured`). Null when the store has no
+    /// WASI hosting configured.
     wasi_host: ?*anyopaque = null,
+    /// Set once an instantiation baked `wasi_host`'s address into
+    /// something that outlives the call: the interpreter's per-import
+    /// `host_call.ctx`, or the JIT runtime's own `wasi_host`. A
+    /// captured host can no longer be freed by the next
+    /// `zwasm_store_set_wasi` — it retires onto `retired_wasi_hosts`
+    /// instead. Deliberately NOT cleared when an instance is deleted:
+    /// the interp bindings are parked with the instance's arena on
+    /// `zombies` and stay callable until store teardown. Cleared only
+    /// when a different host is installed.
+    wasi_host_captured: bool = false,
+    /// Hosts displaced by `zwasm_store_set_wasi` while captured.
+    /// `wasm_store_delete` frees each one exactly like `wasi_host`.
+    /// Erased to `*anyopaque` for the same Zone-1 reason.
+    retired_wasi_hosts: std.ArrayList(*anyopaque) = .empty,
     /// Per-Store zombie-instance list (ADR-0014 §2.1 / 6.K.2
     /// sub-change 4). When `instantiateRuntime` traps mid-
     /// element-segment processing, prior writes into a foreign

--- a/test/c_api_conformance/wasi_host_lifetime.c
+++ b/test/c_api_conformance/wasi_host_lifetime.c
@@ -5,21 +5,33 @@
  * instance created in between is the case that decides it: instantiation
  * bakes the host's address into the instance (the interpreter stores it as
  * each `wasi_snapshot_preview1` import's context; the JIT stores it on the
- * runtime the compiled body reads). Freeing the config out from under that
- * instance leaves the guest calling into released memory.
+ * runtime the compiled body reads). Releasing the config out from under
+ * that instance leaves the guest calling into released memory, and closes
+ * the preopened directories the instance is still entitled to use.
  *
- * The check below never reads released memory itself. It stages the
- * allocator instead: right after the second `zwasm_store_set_wasi`, it
- * creates fresh configs of its own, one of which lands on the block a
- * released host would have vacated. Then it runs a guest whose only act is
- * `proc_exit(42)` — a single store into `exit_code`. A config that we own
- * and that no guest has ever run against must not report an exit status.
- * If one does, the guest wrote through a dangling pointer into it.
+ * Nothing below reads released memory. Two independent checks:
  *
- * The staging is the one soft spot: an allocator that does not hand the
- * released block back to the next same-sized request would let this pass
- * without proving anything. It cannot report a false failure, though — the
- * probes are reachable only through the dangling pointer.
+ *   fd (POSIX only) — a released host closes its preopen directory fd, and
+ *     a closed descriptor is the lowest one the next `open` hands out. So
+ *     an `open` before the swap and an `open` after it must return the same
+ *     descriptor. Deterministic: no allocator behaviour involved. Windows
+ *     dir handles are not CRT descriptors, so this check is POSIX-only.
+ *
+ *   probe — right after the swap, the case creates configs of its own, one
+ *     of which lands on the block a released host vacated. Then it runs a
+ *     guest whose only act is `proc_exit(42)`: a single store into
+ *     `exit_code`. A config that we own, and that no guest ever ran
+ *     against, must not report an exit status.
+ *
+ * The probe check depends on the allocator handing the released block back
+ * to one of the next same-sized requests. It cannot report a false failure
+ * — the probes are reachable only through the dangling pointer — but an
+ * allocator that quarantines the block would leave it empty, so it prints
+ * `probes recycled` for every case rather than passing quietly. Read that
+ * number: where it is 0 on POSIX the fd check still holds, and where it is
+ * 0 on Windows this case proved nothing. The first three-OS run recycled on
+ * the first request on Linux and macOS and on the fourth on Windows, which
+ * is what 64 leaves room for.
  *
  * Both engines are covered because they capture the host separately, and
  * both `set_wasi(store, cfg2)` and `set_wasi(store, NULL)` are covered
@@ -31,6 +43,11 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 #include <wasm.h>
 #include <wasi.h>
@@ -51,9 +68,11 @@ static const uint8_t kExitWasm[] = {
     0x0a, 0x08, 0x01, 0x06, 0x00, 0x41, 0x2a, 0x10, 0x00, 0x0b,
 };
 
-/* Enough probes that the released block is covered even if the allocator
- * serves a couple of other same-sized requests first. */
-#define kProbes 4
+/* Windows recycled the released block on the fourth request where Linux and
+ * macOS recycled it on the first, and left the interpreter's cases empty at
+ * four. Wide enough that "0 recycled" means the allocator kept the block,
+ * not that the case gave up early. */
+#define kProbes 64
 
 static const uint8_t kEngines[] = { ZWASM_ENGINE_INTERP, ZWASM_ENGINE_JIT };
 
@@ -62,7 +81,7 @@ static const char* engine_name(uint8_t kind) {
 }
 
 /* `set_wasi(A)` → instantiate → `set_wasi(B or NULL)` → run the guest.
- * Returns 0 when no probe config saw the guest's write. */
+ * Returns 0 when the first config was still whole afterwards. */
 static int run_case(uint8_t engine, bool detach) {
     const char* what = detach ? "set_wasi(NULL)" : "set_wasi(cfg2)";
     int rc = 1;
@@ -72,10 +91,21 @@ static int run_case(uint8_t engine, bool detach) {
     wasm_instance_t* instance = NULL;
     wasm_extern_vec_t exports = { 0, NULL };
     wasm_store_t* probe_stores[kProbes] = { NULL };
+    uintptr_t first_addr = 0;
+    int recycled = 0;
+#ifndef _WIN32
+    int fd_before = -1, fd_after = -1;
+#endif
     if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
 
     zwasm_wasi_config_t* first = zwasm_wasi_config_new();
     if (!first) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    first_addr = (uintptr_t) first;
+    /* Gives the host something to close on release — see the fd check. */
+    if (!zwasm_wasi_config_preopen_dir(first, ".", "/sandbox")) {
+        fputs("preopen_dir failed\n", stderr);
+        goto cleanup;
+    }
     zwasm_store_set_wasi(store, first); /* takes ownership */
 
     wasm_byte_vec_t binary = { sizeof(kExitWasm), (wasm_byte_t*) kExitWasm };
@@ -84,6 +114,7 @@ static int run_case(uint8_t engine, bool detach) {
 
     wasm_extern_vec_t imports = { 0, NULL };
     wasm_trap_t* itrap = NULL;
+    /* Opens the preopen: the host now holds a directory descriptor. */
     instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
     if (itrap) wasm_trap_delete(itrap);
     if (!instance) { fputs("zwasm_instance_new_ex failed\n", stderr); goto cleanup; }
@@ -95,6 +126,13 @@ static int run_case(uint8_t engine, bool detach) {
         if (!probe_stores[i]) { fputs("probe store new failed\n", stderr); goto cleanup; }
     }
 
+#ifndef _WIN32
+    /* The lowest descriptor free right now — above the host's preopen. */
+    fd_before = open("/dev/null", O_RDONLY);
+    if (fd_before < 0) { perror("open /dev/null"); goto cleanup; }
+    close(fd_before);
+#endif
+
     /* The swap. `first` is now unreachable from C, but the instance above
      * still holds its address. */
     if (detach) {
@@ -105,9 +143,17 @@ static int run_case(uint8_t engine, bool detach) {
         zwasm_store_set_wasi(store, second);
     }
 
+#ifndef _WIN32
+    fd_after = open("/dev/null", O_RDONLY);
+    if (fd_after < 0) { perror("open /dev/null"); goto cleanup; }
+    close(fd_after);
+#endif
+
     for (size_t i = 0; i < kProbes; i++) {
         zwasm_wasi_config_t* probe = zwasm_wasi_config_new();
         if (!probe) { fputs("probe config new failed\n", stderr); goto cleanup; }
+        /* Comparing the address only — `first` is never dereferenced. */
+        if ((uintptr_t) probe == first_addr) recycled++;
         zwasm_store_set_wasi(probe_stores[i], probe);
     }
 
@@ -127,6 +173,15 @@ static int run_case(uint8_t engine, bool detach) {
     wasm_trap_delete(trap);
 
     rc = 0;
+#ifndef _WIN32
+    if (fd_after != fd_before) {
+        fprintf(stderr,
+                "[%s] %s: descriptor %d came free across the swap (was %d before) — the "
+                "host closed a preopen its instance is still entitled to use\n",
+                engine_name(engine), what, fd_after, fd_before);
+        rc = 1;
+    }
+#endif
     for (size_t i = 0; i < kProbes; i++) {
         uint32_t code = 0;
         if (zwasm_store_wasi_exit_code(probe_stores[i], &code)) {
@@ -137,6 +192,7 @@ static int run_case(uint8_t engine, bool detach) {
             rc = 1;
         }
     }
+    fprintf(stderr, "[%s] %s: probes recycled %d/%d\n", engine_name(engine), what, recycled, kProbes);
 
 cleanup:
     if (exports.data) wasm_extern_vec_delete(&exports);
@@ -168,11 +224,16 @@ static int run_uncaptured(void) {
 }
 
 int main(void) {
+    int rc = 0;
+    /* Every case runs even after one fails: which engines and which checks
+     * fire is the diagnosis, and on a platform where the probes come up
+     * empty the fd check is the only one that speaks. */
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
-        if (run_case(kEngines[i], false)) return 1;
-        if (run_case(kEngines[i], true)) return 1;
+        rc |= run_case(kEngines[i], false);
+        rc |= run_case(kEngines[i], true);
     }
-    if (run_uncaptured()) return 1;
+    rc |= run_uncaptured();
+    if (rc) return 1;
     puts("zwasm c_api_conformance/wasi_host_lifetime: a captured WASI host outlives its instances");
     return 0;
 }

--- a/test/c_api_conformance/wasi_host_lifetime.c
+++ b/test/c_api_conformance/wasi_host_lifetime.c
@@ -1,0 +1,178 @@
+/* zwasm v2 — a WASI host outlives the instances that captured it.
+ *
+ * `zwasm_store_set_wasi` takes ownership of a config. Calling it a second
+ * time therefore has to decide what happens to the first one, and an
+ * instance created in between is the case that decides it: instantiation
+ * bakes the host's address into the instance (the interpreter stores it as
+ * each `wasi_snapshot_preview1` import's context; the JIT stores it on the
+ * runtime the compiled body reads). Freeing the config out from under that
+ * instance leaves the guest calling into released memory.
+ *
+ * The check below never reads released memory itself. It stages the
+ * allocator instead: right after the second `zwasm_store_set_wasi`, it
+ * creates fresh configs of its own, one of which lands on the block a
+ * released host would have vacated. Then it runs a guest whose only act is
+ * `proc_exit(42)` — a single store into `exit_code`. A config that we own
+ * and that no guest has ever run against must not report an exit status.
+ * If one does, the guest wrote through a dangling pointer into it.
+ *
+ * The staging is the one soft spot: an allocator that does not hand the
+ * released block back to the next same-sized request would let this pass
+ * without proving anything. It cannot report a false failure, though — the
+ * probes are reachable only through the dangling pointer.
+ *
+ * Both engines are covered because they capture the host separately, and
+ * both `set_wasi(store, cfg2)` and `set_wasi(store, NULL)` are covered
+ * because both release the previous host.
+ *
+ * Run by `test-c-api-conformance`.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <wasm.h>
+#include <wasi.h>
+#include <zwasm.h>
+
+/* (module
+ *   (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
+ *   (func (export "_start") (call $exit (i32.const 42)))) */
+static const uint8_t kExitWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x08, 0x02, 0x60, 0x01, 0x7f, 0x00, 0x60, 0x00, 0x00,
+    0x02, 0x24, 0x01,
+    0x16, 0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+    0x09, 0x70, 0x72, 0x6f, 0x63, 0x5f, 0x65, 0x78, 0x69, 0x74,
+    0x00, 0x00,
+    0x03, 0x02, 0x01, 0x01,
+    0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x01,
+    0x0a, 0x08, 0x01, 0x06, 0x00, 0x41, 0x2a, 0x10, 0x00, 0x0b,
+};
+
+/* Enough probes that the released block is covered even if the allocator
+ * serves a couple of other same-sized requests first. */
+#define kProbes 4
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_INTERP, ZWASM_ENGINE_JIT };
+
+static const char* engine_name(uint8_t kind) {
+    return kind == ZWASM_ENGINE_JIT ? "jit" : "interp";
+}
+
+/* `set_wasi(A)` → instantiate → `set_wasi(B or NULL)` → run the guest.
+ * Returns 0 when no probe config saw the guest's write. */
+static int run_case(uint8_t engine, bool detach) {
+    const char* what = detach ? "set_wasi(NULL)" : "set_wasi(cfg2)";
+    int rc = 1;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    wasm_module_t* module = NULL;
+    wasm_instance_t* instance = NULL;
+    wasm_extern_vec_t exports = { 0, NULL };
+    wasm_store_t* probe_stores[kProbes] = { NULL };
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    zwasm_wasi_config_t* first = zwasm_wasi_config_new();
+    if (!first) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, first); /* takes ownership */
+
+    wasm_byte_vec_t binary = { sizeof(kExitWasm), (wasm_byte_t*) kExitWasm };
+    module = wasm_module_new(store, &binary);
+    if (!module) { fputs("wasm_module_new failed\n", stderr); goto cleanup; }
+
+    wasm_extern_vec_t imports = { 0, NULL };
+    wasm_trap_t* itrap = NULL;
+    instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!instance) { fputs("zwasm_instance_new_ex failed\n", stderr); goto cleanup; }
+
+    /* Built before the swap so their allocations cannot compete for the
+     * block the swap releases. */
+    for (size_t i = 0; i < kProbes; i++) {
+        probe_stores[i] = wasm_store_new(eng);
+        if (!probe_stores[i]) { fputs("probe store new failed\n", stderr); goto cleanup; }
+    }
+
+    /* The swap. `first` is now unreachable from C, but the instance above
+     * still holds its address. */
+    if (detach) {
+        zwasm_store_set_wasi(store, NULL);
+    } else {
+        zwasm_wasi_config_t* second = zwasm_wasi_config_new();
+        if (!second) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+        zwasm_store_set_wasi(store, second);
+    }
+
+    for (size_t i = 0; i < kProbes; i++) {
+        zwasm_wasi_config_t* probe = zwasm_wasi_config_new();
+        if (!probe) { fputs("probe config new failed\n", stderr); goto cleanup; }
+        zwasm_store_set_wasi(probe_stores[i], probe);
+    }
+
+    wasm_instance_exports(instance, &exports);
+    if (exports.size < 1 || !exports.data[0] || wasm_extern_kind(exports.data[0]) != WASM_EXTERN_FUNC) {
+        fputs("missing _start export\n", stderr);
+        goto cleanup;
+    }
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t no_res = { 0, NULL };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(exports.data[0]), &no_args, &no_res);
+    if (!trap) {
+        fprintf(stderr, "[%s] %s: proc_exit did not trap, so the guest never called the host\n",
+                engine_name(engine), what);
+        goto cleanup;
+    }
+    wasm_trap_delete(trap);
+
+    rc = 0;
+    for (size_t i = 0; i < kProbes; i++) {
+        uint32_t code = 0;
+        if (zwasm_store_wasi_exit_code(probe_stores[i], &code)) {
+            fprintf(stderr,
+                    "[%s] %s: probe config %zu reports exit status %u — the guest wrote "
+                    "into a host released out from under its instance\n",
+                    engine_name(engine), what, i, code);
+            rc = 1;
+        }
+    }
+
+cleanup:
+    if (exports.data) wasm_extern_vec_delete(&exports);
+    if (instance) wasm_instance_delete(instance);
+    if (module) wasm_module_delete(module);
+    for (size_t i = 0; i < kProbes; i++) {
+        if (probe_stores[i]) wasm_store_delete(probe_stores[i]);
+    }
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+/* Nothing captured the host, so releasing it right away stays correct:
+ * a swap before any instantiation must not retain the first config. */
+static int run_uncaptured(void) {
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); return 1; }
+    for (int i = 0; i < 3; i++) {
+        zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+        if (!cfg) { fputs("wasi config new failed\n", stderr); return 1; }
+        zwasm_store_set_wasi(store, cfg);
+    }
+    zwasm_store_set_wasi(store, NULL);
+    wasm_store_delete(store);
+    wasm_engine_delete(eng);
+    return 0;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (run_case(kEngines[i], false)) return 1;
+        if (run_case(kEngines[i], true)) return 1;
+    }
+    if (run_uncaptured()) return 1;
+    puts("zwasm c_api_conformance/wasi_host_lifetime: a captured WASI host outlives its instances");
+    return 0;
+}


### PR DESCRIPTION
`zwasm_store_set_wasi(store, B)` freed the config `A` that a live instance was
still pointing at (#314), and closed the directories that instance had
preopened. Instantiation records `A`'s address in two places, which are all of
them: each `wasi_snapshot_preview1` import's `host_call.ctx` under the
interpreter (`buildBindings`), and `jit.owned.rt.wasi_host` under the JIT
(`instantiateJit`). AOT reuses the same instantiation path, the component
surface takes its host as an argument, and the Zig-facade `Linker` owns its
own.

`include/wasi.h` documented the ownership transfer and nothing else — neither
that a second call is constrained, nor that instantiation records the address —
so a C host writing what the header describes hit it.

**Release stays immediate while nothing has captured the host.** A `Store` flag
set at the two sites decides; a captured host retires and is freed by
`wasm_store_delete`. The flag is never cleared by instance deletion, because
`wasm_instance_delete` parks the interp bindings with the instance's arena on
`store.zombies` and they stay callable until store teardown. That is also why a
reference count could not release any earlier — its last holder would be the
same zombie. Reasoning and the rejected alternatives: ADR-0219.

**A retired host holds its preopen directory fds until the store dies**, one
per directory, linear in the number of swaps. The header now says so and points
a store that preopens per run at one store per configuration. Note that this
cost is not what rules out deferring *every* host: preopens are opened at
instantiation, which is what captures, so an uncaptured host holds no fds at
all.

The conformance case checks two independent things. On POSIX it compares
descriptor numbers across the swap — a released host closes its preopen, and a
closed descriptor is the next one `open` hands out, so no allocator behaviour is
involved. Everywhere it also creates configs of its own after the swap and
asserts none reports the guest's exit status; that one depends on the released
block being recycled, so it prints how many probes landed rather than passing
quietly when none do. The first three-OS run is what earned that: Windows left
two of the four cases empty at four probes and passed them.

Verified on all three OSes: red before the fix, green after. Note that the
verification leans on the POSIX descriptor check — on Windows the case reads
`0/64` both before and after, so that leg cannot detect a regression in this
behaviour (ADR-0219, Consequences).
