### PR TITLE
fix(capi): classify host-originated traps apart from a guest fault (#331)

### DIFF
--- a/.dev/decisions/0218_host_originated_trap_classification.md
+++ b/.dev/decisions/0218_host_originated_trap_classification.md
@@ -1,6 +1,6 @@
 # 0218 — Classify host-originated traps apart from guest faults
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-08-29
 - **Author**: Junji Takakura
 - **Tags**: c-abi, trap-surface, wasi, jit

--- a/.dev/decisions/0218_host_originated_trap_classification.md
+++ b/.dev/decisions/0218_host_originated_trap_classification.md
@@ -1,0 +1,162 @@
+# 0218 — Classify host-originated traps apart from guest faults
+
+- **Status**: Proposed
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, trap-surface, wasi, jit
+
+## Context
+
+`zwasm_trap_kind` reported `ZWASM_TRAP_UNREACHABLE` (1) for three conditions
+that do not originate in the guest. Measured on `5d56a3991` through the C ABI,
+with the backend asserted so a silent JIT→interp fallback could not disguise the
+result:
+
+| case | auto | jit | interp |
+|---|---|---|---|
+| guest `unreachable` | 1 | 1 | 1 |
+| `proc_exit(0)` / `proc_exit(3)` | 1 | 1 | 0 |
+| host callback trap | 1 | 1 | 1 |
+
+A C host calling plain `wasm_instance_new` gets `auto`, which resolves to the
+JIT, so it could not tell a clean WASI termination from a genuine fault. The
+engines also disagreed about `proc_exit` (1 vs 0), making the answer depend on
+which engine `auto` happened to pick.
+
+Four sites are responsible, not the two that issue #331 names:
+
+1. `proc_exit` in `src/wasi/jit_dispatch.zig` — sets `trap_flag`, leaves
+   `trap_kind` unwritten (0).
+2. `trapResult` in `src/api/jit_host_bridge.zig` — writes the generic bucket (1).
+3. `hostFuncThunk` in `src/api/instance.zig` — returns `Trap.Unreachable`. The
+   interp twin of (2); leaving it would keep the engines disagreeing.
+4. `mapInterpTrap` in `src/api/trap_surface.zig` — has no arm for the
+   `error.WasiExit` that the interp's preview1 `proc_exit` thunk unwinds with,
+   so it falls through `else => .binding_error`. The interp twin of (1), and
+   the one the first draft of this decision missed: with (1) fixed alone the
+   JIT reported 18 while the interp still reported 0, and the cross-engine test
+   stayed red.
+
+Sites (1) and (2) then fall through `jitTrapCode(...) orelse .unreachable_`.
+
+Two distinct number spaces meet here and are easy to confuse: the JIT
+stub-code space recorded in `JitRuntime.trap_kind`, and the public
+`ZWASM_TRAP_*` / `TrapKind` space. They agree only from 14 upward, and by
+coincidence — `unreachable` is stub 5 / public 1, `oob_table` is stub 2 /
+public 6. `trap_surface.jitTrapCode` is the only place the two are related.
+
+This is **not** the D-292 / D-293 codegen widening. That programme demultiplexes
+traps the *codegen* emits; these three never reach codegen.
+
+Timing: `zwasm/zwasm-rust-sdk` has not published 0.2.0. Its `TrapKind` is
+`#[non_exhaustive]` with `Unknown(i32)`, so *adding* a kind never breaks
+downstream — what costs downstream is a value moving between existing variants,
+which is exactly what "`proc_exit` stops reporting `Unreachable`" is.
+
+## Decision
+
+**Host-originated traps get kinds of their own, distinct from any guest fault.**
+
+WASI `proc_exit` reports a new `ZWASM_TRAP_WASI_EXIT` = 18 (`TrapKind.wasi_exit`):
+a guest that asks to terminate has not faulted, and a successful exit least of
+all. The exit status itself stays where ADR-0156-era work and #330 put it —
+`zwasm_store_wasi_exit_code` — so kind and status remain independent. A host
+callback's trap, and any embedder-binding failure, reports `binding_error` (0)
+on every engine: the meaning that kind already carries ("host invocation
+error"), widened rather than invented.
+
+Each engine reaches those two kinds by its own route. The JIT sites write
+dedicated stub codes that `jitTrapCode` maps; the interp maps its own errors —
+`error.WasiExit` to `wasi_exit`, and a new `error.HostTrap` to `binding_error`.
+The `error.WasiExit` arm is what actually closes the cross-engine
+disagreement.
+
+Both JIT sites carry **dedicated stub codes** (18, 19) rather than being folded
+into the generic bucket. The bucket must keep meaning "the codegen has not split
+this trap yet" (D-292); absorbing host-originated traps into it would make the
+still-generic codegen traps report `binding_error` — a different lie.
+
+`runtime.Trap` gains `HostTrap`, in the same spec-external class as `Interrupted`
+and `OutOfFuel`. It flows into `Instance.InvokeError` for free
+(`InvokeError = {...} || Trap`), so the Zig facade gains the same distinction,
+and Zig's exhaustive switches enumerate the mapping sites instead of an `else`
+arm swallowing them.
+
+Existing `ZWASM_TRAP_*` values are unchanged; 18 is appended, per the header's
+append-only-stable declaration.
+
+## Alternatives considered
+
+### Alternative A — host-originated → `binding_error`, no new constant
+
+- **Sketch**: route all three sites to the existing `binding_error` (0). Closes
+  #331, makes the engines agree, adds nothing to the C ABI.
+- **Why rejected**: it files a successful `proc_exit(0)` under "host invocation
+  error", and forces a C host to make a second call
+  (`zwasm_store_wasi_exit_code`) merely to discover that the reported failure
+  was a normal termination. `proc_exit` is the host-originated trap a WASI
+  embedder meets most often, so this is the case the surface should name, not
+  the one it should obscure. The move off `Unreachable` has to happen either
+  way; making it once, straight to the final value, is strictly cheaper than
+  making it twice.
+
+### Alternative B — carry the host callback's own trap detail across the bridge
+
+- **Sketch**: instead of consuming the callback's `*Trap`, forward its `kind`
+  (and ideally its message) to the C surface, so an embedder sees the trap it
+  itself constructed.
+- **Why rejected**: measured, the detail is not *structurally* lost — the
+  callback's `*Trap` is in hand at both host-callback sites with a live `kind`
+  and `message_ptr` and is deliberately deleted. But it cannot travel through
+  `rt.trap_kind`: that field is stub-code space, the callback's kind is public
+  `ZWASM_TRAP_*` space, and the two collide at exactly 0 and 1 — the values a
+  callback most likely carries. Forwarding the kind needs a new `JitRuntime`
+  field; forwarding the message needs new storage and an ownership contract on
+  both paths. Out of proportion to this defect, and fully compatible with this
+  decision if wanted later.
+
+## Consequences
+
+- **Positive**: a C host can distinguish a guest fault, a clean WASI exit, and
+  its own callback's failure, and gets the same answer from every engine. The
+  cross-engine `proc_exit` disagreement (1 vs 0) is closed. The Zig facade maps
+  `wasi_exit` to the existing `error.ProcExit` ("a clean noreturn termination,
+  NOT a wasm trap"), aligning the JIT path with the component-WASI path.
+- **Negative**: a C host switching on `zwasm_trap_kind` sees changed values for
+  every host-originated trap — `proc_exit` moves `1` → `18` on the JIT and
+  `0` → `18` on the interp, and a host callback's trap moves `1` → `0` on both.
+  This is a behaviour change on a public surface, taken deliberately before
+  `zwasm-rust-sdk` 0.2.0 publishes, while nothing downstream observes the old
+  values.
+- **Neutral / follow-ups**:
+  - `include/zwasm.h` grows one constant; `scripts/check_trap_abi_sync.sh`
+    keeps the header and the enum matched by name and value.
+  - One invariant-stating comment changes meaning: `jitTrapToError` describes
+    `trap_kind` as "the stub-recorded code", which stops being true once host
+    thunks write 18 and 19. Its other claims — including "honest pending the
+    per-kind codegen widening" — stay true of the codegen bucket and stay as
+    they are.
+  - Not addressed here: the Zig facade's preview1 `proc_exit` path reaches
+    `mapDispatchErr`, which has no `error.WasiExit` arm and would `@panic`. No
+    known caller reaches it (the facade wires no preview1 host imports), so it
+    is a latent gap rather than a live bug.
+  - Not addressed here: the doc comment at `src/api/zwasm_ext.zig:113` still
+    says `auto` resolves to the interp; measurement says the JIT. Same class as
+    the header claim tracked by #309.
+
+## References
+
+- Issue: zwasm/zwasm#331; the exit-status reader it leaves untouched is
+  zwasm/zwasm#330
+- Related ADRs: ADR-0200 (JIT-backed engine surface, `jitTrapToError`),
+  ADR-0199 (JIT `proc_exit` post-call `trap_flag` check), ADR-0179 (the
+  `interrupted` / `out_of_fuel` precedent for spec-external trap kinds),
+  ADR-0164 (trap/crash diagnostics programme), ADR-0212 D1 (product semantics
+  require maintainer sign-off)
+- Debt: D-292 / D-293 — the codegen generic-bucket widening this decision
+  deliberately does not touch
+- Files: `src/api/trap_surface.zig`, `src/wasi/jit_dispatch.zig`,
+  `src/api/jit_host_bridge.zig`, `src/api/instance.zig`,
+  `src/zwasm/instance.zig`, `src/runtime/trap.zig`, `include/zwasm.h`;
+  tests in `src/api/zwasm_ext.zig` and the `trapKindName` arm in
+  `test/runners/wast_runtime_runner.zig`

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -75,6 +75,9 @@ WASM_API_EXTERN void zwasm_instance_clear_interrupt(wasm_instance_t*);
 #define ZWASM_TRAP_EXPECTED_SHARED_MEMORY 15
 #define ZWASM_TRAP_INTERRUPTED 16
 #define ZWASM_TRAP_OUT_OF_FUEL 17
+/* Host-originated, not a guest fault: the guest called WASI proc_exit. Read the
+ * status itself with zwasm_store_wasi_exit_code(). */
+#define ZWASM_TRAP_WASI_EXIT 18
 WASM_API_EXTERN int32_t zwasm_trap_kind(const wasm_trap_t*);
 
 /* ── Instance helpers ────────────────────────────────────────────────── */

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -1375,10 +1375,13 @@ fn hostFuncThunk(rt: *runtime.Runtime, ctx: *anyopaque) anyerror!void {
     @memset(res_data, .{ .kind = .i32, .of = .{ .i32 = 0 } });
     var args_vec: ValVec = .{ .size = p.params.len, .data = if (p.params.len > 0) args_data.ptr else null };
     var res_vec: ValVec = .{ .size = nr, .data = if (nr > 0) res_data.ptr else null };
-    const trap: ?*Trap = if (p.callback_env) |cb| cb(p.env, &args_vec, &res_vec) else if (p.callback) |cb| cb(&args_vec, &res_vec) else return runtime.Trap.Unreachable;
+    const trap: ?*Trap = if (p.callback_env) |cb| cb(p.env, &args_vec, &res_vec) else if (p.callback) |cb| cb(&args_vec, &res_vec) else return runtime.Trap.HostTrap;
     if (trap) |tr| {
         trap_surface.wasm_trap_delete(tr); // consume the callback's owned trap
-        return runtime.Trap.Unreachable; // surface as a guest trap
+        // #331: host-originated, so NOT `Unreachable` — a C host must be able to
+        // tell its own callback's failure from a guest fault. The interp twin of
+        // `jit_host_bridge.zig`'s trapResult; both surface `binding_error`.
+        return runtime.Trap.HostTrap;
     }
     // A ref-kind result's `of.ref` is owned by the callback/host (it may
     // be a borrowed view, e.g. `wasm_func_as_ref`); read the payload only,

--- a/src/api/jit_host_bridge.zig
+++ b/src/api/jit_host_bridge.zig
@@ -121,7 +121,13 @@ fn argVal(comptime k: Kind, vt: zir.ValType, v: PT(k)) Val {
 /// returned sentinel is discarded.
 fn trapResult(rt: *JitRuntime, comptime r: RetKind) RT(r) {
     rt.trap_flag = 1;
-    rt.trap_kind = 1; // generic (the host callback's own trap detail is consumed)
+    // #331: a dedicated host-originated code, not the generic bucket (1) — the
+    // bucket means "the codegen has not split this trap yet", and this trap did
+    // not come from codegen at all. The callback's own trap object is still
+    // consumed: carrying its kind would need a JitRuntime field of its own,
+    // because this `trap_kind` is stub-code space while the callback's kind is
+    // public `ZWASM_TRAP_*` space, and the two collide at exactly 0 and 1.
+    rt.trap_kind = 19;
     return switch (r) {
         .void => {},
         .i32, .i64, .f32, .f64 => 0,

--- a/src/api/trap_surface.zig
+++ b/src/api/trap_surface.zig
@@ -66,6 +66,11 @@ pub const TrapKind = enum(u32) {
     // `error.OutOfFuel` (per-instruction units); JIT = poll-site-crossing
     // units (prologue + loop back-edges, stub code 17). Same kind either way.
     out_of_fuel = 17,
+    // Issue #331 — a WASI guest called `proc_exit`. Host-originated: the guest
+    // asked to terminate, it did not fault, so it is neither `unreachable_` nor
+    // an embedder failure. The status itself is read out-of-band with
+    // `zwasm_store_wasi_exit_code`; this kind only says which path ended the run.
+    wasi_exit = 18,
 };
 
 /// `wasm_trap_t` — runtime trap surface. Carries the trap kind +
@@ -111,6 +116,7 @@ pub fn trapMessageFor(kind: TrapKind) []const u8 {
         .expected_shared_memory => "expected shared memory",
         .interrupted => "interrupted",
         .out_of_fuel => "all fuel consumed",
+        .wasi_exit => "wasi proc_exit",
     };
 }
 
@@ -140,6 +146,11 @@ pub fn jitTrapCode(code: u32) ?TrapKind {
         15 => .expected_shared_memory, // ADR-0168 wait* on non-shared (callout)
         16 => .interrupted, // ADR-0179 #3a — JIT prologue/back-edge interruption poll stub
         17 => .out_of_fuel, // ADR-0179 #3b — JIT fuel poll stub (prologue/back-edge SUB → negative)
+        // #331 — the two host-originated paths carry their own codes so the
+        // generic bucket keeps meaning "the codegen has not split this yet"
+        // (D-292) rather than absorbing traps the codegen never emitted.
+        18 => .wasi_exit, // `wasi/jit_dispatch.zig` proc_exit
+        19 => .binding_error, // `api/jit_host_bridge.zig` trapResult
         else => null, // 0 unmarked / 1 generic — still-shared bounds kinds (D-293)
     };
 }
@@ -169,6 +180,13 @@ pub fn mapInterpTrap(err: anyerror) TrapKind {
         // Sandboxing (ADR-0179 #3b): interp fuel exhaustion (dispatch.zig
         // per-instruction decrement) — same kind as the JIT's code-17 stub.
         error.OutOfFuel => .out_of_fuel,
+        // #331 — a host callback trapped, or the binding could not complete.
+        error.HostTrap => .binding_error,
+        // #331 — the interp's preview1 `proc_exit` thunk unwinds with this; the
+        // JIT reaches the same kind through stub code 18. Without this arm the
+        // `else` below reports a clean exit as an embedder failure, which is how
+        // the two engines came to disagree (interp 0 vs JIT 1).
+        error.WasiExit => .wasi_exit,
         else => .binding_error,
     };
 }

--- a/src/api/zwasm_ext.zig
+++ b/src/api/zwasm_ext.zig
@@ -303,3 +303,212 @@ test "ADR-0200: zwasm_instance_new_ex(JIT) builds a JIT instance the C path can 
     try testing.expect(capi.wasm_func_call(fc, &args, &results) == null);
     try testing.expectEqual(@as(i32, 5), rdata[0].of.i32);
 }
+
+// ============================================================
+// Host-originated traps vs. a guest fault (issue #331)
+//
+// Three sites raise a trap on the host's behalf rather than on the guest's:
+// WASI `proc_exit`, a `wasm_func_new` callback that returns a trap under the
+// JIT, and the same callback under the interp. All three used to land in the
+// JIT generic bucket / `Trap.Unreachable`, so `zwasm_trap_kind` could not tell
+// them from a guest `unreachable`. These tests pin the separation on every
+// engine, because the interp and the JIT disagreed about `proc_exit` (0 vs 1).
+// ============================================================
+
+const wasi_ext = @import("wasi.zig");
+const extern_new = @import("extern_new.zig");
+const types = @import("types.zig");
+
+/// `zwasm_instance_new_ex` engine selectors (`ZWASM_ENGINE_*` in zwasm.h).
+const engine_auto: u8 = 0;
+const engine_jit: u8 = 1;
+const engine_interp: u8 = 2;
+const all_engines = [_]u8{ engine_auto, engine_jit, engine_interp };
+
+// (module (func (export "f") unreachable)) — a genuine guest fault, the kind
+// every host-originated trap must stay distinguishable from.
+const guest_unreachable_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type ()->()
+    0x03, 0x02, 0x01, 0x00, // func[0]: type 0
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00, // export "f" → funcidx 0
+    0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b, // code: unreachable; end
+};
+
+// (module (import "wasi_snapshot_preview1" "proc_exit" (func (param i32)))
+//   (func (export "main") i32.const <code> call 0))
+// `code` is the single `i32.const` immediate, so a success exit (0) and a
+// failure exit (3) traverse byte-identical code — the point of the test is
+// that they are treated alike, and 0 is the case a naive fix drops.
+fn procExitWasm(comptime code: u8) [80]u8 {
+    return [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        // type: (i32)->() and ()->()
+        0x01, 0x08, 0x02, 0x60, 0x01, 0x7f, 0x00, 0x60,
+        0x00, 0x00,
+        // import "wasi_snapshot_preview1" "proc_exit" func type 0
+        0x02, 0x24, 0x01, 0x16, 0x77, 0x61,
+        0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73,
+        0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76,
+        0x69, 0x65, 0x77, 0x31, 0x09, 0x70, 0x72, 0x6f,
+        0x63, 0x5f, 0x65, 0x78, 0x69, 0x74, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x01, // func[1]: type 1
+        0x07, 0x08, 0x01, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x00, 0x01, // export "main"
+        0x0a, 0x08, 0x01, 0x06, 0x00, 0x41, code, 0x10, 0x00, 0x0b, // i32.const code; call 0
+    };
+}
+
+// (module (import "env" "h" (func)) (func (export "f") call 0)) — the guest
+// calls a host callback that returns a trap.
+const host_callback_trap_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type ()->()
+    0x02, 0x09, 0x01, 0x03, 0x65, 0x6e, 0x76, 0x01, 0x68, 0x00, 0x00, // import env.h
+    0x03, 0x02, 0x01, 0x00, // func[1]: type 0
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x01, // export "f" → funcidx 1
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b, // code: call 0; end
+};
+
+/// A `wasm_func_new_with_env` callback that always traps. `env` is the Store,
+/// which `wasm_trap_new` needs for the message allocation; the runtime takes
+/// ownership of the returned trap.
+fn alwaysTrapCallback(env: ?*anyopaque, args: ?*const ValVec, results: ?*ValVec) callconv(.c) ?*trap_surface.Trap {
+    _ = args;
+    _ = results;
+    var msg = "host callback refused".*;
+    const bv: ByteVec = .{ .size = msg.len, .data = &msg };
+    return trap_surface.wasm_trap_new(@ptrCast(@alignCast(env)), &bv);
+}
+
+/// Assert `engine` really produced the backend it names. Without this a JIT
+/// that silently fell back to the interp would make every cross-engine
+/// assertion below vacuously true. `auto`'s backend is deliberately unpinned —
+/// which engine it picks is documented to change without an API break.
+fn expectBackend(inst: *Instance, engine: u8) !void {
+    if (engine == engine_jit) try testing.expect(inst.jit != null);
+    if (engine == engine_interp) try testing.expect(inst.runtime != null);
+}
+
+/// Run export 0 of `bytes` on `engine` and return its trap kind. `-1` means it
+/// returned without trapping. `exit_out`, when given, receives the WASI exit
+/// status the store recorded (left untouched if none was).
+fn trapKindOfExport0(engine: u8, bytes: []const u8, wire_wasi: bool, exit_out: ?*u32) !i32 {
+    const e = capi.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer capi.wasm_engine_delete(e);
+    const s = capi.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer capi.wasm_store_delete(s);
+    if (wire_wasi) {
+        const cfg = wasi_ext.zwasm_wasi_config_new() orelse return error.ConfigAllocFailed;
+        capi.zwasm_store_set_wasi(s, cfg);
+    }
+    const bv: ByteVec = .{ .size = bytes.len, .data = @constCast(bytes.ptr) };
+    const m = capi.wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer capi.wasm_module_delete(m);
+    const inst = zwasm_instance_new_ex(s, m, null, null, engine) orelse return error.InstanceAllocFailed;
+    defer capi.wasm_instance_delete(inst);
+    try expectBackend(inst, engine);
+
+    var exports: vec.ExternVec = .{ .size = 0, .data = null };
+    capi.wasm_instance_exports(inst, &exports);
+    defer capi.wasm_extern_vec_delete(&exports);
+    const fc = capi.wasm_extern_as_func(exports.data.?[0].?) orelse return error.NotFunc;
+    const args: ValVec = .{ .size = 0, .data = null };
+    var results: ValVec = .{ .size = 0, .data = null };
+    const trap = capi.wasm_func_call(fc, &args, &results);
+    if (exit_out) |p| _ = capi.zwasm_store_wasi_exit_code(s, p);
+    const trap_ptr = trap orelse return -1;
+    defer trap_surface.wasm_trap_delete(trap_ptr);
+    return trap_surface.zwasm_trap_kind(trap_ptr);
+}
+
+/// As `trapKindOfExport0`, but imports a host callback that traps.
+fn trapKindOfHostCallback(engine: u8) !i32 {
+    const e = capi.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer capi.wasm_engine_delete(e);
+    const s = capi.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer capi.wasm_store_delete(s);
+
+    var pv: types.ValTypeVec = undefined;
+    var rv: types.ValTypeVec = undefined;
+    types.wasm_valtype_vec_new_empty(&pv);
+    types.wasm_valtype_vec_new_empty(&rv);
+    const ft = types.wasm_functype_new(&pv, &rv) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    const hf = extern_new.wasm_func_new_with_env(s, ft, alwaysTrapCallback, s, null) orelse return error.FuncNewFailed;
+    defer capi.wasm_func_delete(hf);
+
+    const bv: ByteVec = .{ .size = host_callback_trap_wasm.len, .data = @constCast(&host_callback_trap_wasm) };
+    const m = capi.wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer capi.wasm_module_delete(m);
+    var iarr = [_]?*capi.Extern{extern_new.wasm_func_as_extern(hf)};
+    var imports: vec.ExternVec = .{ .size = iarr.len, .data = &iarr };
+    const inst = zwasm_instance_new_ex(s, m, &imports, null, engine) orelse return error.InstanceAllocFailed;
+    defer capi.wasm_instance_delete(inst);
+    try expectBackend(inst, engine);
+
+    var exports: vec.ExternVec = .{ .size = 0, .data = null };
+    capi.wasm_instance_exports(inst, &exports);
+    defer capi.wasm_extern_vec_delete(&exports);
+    const fc = capi.wasm_extern_as_func(exports.data.?[0].?) orelse return error.NotFunc;
+    const args: ValVec = .{ .size = 0, .data = null };
+    var results: ValVec = .{ .size = 0, .data = null };
+    const trap = capi.wasm_func_call(fc, &args, &results);
+    const trap_ptr = trap orelse return -1;
+    defer trap_surface.wasm_trap_delete(trap_ptr);
+    return trap_surface.zwasm_trap_kind(trap_ptr);
+}
+
+test "#331: a guest `unreachable` reports unreachable_ on every engine" {
+    for (all_engines) |eng| {
+        const kind = try trapKindOfExport0(eng, &guest_unreachable_wasm, false, null);
+        try testing.expectEqual(@as(i32, @intFromEnum(TrapKind.unreachable_)), kind);
+    }
+}
+
+test "#331: proc_exit reports wasi_exit, not unreachable, and exit 0 is treated like exit 3" {
+    const success = procExitWasm(0x00);
+    const failure = procExitWasm(0x03);
+    for (all_engines) |eng| {
+        var code0: u32 = 0xFFFF_FFFF;
+        const kind0 = try trapKindOfExport0(eng, &success, true, &code0);
+        var code3: u32 = 0xFFFF_FFFF;
+        const kind3 = try trapKindOfExport0(eng, &failure, true, &code3);
+
+        // The case a fix that only chases "exit 3" would drop: a successful
+        // exit runs the same path and must classify the same way.
+        try testing.expectEqual(@as(i32, @intFromEnum(TrapKind.wasi_exit)), kind0);
+        try testing.expectEqual(kind0, kind3);
+        // Separable from a guest fault — the whole point of the issue.
+        try testing.expect(kind0 != @as(i32, @intFromEnum(TrapKind.unreachable_)));
+        // The kind carries no exit status; #330's accessor still does (both
+        // directions, so a 0 status is not confused with "nothing recorded").
+        try testing.expectEqual(@as(u32, 0), code0);
+        try testing.expectEqual(@as(u32, 3), code3);
+    }
+}
+
+test "#331: a host callback's trap reports binding_error, not unreachable" {
+    for (all_engines) |eng| {
+        const kind = try trapKindOfHostCallback(eng);
+        try testing.expectEqual(@as(i32, @intFromEnum(TrapKind.binding_error)), kind);
+        try testing.expect(kind != @as(i32, @intFromEnum(TrapKind.unreachable_)));
+    }
+}
+
+test "#331: the three engines agree on every host-originated trap kind" {
+    // The interp reported proc_exit as binding_error(0) while the JIT reported
+    // unreachable_(1); a C host switching on the kind saw a different program
+    // depending on which engine `auto` happened to pick.
+    const success = procExitWasm(0x00);
+    const auto_exit = try trapKindOfExport0(engine_auto, &success, true, null);
+    const jit_exit = try trapKindOfExport0(engine_jit, &success, true, null);
+    const interp_exit = try trapKindOfExport0(engine_interp, &success, true, null);
+    try testing.expectEqual(jit_exit, interp_exit);
+    try testing.expectEqual(jit_exit, auto_exit);
+
+    const jit_cb = try trapKindOfHostCallback(engine_jit);
+    const interp_cb = try trapKindOfHostCallback(engine_interp);
+    try testing.expectEqual(jit_cb, interp_cb);
+    // …and the two host-originated classes stay distinct from each other.
+    try testing.expect(jit_exit != jit_cb);
+}

--- a/src/runtime/trap.zig
+++ b/src/runtime/trap.zig
@@ -66,6 +66,12 @@ pub const Trap = error{
     /// resource control); deterministic (decrements once per executed interp
     /// instruction). Spec reason: "all fuel consumed".
     OutOfFuel,
+    /// A host callback returned a trap, or the embedder binding could not
+    /// complete the call (issue #331). Host-originated: nothing in the guest
+    /// faulted, so this must not be conflated with `Unreachable`. Spec-external,
+    /// same class as `Interrupted` / `OutOfFuel`. Surfaces as `binding_error`
+    /// ("host invocation error") on the C ABI.
+    HostTrap,
 };
 
 /// Per-instruction trace event (Phase 6 / §9.6 / 6.A per ADR-0013).

--- a/src/wasi/jit_dispatch.zig
+++ b/src/wasi/jit_dispatch.zig
@@ -334,6 +334,11 @@ pub fn proc_exit(rt: *JitRuntime, rval: i32) callconv(.c) void {
         const host: *wasi_host_mod.Host = @ptrCast(@alignCast(hp));
         _ = wasi_proc.procExit(host, @bitCast(rval));
     }
+    // #331: mark the unwind host-originated so the C surface does not report a
+    // clean exit as a guest `unreachable`. 18 is the JIT stub-code space, which
+    // is NOT the public `ZWASM_TRAP_*` space — `trap_surface.jitTrapCode` is the
+    // only place the two are related.
+    rt.trap_kind = 18;
     rt.trap_flag = 1;
 }
 

--- a/src/zwasm/instance.zig
+++ b/src/zwasm/instance.zig
@@ -506,10 +506,11 @@ fn mapJitErr(err: _runner.Error, jit: *_runner.JitInstance) Instance.InvokeError
     };
 }
 
-/// ADR-0200 — map the JIT runtime's numeric `trap_kind` (the stub-recorded code)
-/// to the facade `Trap` error. The generic bucket (codes the codegen does not
-/// yet distinguish, D-292) maps to `error.Unreachable` — honest pending the
-/// per-kind codegen widening; `oob_memory` collapses load/store (same D-292 gap).
+/// ADR-0200 — map the JIT runtime's numeric `trap_kind` (recorded by a trap
+/// stub or, for host-originated traps, by a host thunk) to the facade `Trap`
+/// error. The generic bucket (codes the codegen does not yet distinguish,
+/// D-292) maps to `error.Unreachable` — honest pending the per-kind codegen
+/// widening; `oob_memory` collapses load/store (same D-292 gap).
 fn jitTrapToError(code: u32) Instance.InvokeError {
     const kind = _trap_surface.jitTrapCode(code) orelse return error.Unreachable;
     return switch (kind) {
@@ -530,7 +531,8 @@ fn jitTrapToError(code: u32) Instance.InvokeError {
         .expected_shared_memory => error.ExpectedSharedMemory,
         .interrupted => error.Interrupted,
         .out_of_fuel => error.OutOfFuel,
-        .binding_error => error.Unreachable,
+        .wasi_exit => error.ProcExit, // #331 — a clean WASI termination, not a fault
+        .binding_error => error.HostTrap, // #331 — the embedder's own failure
     };
 }
 
@@ -559,6 +561,7 @@ fn mapDispatchErr(err: anyerror) Instance.InvokeError {
         error.ExpectedSharedMemory => error.ExpectedSharedMemory, // Wasm threads (ADR-0168)
         error.Interrupted => error.Interrupted, // host timeout/cancel (ADR-0179 #3a)
         error.OutOfFuel => error.OutOfFuel, // host fuel budget exhausted (ADR-0179 #3b)
+        error.HostTrap => error.HostTrap, // a host callback trapped (#331)
         error.OutOfMemory => error.OutOfMemory,
         // GC heap 4 GiB cap exceeded (huge array.new* / struct.new) — surfaces
         // as the OutOfMemory trap ("allocation size too large"; wasmtime

--- a/test/runners/wast_runtime_runner.zig
+++ b/test/runners/wast_runtime_runner.zig
@@ -989,6 +989,10 @@ fn trapKindName(k: wasm_c_api.TrapKind) []const u8 {
         .expected_shared_memory => "ExpectedSharedMemory", // Wasm threads (ADR-0168)
         .interrupted => "Interrupted", // sandboxing host cancel/timeout (ADR-0179 #3a)
         .out_of_fuel => "OutOfFuel", // sandboxing fuel budget (ADR-0179 #3b)
+        // #331 — host-originated WASI termination. No spec corpus reaches it
+        // (the testsuite imports no WASI), so this name only ever appears in a
+        // mismatch message, where naming the kind beats naming nothing.
+        .wasi_exit => "WasiExit",
     };
 }
 


### PR DESCRIPTION
Closes #331.

`zwasm_trap_kind` returned `ZWASM_TRAP_UNREACHABLE` for three conditions that
never came from the guest. Measured on `5d56a3991`, all three engines:

| case | auto | jit | interp |
|---|---|---|---|
| guest `unreachable` | 1 | 1 | 1 |
| `proc_exit(0)` / `proc_exit(3)` | 1 | 1 | 0 |
| host callback trap | 1 | 1 | **1** |

The issue named two sites; there are three — the interp's own host-callback
path collapses to `unreachable` as well, so fixing only the JIT bridge would
have left the engines disagreeing.

`proc_exit` now reports a new `ZWASM_TRAP_WASI_EXIT` (18). A host callback's
trap and any embedder-binding failure report `binding_error` on every engine —
the meaning the interp already gave `proc_exit`. Both JIT sites carry dedicated
stub codes rather than the generic bucket: that bucket has to keep meaning "the
codegen has not split this trap yet" (D-292), and folding host traps into it
would make the still-generic codegen traps report `binding_error` instead.

Existing `ZWASM_TRAP_*` values are unchanged; 18 is appended per the header's
append-only-stable declaration. `zwasm_store_wasi_exit_code` (#330) is
untouched — the tests assert it still reads back both 0 and 3, so the kind and
the status stay independent.

Not done here: carrying the host callback's own trap kind and message across
the bridge. The callback's `*Trap` is in hand and deliberately deleted, so the
kind is not structurally lost — but `rt.trap_kind` is JIT stub-code space while
the callback's kind is public `ZWASM_TRAP_*` space, and the two collide at
exactly 0 and 1. That needs a new `JitRuntime` field and a message-ownership
contract; it composes on top of this.

Tests cover all three engines, with the backend asserted so a silent JIT→interp
fallback cannot make them vacuous: a guest `unreachable` stays distinct, `exit
0` and `exit 3` classify alike, a host callback's trap is `binding_error`, and
the three engines agree.

ADR-0218 records the decision, the two alternatives rejected, and why the
generic bucket is left alone.

Verified locally: `zig build test-all`, `test-spec`, and `scripts/gate_commit.sh`
(no `--fast`) all green; the `docs/examples/` Zig host still exits 0.
`-Doptimize=ReleaseSafe` crashes twice, both `panic: incorrect alignment` at
`throw_trampoline.zig:283` — that is #323, pre-existing and untouched here.

Not verified locally: macOS and Windows — the 3-OS gate is the first check.
