### PR TITLE
feat(capi): let a C host read the runtime's version (#237)

### DIFF
--- a/.dev/decisions/0221_capi_version_accessor_scope.md
+++ b/.dev/decisions/0221_capi_version_accessor_scope.md
@@ -1,0 +1,214 @@
+# 0221 — Expose the runtime version to C as semver alone, by function alone
+
+- **Status**: Accepted
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, versioning, distribution
+
+## Context
+
+`include/zwasm.h` has no way to ask the linked library what it is, so a C
+consumer cannot report the runtime version it is running against. The value
+itself already exists and is already threaded: `build.zig:110` reads
+`.version` out of `build.zig.zon` and injects it as `build_options.version`
+(again at `:472` and `:522` for the component and p3 modules);
+`src/zwasm.zig:39` re-exports it as `zwasm.version`, and `src/cli/cache.zig:51`
+puts it in the cache directory name. Nothing carries it across the C boundary.
+
+Issue #237 left two questions open, and both turn on facts about how zwasm is
+actually distributed and consumed rather than on taste. Those facts were
+checked rather than assumed:
+
+**There is no distribution shape in which a header and a library can come from
+different commits.** `build.zig:1241` declares the only library, and its
+`.linkage` is `.static`; there is no shared-library step. `zig build static-lib`
+(`build.zig:1270`–`1282`) installs `libzwasm.a` and `wasm.h` / `wasi.h` /
+`zwasm.h` into one prefix out of one checkout. `.github/workflows/release.yml`
+publishes the CLI executable only — no archive, no headers — so a release
+carries no C surface at all. There is no distro packaging.
+
+**The one downstream C consumer builds the library from the header's own
+commit.** `zwasm-rust-sdk`'s `crates/zwasm-sys` vendors this repository as a git
+submodule (`.gitmodules`: `crates/zwasm-sys/zwasm`), runs `zig build static-lib`
+inside it (`build.rs:112`–`122`) and links `static=zwasm` (`build.rs:134`), with
+bindgen generating the Rust bindings from that same `zwasm.h`
+(`build.rs:6`, `:44`). `containerd-shim-zwasm` reaches zwasm only through that
+SDK. So header and library are the same commit by construction, and the
+mismatch a version macro would detect cannot occur.
+
+**`include/zwasm.h` is hand-authored.** Nothing generates it —
+`scripts/fetch_wasm_c_api.sh` fetches `wasm.h` from upstream and leaves
+`zwasm.h` alone. This is the difference from wasmtime, whose header is
+generated per release and therefore cannot drift from its manifest.
+
+**No consumer maps a capability axis yet.** `zwasm-sys` passes only `-Dtarget`,
+`-Dcompiler-rt` and `-Doptimize` to `zig build static-lib`; neither
+`zwasm-sys/Cargo.toml` nor the workspace declares a `[features]` section. The
+identity consumer named in the issue — the SDK mapping `-Dgc` / `-Dcomponent`
+onto cargo features — is real but not yet present, and its arrival is
+observable in exactly those two files.
+
+## Decision
+
+**One function, semver alone.**
+
+`const char* zwasm_version(void)` in `include/zwasm.h`, implemented as
+`zwasm_version` in `src/api/zwasm_ext.zig` beside the other zwasm-only
+extensions. It returns `build_options.version` in static storage, never NULL,
+and the caller never frees it.
+
+`build_options.version` is a `[]const u8` with no terminator, so returning its
+`.ptr` would hand C an unterminated pointer. The accessor re-materialises the
+same comptime bytes as a sentinel-terminated array with
+`std.fmt.comptimePrint`, which lives in the binary's constant data for the
+process's life. This is the first `[*:0]const u8` export in `src/api/`; there
+was no house form to copy.
+
+**Macros (`ZWASM_VERSION`, `ZWASM_VERSION_MAJOR`, …) are deferred** until a
+distribution exists in which a header and a library can arrive separately.
+When they ship, the sync gate that keeps them equal to `build.zig.zon` ships in
+the same PR.
+
+**Numeric accessors (`zwasm_version_major()` and friends) are deferred** until
+a consumer wants runtime gating.
+
+**Build identity is deferred**, and when it ships it ships as one accessor per
+axis rather than one composed string — the one-function-per-capability shape
+discussion #209 settled. The trigger is concrete: the SDK growing a
+`[features]` section that maps `-Dgc` / `-Dcomponent`.
+
+Recorded beside that defer, because it is the cost of it: deferring identity
+delays diagnosis, not prevention. A consumer linking a `-Dwasi=p1` build and
+reading `"2.5.0"` can believe it holds everything that version implies. In
+practice a link error or a runtime failure surfaces first, which is why this
+does not overturn the defer — but the header says so in as many words, so the
+belief is at least contradicted in the place the consumer reads.
+
+## Alternatives considered
+
+### Alternative A — ship macros alongside the function
+
+- **Sketch**: `#define ZWASM_VERSION "2.5.0"` (and the numeric triple) next to
+  the accessor, so a consumer can compare the header it compiled against with
+  the library it linked.
+- **Why rejected**: the mismatch it detects is unreachable today — every
+  distribution path above ships header and library from one checkout. Against
+  that, a hand-authored header with baked numbers is dual maintenance with
+  `build.zig.zon`, which is the rot ADR-0216 argues against, and the only
+  honest fix is a gate that re-reads the manifest and compares. That gate is a
+  larger artifact than the accessor it guards. Macros are purely additive on a
+  pre-1.0 surface, so deferring costs only the date on which mismatch
+  detection becomes available.
+
+### Alternative B — numeric accessors instead of (or beside) the string
+
+- **Sketch**: `zwasm_version_major()` / `_minor()` / `_patch()`, the shape
+  wasmedge uses. They read `build_options` exactly as the string accessor does,
+  so they carry no drift risk.
+- **Why rejected**: nothing is asking to gate on a version at runtime. The
+  string answers the stated need — a C host reporting what it links, so a bug
+  report can name it — and parsing `"2.5.0"` is not the obstacle that would
+  make a consumer ask. Deferring keeps the surface at one symbol; the numeric
+  form remains available without breaking anything, since it is additive.
+
+### Alternative C — build identity in this change
+
+- **Sketch**: answer what `zwasm --version` answers —
+  `wasm: <level>, wasi: <level>, engine: <default>` — either as the CLI's
+  composed line or as per-axis accessors.
+- **Why rejected**: this is the project's own bar, applied in #209 to both the
+  invoke hook and wasi:otel — the C API grows when a consumer asks. No consumer
+  asks yet, and the check above says so from the consumer's own source rather
+  than from belief. Shipping the composed string would additionally be the
+  wrong shape to be stuck with: it is a string a consumer must parse, where
+  #209 settled on machine-readable per-capability functions. The cost of
+  waiting is recorded above rather than dismissed.
+
+### Alternative D — return the unterminated `.ptr` and document a length
+
+- **Sketch**: hand C `build_options.version.ptr` and expose the length
+  separately, avoiding the sentinel question altogether.
+- **Why rejected**: it makes every caller's `printf("%s")` undefined behaviour
+  — the shape a C consumer will reach for first. A NUL-terminated `const char*`
+  is what the header's other string-shaped neighbours in `wasm.h` imply, and
+  the terminator costs one comptime byte.
+
+## Consequences
+
+- **Positive**: a C host can print the runtime version of the library it
+  linked, which is what a bug report needs. `zwasm-rust-sdk` picks the symbol
+  up with no work — bindgen regenerates from the same header. The accessor
+  reads the same `build_options.version` as the CLI and the cache directory,
+  so there is exactly one place the version lives.
+- **Negative**: the answer does not distinguish builds that are not
+  interchangeable, and the failure mode of that is recorded above rather than
+  solved. Consumers who want identity wait for a follow-up.
+- **Neutral / follow-ups**:
+  - `include/zwasm.h` grows one declaration. No existing symbol, value or
+    signature changes; `scripts/test_extlink.sh` derives its symbol set from
+    the headers, so the new export is required of the archive automatically.
+  - `zwasm --version` is untouched: the CLI keeps printing identity, and the C
+    API deliberately answers less. The two surfaces now disagree in scope, on
+    purpose.
+  - The change is tested from both sides, because neither side can cover the
+    other. `test/c_api_conformance/version.c` is the shape a new public C
+    function takes here — the precedent is #330's `wasi_exit_code.c` — and it
+    holds three things nothing else does:
+    1. `include/zwasm.h`'s declaration agrees with the export. Compiling this
+       file against the header and linking it against `libzwasm.a` is what
+       catches a wrong return type or linkage in the header.
+    2. A C translation unit reaches the symbol at all.
+    3. The storage is stable: the same pointer on every call, unchanged across
+       unrelated runtime activity, nothing to free — the ownership the header
+       claims.
+    `scripts/test_extlink.sh` does not substitute for any of them: it proves
+    an external toolchain can link the archive, not that the declaration
+    matches the implementation. The Zig test in `src/api/zwasm_ext.zig` owns
+    the other half — the string equals `build.zig.zon`'s `.version`.
+  - Neither test proves the terminator, and both say so. The sentinel is a
+    compile-time guarantee of the `[*:0]const u8` return type: `return
+    build_options.version.ptr;` does not compile ("destination pointer
+    requires '0' sentinel"), so only an explicit `@ptrCast` defeats it.
+    Measured on x86_64-linux, Zig 0.16.0: a build carrying that cast still
+    reads back `"2.5.0"` with `strlen` 5 from C, because the byte following
+    the version in constant data happens to be 0. A runtime test cannot
+    distinguish the two here, and claiming otherwise would be a hollow gate —
+    so the claim is written down at its real strength instead.
+  - That Zig test compares two different *readings* of the manifest, which is
+    why it is not tautological: the accessor's value is `.version` as
+    `build.zig`'s `@import("build.zig.zon")` parsed it at build time, and the
+    expectation is the same field read off disk at test time. Comparing
+    against `build_options.version` instead would compare the injection with
+    itself; transcribing `"2.5.0"` would be the dual maintenance this decision
+    rejects macros for. Its reach is correspondingly narrow and worth stating
+    exactly: it catches a stale `build_options` that was not regenerated, and
+    an accessor that later grows a hardcoded string. Both are small, and both
+    are real.
+  - The manifest cannot be reached at comptime:
+    `@embedFile("../../build.zig.zon")` from `src/api/` is rejected with
+    "embed of file outside package path", because the root module is
+    `src/zwasm.zig` and the package root is therefore `src/` (measured on Zig
+    0.16.0). The read is a runtime one, so the test requires CWD = the
+    repository root. That requirement is stated in the test's own doc comment
+    and a wrong CWD fails by a named error rather than silently — an
+    environment-dependent check that goes quiet is the failure mode #327 and
+    #268 are about.
+
+## References
+
+- Issue: zwasm/zwasm#237
+- Related ADRs: ADR-0216 (a value duplicated between two files rots; the ledger
+  case for the same argument), ADR-0212 D1 (a change to product semantics needs
+  maintainer sign-off — this ADR is that record), ADR-0214 (the `static-lib`
+  target C and Rust consumers build), ADR-0156 (the v2 C surface broke v1 on
+  purpose; release stays user-only)
+- Discussion: zwasm/zwasm#209 — "the C API grows when a consumer asks", and the
+  one-function-per-capability shape
+- Files: `include/zwasm.h`, `src/api/zwasm_ext.zig`,
+  `test/c_api_conformance/version.c` (and its entry in `build.zig`'s
+  `conformance_cases`); the value's origin at
+  `build.zig:110` and `src/zwasm.zig:39`; the distribution evidence at
+  `build.zig:1241`, `build.zig:1270`–`1282`,
+  `.github/workflows/release.yml`
+- External: `zwasm/zwasm-rust-sdk` — `.gitmodules`,
+  `crates/zwasm-sys/build.rs:6`, `:44`, `:112`–`134`

--- a/build.zig
+++ b/build.zig
@@ -1311,6 +1311,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/wasi_exit_code.c", .name = "wasi_exit_code" }, // a C host reads a WASI exit status
         .{ .src = "test/c_api_conformance/wasi_host_lifetime.c", .name = "wasi_host_lifetime" }, // a captured WASI host outlives its instances
         .{ .src = "test/c_api_conformance/host_func_direct_call.c", .name = "host_func_direct_call" }, // #315 wasm_func_call on a wasm_func_new func
+        .{ .src = "test/c_api_conformance/version.c", .name = "version" }, // a C host reads the runtime's version
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -27,6 +27,19 @@
 extern "C" {
 #endif
 
+/* ── Runtime version ─────────────────────────────────────────────────── */
+
+/* Semantic version of the LINKED LIBRARY (e.g. "2.5.0"). Static storage,
+ * never NULL; do not free.
+ *
+ * This is the semver ALONE, not the build identity. -Dwasm / -Dwasi /
+ * -Dengine are compile-time and change what the library can do, yet two
+ * builds of the same commit differing in all three return the same string:
+ * "2.5.0" does NOT promise this library holds everything that version can
+ * do. Per-axis identity accessors are deferred until a consumer needs one
+ * (ADR-0221). */
+WASM_API_EXTERN const char* zwasm_version(void);
+
 /* ── Fuel (deterministic budget) ─────────────────────────────────────── */
 
 /* Fuel units are engine-specific: interpreter = instructions executed;

--- a/src/api/zwasm_ext.zig
+++ b/src/api/zwasm_ext.zig
@@ -17,15 +17,35 @@
 //! would be a sandbox-bypass footgun (set_fuel doing nothing). Null
 //! instance/no-engine = no-op, matching wasm.h's null-tolerant style.
 //!
+//! `zwasm_version` is the one member here that is not instance-scoped: it
+//! answers for the library as a whole (ADR-0221).
+//!
 //! Zone 3 (`src/api/`).
 
 const std = @import("std");
+const build_options = @import("build_options");
 
 const capi = @import("instance.zig");
 const trap_surface = @import("trap_surface.zig");
 const vec = @import("vec.zig");
 
 const Instance = capi.Instance;
+
+/// The semantic version of the *linked library* — `build.zig.zon`'s
+/// `.version`, threaded through `build_options` — NUL-terminated, in static
+/// storage. Never null; the caller must not free it.
+///
+/// Semver ALONE, not build identity: `-Dwasm` / `-Dwasi` / `-Dengine` are
+/// compile-time and change what the library can do, yet two builds of this
+/// commit differing in all three return the same string. Per-axis identity
+/// accessors are deferred until a consumer needs them (ADR-0221).
+pub export fn zwasm_version() callconv(.c) [*:0]const u8 {
+    // `build_options.version` is a plain `[]const u8` with no terminator, so
+    // returning its `.ptr` would hand C an unterminated pointer.
+    // `comptimePrint` re-materialises the same comptime bytes as a
+    // sentinel-terminated array in the binary's constant data.
+    return std.fmt.comptimePrint("{s}", .{build_options.version});
+}
 
 /// Arm (or re-arm) the deterministic fuel budget; the running guest traps
 /// "all fuel consumed" (kind `out_of_fuel` = 17) when it is exhausted.
@@ -511,4 +531,66 @@ test "#331: the three engines agree on every host-originated trap kind" {
     try testing.expectEqual(jit_cb, interp_cb);
     // …and the two host-originated classes stay distinct from each other.
     try testing.expect(jit_exit != jit_cb);
+}
+
+// ============================================================
+// Runtime version (issue #237)
+// ============================================================
+
+/// `.version` read straight out of `build.zig.zon`. This is not a tautology:
+/// the accessor's value is that field as `build.zig`'s
+/// `@import("build.zig.zon")` parsed it at build time, and this is the same
+/// field read off disk at test time — two readings, not one. Comparing
+/// against `build_options.version` would compare the injection with itself;
+/// transcribing `"2.5.0"` would be the dual maintenance ADR-0216 argues
+/// against. The reach is correspondingly narrow, and that is the whole claim:
+/// it catches a stale `build_options` and an accessor that later grows a
+/// hardcoded string.
+///
+/// **This test requires CWD = the repository root.** The manifest cannot be
+/// reached at comptime: `@embedFile("../../build.zig.zon")` is rejected with
+/// "embed of file outside package path", because the root module is
+/// `src/zwasm.zig` and the package root is therefore `src/` (measured on Zig
+/// 0.16.0). So the read is a runtime one, relative to the CWD that
+/// `zig build` passes down. A wrong CWD fails loudly and by name rather than
+/// silently skipping — the failure mode this file must not add to.
+fn manifestVersion(gpa: std.mem.Allocator) ![]u8 {
+    const manifest = std.Io.Dir.cwd().readFileAlloc(
+        std.testing.io,
+        "build.zig.zon",
+        gpa,
+        .limited(64 << 10),
+    ) catch |err| switch (err) {
+        error.FileNotFound => return error.RunThisTestFromTheRepositoryRoot,
+        else => return err,
+    };
+    defer gpa.free(manifest);
+    const key = ".version = \"";
+    const start = (std.mem.find(u8, manifest, key) orelse return error.NoVersionField) + key.len;
+    const len = std.mem.find(u8, manifest[start..], "\"") orelse return error.UnterminatedVersion;
+    return gpa.dupe(u8, manifest[start..][0..len]);
+}
+
+test "#237: zwasm_version reports build.zig.zon's .version, NUL-terminated" {
+    const p = zwasm_version();
+
+    // Non-NULL. `[*:0]const u8` already forbids it, so this pins the
+    // C-visible contract against a future signature loosened to optional.
+    try testing.expect(@intFromPtr(p) != 0);
+
+    // The reported string is the manifest's value and stops there. The
+    // terminator itself is NOT what this proves: it is a compile-time
+    // guarantee of the `[*:0]const u8` return type — `return
+    // build_options.version.ptr;` is rejected with "destination pointer
+    // requires '0' sentinel" (measured, Zig 0.16.0), so only an explicit
+    // `@ptrCast` could defeat it. And a build that did would still read back
+    // correctly here, because the byte after the version in constant data
+    // happens to be 0 (also measured). Index from the manifest's length
+    // rather than `span(p)`'s so at least the length is not taken from the
+    // value under test.
+    const expected = try manifestVersion(testing.allocator);
+    defer testing.allocator.free(expected);
+    try testing.expectEqual(@as(u8, 0), p[expected.len]);
+    try testing.expectEqualStrings(expected, p[0..expected.len]);
+    try testing.expectEqualStrings(expected, std.mem.span(p));
 }

--- a/test/c_api_conformance/version.c
+++ b/test/c_api_conformance/version.c
@@ -1,0 +1,114 @@
+/* zwasm v2 — a C host asks the linked library what version it is.
+ *
+ * The accessor exists so a C consumer can name a version in a bug report, and
+ * that is only true if the value crosses the ABI. The Zig test beside the
+ * implementation pins what the string *is* — it equals `build.zig.zon`'s
+ * `.version`. It cannot pin any of the three things this case exists for:
+ *
+ *   - `include/zwasm.h`'s declaration agrees with the exported symbol. That is
+ *     what compiling this file against the header and linking it against
+ *     libzwasm.a proves; a return type or linkage the header got wrong fails
+ *     here and nowhere else.
+ *   - a C translation unit reaches the symbol at all.
+ *   - the value survives being read as a C string: `strlen` returns something
+ *     plausible, the storage is stable across calls and across unrelated
+ *     runtime activity, and there is nothing to free.
+ *
+ * What this case does NOT prove is that the NUL terminator is present. That
+ * is a compile-time guarantee of the Zig side's `[*:0]const u8` return type —
+ * returning the unterminated `build_options.version.ptr` is a compile error,
+ * so only an explicit `@ptrCast` could defeat it. Measured: a build with that
+ * cast still prints `"2.5.0"` with strlen 5 from here, because the byte after
+ * the version in constant data happens to be 0. The semver-shape check below
+ * would catch an overrun into less friendly bytes, but it is a net, not a
+ * proof, and it is written down as one.
+ *
+ * Run by `test-c-api-conformance`.
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* MAJOR.MINOR.PATCH: three non-empty all-digit components, nothing else.
+ * Stricter than "contains a dot" so that a string which starts correctly and
+ * runs on into unrelated bytes is rejected — see the caveat in the header
+ * comment about what that does and does not establish. */
+static bool is_semver(const char* s) {
+    size_t digits = 0;
+    size_t dots = 0;
+    for (const char* p = s; *p; p++) {
+        if (*p >= '0' && *p <= '9') {
+            digits++;
+        } else if (*p == '.') {
+            if (digits == 0) return false; /* empty component */
+            digits = 0;
+            dots++;
+        } else {
+            return false;
+        }
+    }
+    return dots == 2 && digits > 0;
+}
+
+int main(void) {
+    /* Declared `const char*` in zwasm.h; a mismatch with the export is a
+     * compile or link failure, not a runtime one. */
+    const char* v = zwasm_version();
+
+    if (v == NULL) {
+        fputs("zwasm_version() returned NULL\n", stderr);
+        return 1;
+    }
+
+    const size_t len = strlen(v);
+    if (len == 0) {
+        fputs("zwasm_version() returned an empty string\n", stderr);
+        return 1;
+    }
+    if (!is_semver(v)) {
+        fprintf(stderr, "zwasm_version() = \"%s\" (strlen %zu) is not MAJOR.MINOR.PATCH\n",
+                v, len);
+        return 1;
+    }
+
+    /* Static storage: the same pointer every call, so there is nothing to free
+     * and no allocator involved. A different pointer would mean the header's
+     * ownership claim is wrong. */
+    if (zwasm_version() != v) {
+        fputs("zwasm_version() returned a different pointer on the second call\n", stderr);
+        return 1;
+    }
+
+    /* …and that storage is not a buffer some later runtime activity reuses.
+     * Copy it, drive the runtime, read it back. */
+    char snapshot[64];
+    if (len >= sizeof(snapshot)) {
+        fprintf(stderr, "version string implausibly long (%zu)\n", len);
+        return 1;
+    }
+    memcpy(snapshot, v, len + 1);
+
+    wasm_engine_t* engine = wasm_engine_new();
+    wasm_store_t* store = engine ? wasm_store_new(engine) : NULL;
+    if (!engine || !store) {
+        fputs("engine/store new failed\n", stderr);
+        if (store) wasm_store_delete(store);
+        if (engine) wasm_engine_delete(engine);
+        return 1;
+    }
+    wasm_store_delete(store);
+    wasm_engine_delete(engine);
+
+    if (strcmp(zwasm_version(), snapshot) != 0) {
+        fprintf(stderr, "version changed across runtime activity: \"%s\" then \"%s\"\n",
+                snapshot, zwasm_version());
+        return 1;
+    }
+
+    printf("zwasm c_api_conformance/version: zwasm_version() = \"%s\" (strlen %zu)\n", v, len);
+    return 0;
+}


### PR DESCRIPTION
Closes #237.

`include/zwasm.h` exposed no way to ask the linked library what it is. The
string already exists — `build.zig:110` injects `build.zig.zon`'s `.version`
as `build_options.version` — so this only carries it across the C boundary.

## Decision (ADR-0221)

Semver alone, one function. Macros, numeric accessors and build identity are
each deferred with a named trigger. The premises were checked, not assumed:

- Only `libzwasm.a` exists (`build.zig:1241`, `.linkage = .static`), and
  `zig build static-lib` installs it together with the headers out of one
  checkout; `release.yml` publishes the CLI binary only, no C surface. So a
  header/library mismatch — the failure a version macro detects — has no way
  to occur, and `zwasm.h` being hand-authored means baked numbers would need
  a sync gate larger than the accessor.
- `zwasm-rust-sdk`'s `zwasm-sys` vendors this repo as a submodule, runs
  `zig build static-lib` in it and links `static=zwasm`, passing no capability
  flags and declaring no cargo features. The identity consumer named in the
  issue is real but not yet present, and its arrival is observable there.

The cost of that defer is recorded beside it, in the ADR and in the header: a
consumer linking a `-Dwasi=p1` build and reading `"2.5.0"` can believe it
holds everything that version implies.

## The sentinel

`build_options.version` is a `[]const u8` with no terminator, so returning its
`.ptr` would hand C an unterminated pointer. The accessor re-materialises the
same comptime bytes with `std.fmt.comptimePrint`. First `[*:0]const u8` export
in `src/api/`.

The terminator is enforced by the return type, not by a test: `return
build_options.version.ptr;` does not compile ("destination pointer requires
'0' sentinel"), so only an explicit `@ptrCast` defeats it. Measured — a build
carrying that cast still reads back `"2.5.0"` with `strlen` 5 from C, because
the byte after the version in constant data happens to be 0. No runtime test
here distinguishes the two, and both tests say so rather than implying
coverage they do not have.

## Tests

Both sides, because neither covers the other:

- `test/c_api_conformance/version.c` (the shape #330 used for a new public C
  function) holds three things nothing else does: `include/zwasm.h`'s
  declaration agrees with the export (a wrong return type or linkage fails at
  compile/link here), a C translation unit reaches the symbol, and the storage
  is stable — same pointer every call, unchanged across unrelated runtime
  activity, nothing to free. `scripts/test_extlink.sh` is not a substitute: it
  proves the archive links, not that the declaration matches the
  implementation.
- The Zig test in `src/api/zwasm_ext.zig` — the accessor's value, which is
  `.version` as `@import("build.zig.zon")` parsed it at build time, against
  the same field read off disk at test time. Two readings, not one, so it
  catches a stale `build_options` and a later hardcoded string; that is its
  whole reach. It requires CWD = the repository root and says so:
  `@embedFile("../../build.zig.zon")` is rejected ("embed of file outside
  package path" — the root module is `src/zwasm.zig`, so the package root is
  `src/`). A wrong CWD fails by a named error, not silently.

## Measured (x86_64-linux, Zig 0.16.0)

- `zig fmt --check src/ build.zig`, `zig build test-all`,
  `zig build test-c-api-conformance`, `scripts/gate_commit.sh` (no `--fast`)
  — all green.
- `test-c-api`, `run-zig-host`, `run-zig-host-jit`, `run-rust-host` — green.
- `zig build static-lib -Dcompiler-rt=true` → `nm` reports `T zwasm_version`;
  a C program compiled against `zig-out/include` and `libzwasm.a` prints
  `"2.5.0"` with `strlen` 5.
- `zig build test -Doptimize=ReleaseSafe` is **not green, and is not green on
  `main` either** — the two JIT EH tests of #323 crash with `incorrect
  alignment` in `frame_chain.zig:113`. Measured both ways on this PR's base
  `c0a5be210`: main alone 3252 pass / 2 crash, this branch 3253 pass / the
  same 2 crash. Nothing here touches that path.
- macOS and Windows were not measurable here; the 3-OS gate is their first
  check.
