### PR TITLE
fix(capi): run a host func's callback when it is called directly (#315)

### DIFF
--- a/.dev/decisions/0220_direct_host_func_call.md
+++ b/.dev/decisions/0220_direct_host_func_call.md
@@ -1,0 +1,104 @@
+# 0220 — `wasm_func_call` runs a host func's callback
+
+- **Status**: Accepted
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, host-func, trap-surface
+
+## Context
+
+`wasm_func_call` on a func created by `wasm_func_new[_with_env]` returned NULL —
+no trap, therefore success — without running the callback and without writing
+`results`. The caller read its own uninitialised buffer as a completed call.
+
+Measured on `29026a699`, both directions, through the real C ABI:
+
+| call site | callback runs | `results` written | return |
+|---|:-:|:-:|:-:|
+| guest `call` through the import (`hostFuncThunk`) | yes | yes | trap or null |
+| `wasm_func_call` on the handle | **no** | **no** | **null** |
+
+Nothing at the call site distinguishes the second row from a real success.
+`wasm_func_param_arity` / `wasm_func_result_arity` already answer for a host
+func (`module_introspect.zig:385`), so an embedder that validates its argument
+shape first gets clean answers and then an empty result. wasmtime permits the
+direct call, so ported code compiles, runs, and reports success.
+
+`wasm_func_call` has six `return null` exits. Reachability, measured by walking
+the construction sites rather than reading the guards:
+
+| # | exit | reachable by valid use |
+|---|---|---|
+| 1 | `f orelse` | yes — the documented null-argument discipline |
+| 2 | `handle.instance orelse` | **yes** — `funcNewImpl` sets `instance = null`; this is the defect |
+| 3 | `inst.store orelse` | no — both C-API instance constructors set `.store` non-null and nothing clears it (`.store = null` occurs only in `runtime/instance/instance.zig` unit fixtures) |
+| 4 | `storeAllocator(store) orelse` | no — `wasm_store_new` is the only constructor and always sets an engine; nothing clears it |
+| 5 | `inst.runtime == null` with no JIT | no — the interp constructor sets `runtime`, the JIT constructor sets `jit`; the one `handle.jit = null` is followed immediately by `destroy(handle)` |
+| 6 | `const rt = inst.runtime orelse` | no — dead: the preceding `if (inst.runtime == null)` returns on both arms |
+
+So there is one defect here, not three. Exits 3 and 4 could not return a trap
+in any case: they are the steps that *recover* the allocator a trap needs.
+
+The direct path needs no marshalling. The callback's signature takes
+`(?*const ValVec, ?*ValVec)` — the types `wasm_func_call` was handed. It also
+needs no ownership handling: both sides are the same host, so a ref-kind
+`of.ref` is the caller's own pointer, and zwasm neither mints a `*Ref` view for
+it nor frees one. That is the opposite of `hostFuncThunk`, whose `of.ref`
+comment is about lending a handle *across the guest boundary*; the comment does
+not transfer to this path.
+
+## Decision
+
+Invoke the callback. `wasm_func_call` checks `Func.host` before it dereferences
+`Func.instance` and, when set, calls the callback with the caller's own vecs.
+Two behaviours diverge from `hostFuncThunk` deliberately:
+
+- **The callback's trap is returned unconsumed.** The thunk deletes it and
+  raises a guest trap because a guest frame must fault; a direct call has no
+  guest, so the caller gets the trap object it would have gotten from any other
+  `wasm_func_call`, with the host's own message intact.
+- **No ref handle is minted or freed.** See above.
+
+An arity mismatch traps with `binding_error`, matching what the instance path
+already does for the same mistake. A null `f` still returns null.
+
+## Alternatives considered
+
+### Alternative A — trap instead of running the callback
+
+Return `binding_error` so the direct call fails loudly, declaring the direct
+form out of scope. **Rejected.** It was only worth considering while the fix
+looked expensive; the measurement above says it is not — no marshalling, no
+ownership transfer, no new state. Trapping would also diverge from wasmtime for
+no gain, and the surface wasm-c-api documents is `wasm_func_call(func, …)`, not
+`wasm_func_call(export_of_instance, …)`.
+
+### Alternative B — a `zwasm_func_is_host()` capability query
+
+Let the embedder ask whether a handle is directly callable. **Rejected**: it
+exports the problem. Every C host would have to learn a zwasm-specific
+predicate to avoid a silent wrong answer, and one that forgot would be exactly
+where it started. The issue rejects this itself.
+
+## Consequences
+
+- A C host can call a `wasm_func_new` func directly, as under wasmtime.
+- No behaviour change for the guest→host direction: `hostFuncThunk` is
+  untouched, and its trap-consuming semantics stay as ADR-0218 leaves them.
+- `wasm_func_call` no longer reports success for anything reachable. Exits 3–6
+  remain as defensive `return null`s: 3 and 4 have no allocator to build a trap
+  with, 5 and 6 are unreachable, and none can be triggered from C.
+- The direct path allocates only when it traps, so a host func call on the hot
+  path costs one branch over calling the C function pointer directly.
+
+## References
+
+- Issue: zwasm/zwasm#315. Deliberately untouched neighbours: zwasm/zwasm#331
+  (host-trap classification, ADR-0218), zwasm/zwasm#314 (host lifetime),
+  zwasm/zwasm#337 (marshalling-failure kind inside `hostFuncThunk`)
+- Related ADRs: ADR-0218 (host-originated trap classification — the guest-side
+  twin of this path's trap handling), ADR-0157 (the `handles.zig` carve-out
+  that owns `Func.host` / `HostFuncPayload`), ADR-0109 (host-func marshalling),
+  ADR-0212 D1 (product semantics require maintainer sign-off)
+- Files: `src/api/instance.zig`; tests in `src/api/extern_new.zig` and
+  `test/c_api_conformance/host_func_direct_call.c`

--- a/build.zig
+++ b/build.zig
@@ -1309,6 +1309,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/jit_start.c", .name = "jit_start" }, // D-478 start function under JIT
         .{ .src = "test/c_api_conformance/jit_wasi.c", .name = "jit_wasi" }, // ADR-0200/D-478 WASI host-fn under JIT
         .{ .src = "test/c_api_conformance/wasi_exit_code.c", .name = "wasi_exit_code" }, // a C host reads a WASI exit status
+        .{ .src = "test/c_api_conformance/host_func_direct_call.c", .name = "host_func_direct_call" }, // #315 wasm_func_call on a wasm_func_new func
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/src/api/extern_new.zig
+++ b/src/api/extern_new.zig
@@ -29,6 +29,7 @@ const runtime = @import("../runtime/runtime.zig");
 const memory_backing = @import("../runtime/instance/memory_backing.zig");
 const zir = @import("../ir/zir.zig");
 const trap_surface = @import("trap_surface.zig");
+const module_introspect = @import("module_introspect.zig");
 
 const Extern = instance.Extern;
 const Func = instance.Func;
@@ -1088,4 +1089,208 @@ test "wasm_foreign: new + host_info + as_ref/ref_as_foreign round-trip + finaliz
     wasm_foreign_set_host_info_with_finalizer(f2, &marker, markForeignFinalized);
     wasm_foreign_delete(f2);
     try testing.expect(foreign_test_finalized);
+}
+
+// ----------------------------------------------------------------
+// #315 — `wasm_func_call` on a `wasm_func_new` host func. Before the
+// fix `wasm_func_call` returned null (= success) without running the
+// callback, so the caller read an uninitialised `results` buffer as a
+// successful invocation. These pin that the direct-call path invokes
+// the callback for real, hands the callback's own trap back to the
+// caller unconsumed (UNLIKE the guest-boundary `hostFuncThunk`, which
+// converts it), and rejects an arity mismatch with a trap.
+// ----------------------------------------------------------------
+
+/// (i32) -> (i32) functype for the host-func direct-call tests. The
+/// returned FuncType owns the vecs (`wasm_functype_new` consumes them).
+fn hostFuncI32ToI32(_: void) ?*types.FuncType {
+    var p_arr = [_]?*types.ValType{types.wasm_valtype_new(0)};
+    var r_arr = [_]?*types.ValType{types.wasm_valtype_new(0)};
+    var pv: types.ValTypeVec = undefined;
+    var rv: types.ValTypeVec = undefined;
+    types.wasm_valtype_vec_new(&pv, 1, &p_arr);
+    types.wasm_valtype_vec_new(&rv, 1, &r_arr);
+    return types.wasm_functype_new(&pv, &rv);
+}
+
+var direct_call_env_seen: i32 = 0;
+
+fn addEnvCallback(env: ?*anyopaque, args: ?*const vec.ValVec, results: ?*vec.ValVec) callconv(.c) ?*trap_surface.Trap {
+    const a = args orelse return null;
+    const r = results orelse return null;
+    const bump: *i32 = @ptrCast(@alignCast(env.?));
+    direct_call_env_seen = bump.*;
+    r.data.?[0] = .{ .kind = .i32, .of = .{ .i32 = a.data.?[0].of.i32 + bump.* } };
+    return null;
+}
+
+var trapping_callback_store: ?*instance.Store = null;
+
+fn trappingCallback(args: ?*const vec.ValVec, results: ?*vec.ValVec) callconv(.c) ?*trap_surface.Trap {
+    _ = args;
+    _ = results;
+    var msg = [_]u8{ 'h', 'o', 's', 't', ' ', 's', 'a', 'i', 'd', ' ', 'n', 'o' };
+    const bv: vec.ByteVec = .{ .size = msg.len, .data = &msg };
+    return trap_surface.wasm_trap_new(trapping_callback_store, &bv);
+}
+
+test "#315 wasm_func_call: a wasm_func_new host func runs its callback" {
+    const e = instance.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer instance.wasm_engine_delete(e);
+    const s = instance.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer instance.wasm_store_delete(s);
+
+    const ft = hostFuncI32ToI32({}) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    const hf = wasm_func_new(s, ft, addOneCallback) orelse return error.FuncNewFailed;
+    defer instance.wasm_func_delete(hf);
+
+    // The arity surface already answers for a host func, so an embedder
+    // that pre-validates gets through cleanly — hence the silent zero.
+    try testing.expectEqual(@as(usize, 1), module_introspect.wasm_func_param_arity(hf));
+    try testing.expectEqual(@as(usize, 1), module_introspect.wasm_func_result_arity(hf));
+
+    var args_data = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = 41 } }};
+    const args: vec.ValVec = .{ .size = 1, .data = &args_data };
+    // Poison the result slot: a silent success leaves this untouched.
+    var results_data = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = -12345 } }};
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+
+    try testing.expect(instance.wasm_func_call(hf, &args, &results) == null);
+    try testing.expectEqual(@as(i32, 42), results_data[0].of.i32);
+}
+
+test "#315 wasm_func_call: the with_env host func gets its env" {
+    const e = instance.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer instance.wasm_engine_delete(e);
+    const s = instance.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer instance.wasm_store_delete(s);
+
+    const ft = hostFuncI32ToI32({}) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    var bump: i32 = 10;
+    const hf = wasm_func_new_with_env(s, ft, addEnvCallback, &bump, null) orelse return error.FuncNewFailed;
+    defer instance.wasm_func_delete(hf);
+
+    direct_call_env_seen = 0;
+    var args_data = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = 5 } }};
+    const args: vec.ValVec = .{ .size = 1, .data = &args_data };
+    var results_data = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = -12345 } }};
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+
+    try testing.expect(instance.wasm_func_call(hf, &args, &results) == null);
+    try testing.expectEqual(@as(i32, 10), direct_call_env_seen);
+    try testing.expectEqual(@as(i32, 15), results_data[0].of.i32);
+}
+
+test "#315 wasm_func_call: the callback's own trap reaches the caller unconsumed" {
+    const e = instance.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer instance.wasm_engine_delete(e);
+    const s = instance.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer instance.wasm_store_delete(s);
+
+    const ft = hostFuncI32ToI32({}) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    trapping_callback_store = s;
+    defer trapping_callback_store = null;
+    const hf = wasm_func_new(s, ft, trappingCallback) orelse return error.FuncNewFailed;
+    defer instance.wasm_func_delete(hf);
+
+    var args_data = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = 1 } }};
+    const args: vec.ValVec = .{ .size = 1, .data = &args_data };
+    var results_data: [1]instance.Val = undefined;
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+
+    const trap = instance.wasm_func_call(hf, &args, &results) orelse return error.ExpectedTrap;
+    defer trap_surface.wasm_trap_delete(trap);
+    // The direct path hands the callback's own trap object back — it is
+    // NOT consumed and re-raised as a guest fault the way the guest-
+    // boundary thunk does, so the host's own message survives.
+    var msg: vec.ByteVec = .{ .size = 0, .data = null };
+    trap_surface.wasm_trap_message(trap, &msg);
+    defer vec.wasm_byte_vec_delete(&msg);
+    try testing.expectEqualStrings("host said no", msg.data.?[0..msg.size]);
+}
+
+test "#315 wasm_func_call: an arity mismatch on a host func traps" {
+    const e = instance.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer instance.wasm_engine_delete(e);
+    const s = instance.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer instance.wasm_store_delete(s);
+
+    const ft = hostFuncI32ToI32({}) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    const hf = wasm_func_new(s, ft, addOneCallback) orelse return error.FuncNewFailed;
+    defer instance.wasm_func_delete(hf);
+
+    // Two args for a one-param func.
+    var args_data = [_]instance.Val{
+        .{ .kind = .i32, .of = .{ .i32 = 1 } },
+        .{ .kind = .i32, .of = .{ .i32 = 2 } },
+    };
+    const args: vec.ValVec = .{ .size = 2, .data = &args_data };
+    var results_data: [1]instance.Val = undefined;
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+    const t1 = instance.wasm_func_call(hf, &args, &results) orelse return error.ExpectedTrap;
+    trap_surface.wasm_trap_delete(t1);
+
+    // Zero result slots for a one-result func.
+    var ok_args = [_]instance.Val{.{ .kind = .i32, .of = .{ .i32 = 1 } }};
+    const args1: vec.ValVec = .{ .size = 1, .data = &ok_args };
+    var no_results: vec.ValVec = .{ .size = 0, .data = null };
+    const t2 = instance.wasm_func_call(hf, &args1, &no_results) orelse return error.ExpectedTrap;
+    trap_surface.wasm_trap_delete(t2);
+}
+
+test "#315 wasm_func_call: a null func handle still returns null, not a trap" {
+    var results_data: [1]instance.Val = undefined;
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+    try testing.expect(instance.wasm_func_call(null, null, &results) == null);
+}
+
+var ref_passthrough_seen: ?*anyopaque = null;
+var ref_passthrough_out: u32 = 0;
+
+fn refEchoCallback(args: ?*const vec.ValVec, results: ?*vec.ValVec) callconv(.c) ?*trap_surface.Trap {
+    ref_passthrough_seen = args.?.data.?[0].of.ref;
+    results.?.data.?[0] = .{ .kind = .anyref, .of = .{ .ref = @ptrCast(&ref_passthrough_out) } };
+    return null;
+}
+
+test "#315 wasm_func_call: a ref-kind val is passed through, not owned" {
+    const e = instance.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer instance.wasm_engine_delete(e);
+    const s = instance.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer instance.wasm_store_delete(s);
+
+    // (externref) -> (externref)
+    var p_arr = [_]?*types.ValType{types.wasm_valtype_new(128)};
+    var r_arr = [_]?*types.ValType{types.wasm_valtype_new(128)};
+    var pv: types.ValTypeVec = undefined;
+    var rv: types.ValTypeVec = undefined;
+    types.wasm_valtype_vec_new(&pv, 1, &p_arr);
+    types.wasm_valtype_vec_new(&rv, 1, &r_arr);
+    const ft = types.wasm_functype_new(&pv, &rv) orelse return error.FuncTypeAllocFailed;
+    defer types.wasm_functype_delete(ft);
+    const hf = wasm_func_new(s, ft, refEchoCallback) orelse return error.FuncNewFailed;
+    defer instance.wasm_func_delete(hf);
+
+    // A host-owned object, NOT a zwasm handle. Both sides of a direct call
+    // are the same host, so the direct path mints no `*Ref` view for the
+    // callback and frees none afterwards — unlike the guest-boundary
+    // `hostFuncThunk`, which lends an owned handle and deletes it. If that
+    // discipline leaked into this path, this pointer would be freed here.
+    var host_owned: u64 = 0xfeed;
+    ref_passthrough_seen = null;
+    var args_data = [_]instance.Val{.{ .kind = .anyref, .of = .{ .ref = @ptrCast(&host_owned) } }};
+    const args: vec.ValVec = .{ .size = 1, .data = &args_data };
+    var results_data: [1]instance.Val = undefined;
+    var results: vec.ValVec = .{ .size = 1, .data = &results_data };
+
+    try testing.expect(instance.wasm_func_call(hf, &args, &results) == null);
+    // The callback saw the caller's own pointer, unwrapped.
+    try testing.expectEqual(@as(?*anyopaque, @ptrCast(&host_owned)), ref_passthrough_seen);
+    try testing.expectEqual(@as(u64, 0xfeed), host_owned);
+    // And the caller got the callback's pointer back, unwrapped.
+    try testing.expectEqual(@as(?*anyopaque, @ptrCast(&ref_passthrough_out)), results_data[0].of.ref);
 }

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -2002,6 +2002,9 @@ pub export fn wasm_func_call(
     results: ?*ValVec,
 ) callconv(.c) ?*Trap {
     const handle = f orelse return null;
+    // #315: a `wasm_func_new[_with_env]` func has no instance — the C callback
+    // IS its body, so invoke it here rather than reporting a silent success.
+    if (handle.host) |hp| return hostFuncCallDirect(handle, hp, args, results);
     const inst = handle.instance orelse return null;
     const store = inst.store orelse return null;
     const alloc = storeAllocator(store) orelse return null;
@@ -2068,6 +2071,32 @@ pub export fn wasm_func_call(
     };
     rt.operand_len = op_base;
     return null;
+}
+
+/// #315 — `wasm_func_call` on a host func created by `wasm_func_new[_with_env]`
+/// (no instance, no guest frame). Nothing is marshalled: the callback's
+/// `(args, results)` ABI is the one `wasm_func_call` was handed, and neither
+/// vec nor any ref-kind `of.ref` inside one is owned by zwasm on this path —
+/// both sides are the same host. Two DIVERGENCES from `hostFuncThunk`, which
+/// serves the guest boundary: the callback's trap is returned to the caller
+/// unconsumed (there is no guest to fault), and no arg ref handle is minted or
+/// freed. Arity mismatch traps, matching the instance path.
+fn hostFuncCallDirect(
+    handle: *const Func,
+    hp: *HostFuncPayload,
+    args: ?*const ValVec,
+    results: ?*ValVec,
+) ?*Trap {
+    const store = handle.store;
+    const alloc = if (store) |s| storeAllocator(s) else null;
+    const args_size = if (args) |a| a.size else 0;
+    const results_size = if (results) |r| r.size else 0;
+    if (args_size != hp.params.len or results_size != hp.results.len) {
+        return if (alloc) |al| allocTrap(al, store, .binding_error) else null;
+    }
+    if (hp.callback_env) |cb| return cb(hp.env, args, results);
+    if (hp.callback) |cb| return cb(args, results);
+    return if (alloc) |al| allocTrap(al, store, .binding_error) else null;
 }
 
 /// ADR-0200 — cast the Zone-1 `Instance.jit` opaque slot to the engine type at

--- a/test/c_api_conformance/host_func_direct_call.c
+++ b/test/c_api_conformance/host_func_direct_call.c
@@ -1,0 +1,149 @@
+/* zwasm v2 — C-API conformance: calling a host func directly (#315)
+ *
+ * `callback.c` covers the guest->host direction: a `wasm_func_new` func
+ * passed as an import and reached through the guest's `call`. This covers
+ * the direction a C host reaches for when it wants to invoke that same
+ * func itself — `wasm_func_call` straight on the handle, no instance in
+ * between. wasmtime permits it, so ported code compiles and runs; before
+ * #315 zwasm returned NULL (= no trap = success) without running the
+ * callback, leaving `results` untouched. That is invisible from the call
+ * site, which is why it gets a C-side test and not only a Zig one.
+ *
+ * Three things are pinned here:
+ *   1. the callback actually runs and writes `results`;
+ *   2. a trap the callback returns reaches the caller with ITS OWN
+ *      message — the direct path does not consume it the way the
+ *      guest-boundary thunk does;
+ *   3. an arity mismatch traps rather than silently doing nothing.
+ *
+ * Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <wasm.h>
+
+/* host callback: results[0] = args[0] + 1 */
+static wasm_trap_t* add_one(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    results->data[0].kind = WASM_I32;
+    results->data[0].of.i32 = args->data[0].of.i32 + 1;
+    return NULL;
+}
+
+/* host callback with env: results[0] = args[0] + *(int*)env */
+static wasm_trap_t* add_env(void* env, const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    results->data[0].kind = WASM_I32;
+    results->data[0].of.i32 = args->data[0].of.i32 + *(int32_t*) env;
+    return NULL;
+}
+
+static const char kRefusal[] = "host refused";
+static wasm_store_t* g_store = NULL;
+
+/* host callback that fails: hands back an owned trap of its own making */
+static wasm_trap_t* refuse(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    (void) args;
+    (void) results;
+    wasm_byte_vec_t msg = { sizeof(kRefusal) - 1, (wasm_byte_t*) kRefusal };
+    return wasm_trap_new(g_store, &msg);
+}
+
+int main(void) {
+    int rc = 1;
+    wasm_engine_t* engine = wasm_engine_new();
+    wasm_store_t* store = engine ? wasm_store_new(engine) : NULL;
+    wasm_functype_t* ft_plain = NULL;
+    wasm_functype_t* ft_env = NULL;
+    wasm_functype_t* ft_refuse = NULL;
+    wasm_func_t* plain_fn = NULL;
+    wasm_func_t* env_fn = NULL;
+    wasm_func_t* refuse_fn = NULL;
+    if (!engine || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+    g_store = store;
+
+    ft_plain = wasm_functype_new_1_1(wasm_valtype_new(WASM_I32), wasm_valtype_new(WASM_I32));
+    plain_fn = wasm_func_new(store, ft_plain, add_one);
+    if (!plain_fn) { fputs("wasm_func_new failed\n", stderr); goto cleanup; }
+
+    /* The arity surface answers for a host func, so an embedder that
+     * pre-validates its argument shape gets clean answers here and then
+     * an empty result — the reason #315 is invisible from the call site. */
+    if (wasm_func_param_arity(plain_fn) != 1 || wasm_func_result_arity(plain_fn) != 1) {
+        fputs("host func arity wrong\n", stderr);
+        goto cleanup;
+    }
+
+    /* 1. the callback runs. Poison `results` first: a silent success
+     *    leaves it exactly as it was. */
+    wasm_val_t args_data[2] = {
+        { .kind = WASM_I32, .of = { .i32 = 41 } },
+        { .kind = WASM_I32, .of = { .i32 = 0 } },
+    };
+    wasm_val_vec_t args = { 1, args_data };
+    wasm_val_t results_data[1] = { { .kind = WASM_I32, .of = { .i32 = -12345 } } };
+    wasm_val_vec_t results = { 1, results_data };
+
+    wasm_trap_t* trap = wasm_func_call(plain_fn, &args, &results);
+    if (trap) { fputs("direct host call trapped\n", stderr); wasm_trap_delete(trap); goto cleanup; }
+    if (results_data[0].kind != WASM_I32 || results_data[0].of.i32 != 42) {
+        fprintf(stderr, "direct host call: expected 42, got %d\n", results_data[0].of.i32);
+        goto cleanup;
+    }
+    printf("zwasm c_api_conformance/host_func_direct_call: h(41) = %d\n", results_data[0].of.i32);
+
+    /* the _with_env form reaches its env the same way */
+    int32_t bump = 10;
+    ft_env = wasm_functype_new_1_1(wasm_valtype_new(WASM_I32), wasm_valtype_new(WASM_I32));
+    env_fn = wasm_func_new_with_env(store, ft_env, add_env, &bump, NULL);
+    if (!env_fn) { fputs("wasm_func_new_with_env failed\n", stderr); goto cleanup; }
+    args_data[0].of.i32 = 5;
+    results_data[0].of.i32 = -12345;
+    trap = wasm_func_call(env_fn, &args, &results);
+    if (trap) { fputs("direct env host call trapped\n", stderr); wasm_trap_delete(trap); goto cleanup; }
+    if (results_data[0].of.i32 != 15) {
+        fprintf(stderr, "direct env host call: expected 15, got %d\n", results_data[0].of.i32);
+        goto cleanup;
+    }
+
+    /* 2. the callback's own trap reaches the caller, message intact */
+    ft_refuse = wasm_functype_new_1_1(wasm_valtype_new(WASM_I32), wasm_valtype_new(WASM_I32));
+    refuse_fn = wasm_func_new(store, ft_refuse, refuse);
+    if (!refuse_fn) { fputs("wasm_func_new (refuse) failed\n", stderr); goto cleanup; }
+    trap = wasm_func_call(refuse_fn, &args, &results);
+    if (!trap) { fputs("refusing host callback reported success\n", stderr); goto cleanup; }
+    wasm_byte_vec_t msg = { 0, NULL };
+    wasm_trap_message(trap, &msg);
+    int msg_ok = msg.data && msg.size == sizeof(kRefusal) - 1 &&
+                 memcmp(msg.data, kRefusal, msg.size) == 0;
+    if (msg.data) wasm_byte_vec_delete(&msg);
+    wasm_trap_delete(trap);
+    if (!msg_ok) { fputs("host trap message did not survive the call\n", stderr); goto cleanup; }
+
+    /* 3. an arity mismatch traps */
+    wasm_val_vec_t two_args = { 2, args_data };
+    trap = wasm_func_call(plain_fn, &two_args, &results);
+    if (!trap) { fputs("arity mismatch reported success\n", stderr); goto cleanup; }
+    wasm_trap_delete(trap);
+
+    /* a null handle keeps the existing null-argument discipline */
+    if (wasm_func_call(NULL, &args, &results) != NULL) {
+        fputs("null func handle produced a trap\n", stderr);
+        goto cleanup;
+    }
+
+    rc = 0;
+
+cleanup:
+    if (refuse_fn) wasm_func_delete(refuse_fn);
+    if (env_fn) wasm_func_delete(env_fn);
+    if (plain_fn) wasm_func_delete(plain_fn);
+    if (ft_refuse) wasm_functype_delete(ft_refuse);
+    if (ft_env) wasm_functype_delete(ft_env);
+    if (ft_plain) wasm_functype_delete(ft_plain);
+    if (store) wasm_store_delete(store);
+    if (engine) wasm_engine_delete(engine);
+    return rc;
+}


### PR DESCRIPTION
Closes #315.

`wasm_func_call` on a func created by `wasm_func_new[_with_env]` returned NULL
— no trap, therefore success — without running the callback and without writing
`results`. The caller read its own uninitialised buffer as a completed call.
wasmtime permits the direct call, so ported code compiles, runs, and reports
success.

Measured on `29026a699` through the real C ABI:

| call site | callback runs | `results` written | return |
|---|:-:|:-:|:-:|
| guest `call` through the import | yes | yes | trap or null |
| `wasm_func_call` on the handle | no | no | null |

`wasm_func_param_arity` / `wasm_func_result_arity` already answer for a host
func, so an embedder that validates its argument shape first gets clean answers
and then an empty result.

The fix invokes the callback. No marshalling is involved — the callback's
`(args, results)` ABI is the one `wasm_func_call` was handed — and no ownership
moves, since both sides are the same host. Two deliberate divergences from
`hostFuncThunk`, which serves the guest boundary: the callback's trap goes back
to the caller unconsumed, and no ref handle is minted or freed. The thunk itself
is untouched.

The issue's alternative — trap on a direct call — is rejected in ADR-0220: it
was only worth considering while the fix looked expensive, and the measurement
says it is not. The capability-query alternative is rejected as exporting the
problem, which the issue says itself.

The other five `return null` exits are unreachable from C (table in the ADR);
two of them are the steps that recover the allocator a trap would need.

Tests: six Zig cases in `src/api/extern_new.zig` (both callback forms, trap
pass-through, arity mismatch, null handle, ref pass-through) and a C host in
`test/c_api_conformance/host_func_direct_call.c`, which fails with
`expected 42, got -12345` without the fix.

Rebased onto `c47a00b2f` (#334) and re-verified there. On x86_64-linux:
`zig fmt --check src/`, `scripts/gate_commit.sh`,
`zig build test-all`, `test-c-api-conformance`, `test-c-api`, `run-zig-host`,
`run-zig-host-jit`, `run-rust-host`, and ReleaseSafe. ReleaseSafe crashes two
`engine.runner_test` EH cases — reproduced identically on clean `29026a699`,
so it is #323, not this change. macOS and Windows are not available here; the
3-OS gate is their first check.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zwasm/zwasm/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->