### PR TITLE
docs: tell a C embedder to run `zig build static-lib` (#325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,9 +220,15 @@ zig build              # compile the zwasm binary
 zig build test         # unit tests
 zig build test-all     # all enabled test layers
 
+# Embedding from C or Rust: libzwasm.a + the three public headers into zig-out/
+zig build static-lib -Doptimize=ReleaseSafe -Dcompiler-rt=true
+
 # Cross-compile sanity check (catches, e.g., Win64 compile errors in ~3s)
 zig build -Dtarget=x86_64-windows-gnu
 ```
+
+The link line that goes with `static-lib`, and what each of its flags is for,
+is in [`docs/tutorial.md`](docs/tutorial.md) §5.
 
 **You need Zig 0.16.0 and [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools)**
 (pinned in [`.github/versions.lock`](.github/versions.lock); the build

--- a/docs/examples/c_host/hello.c
+++ b/docs/examples/c_host/hello.c
@@ -9,12 +9,15 @@
  * — embedded as a byte array so the example stays import-free
  * (no WASI dependency, no external assembler / wabt step).
  *
- * Build wiring lands in §9.3 / 3.9 (`zig build test-c-api`).
- * For now this file is hand-compileable via:
+ * `zig build test-c-api` builds libzwasm.a and this example and runs it.
+ * To compile it the way an embedder would — against the installed archive
+ * and headers rather than through the build script:
  *
- *   zig cc -c -I include docs/examples/c_host/hello.c -o /tmp/hello.o
+ *   zig build static-lib -Doptimize=ReleaseSafe -Dcompiler-rt=true
+ *   cc -I zig-out/include docs/examples/c_host/hello.c \
+ *      zig-out/lib/libzwasm.a -lm -Wl,-z,noexecstack -o c_host
  *
- * which proves the wasm.h surface is consumable by a real C TU.
+ * What each flag is for: docs/tutorial.md section 5.
  */
 
 #include <stdio.h>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -91,8 +91,38 @@ consumer, exercises the full surface) and
 
 zwasm implements the standard wasm-c-api ([`include/wasm.h`](../include/wasm.h)).
 A C host that drives any wasm-c-api runtime drives zwasm unchanged; WASI
-is configured via [`include/wasi.h`](../include/wasi.h). Runnable:
-[`docs/examples/c_host/`](examples/c_host/). Reference:
+is configured via [`include/wasi.h`](../include/wasi.h).
+
+Build the library and the headers yourself — a release tarball holds the
+`zwasm` executable and nothing else:
+
+```sh
+zig build static-lib -Doptimize=ReleaseSafe -Dcompiler-rt=true
+# → zig-out/lib/libzwasm.a
+#   zig-out/include/{wasm,wasi,zwasm}.h
+```
+
+Then compile a host against them (x86_64-linux shown):
+
+```sh
+cc -I zig-out/include docs/examples/c_host/hello.c zig-out/lib/libzwasm.a \
+   -lm -Wl,-z,noexecstack -o c_host
+./c_host      # → zwasm c_host: main() returned 42
+```
+
+The three extra flags are not decoration, and each has its own condition:
+
+| Flag | Why it is there |
+|---|---|
+| `-Dcompiler-rt=true` | Bundles Zig's compiler-rt into the archive. Without it a `-Doptimize=ReleaseSafe` build fails to link with `undefined reference to __zig_probe_stack`; at the default `Debug` it happens to link, which is what makes the omission easy to miss. |
+| `-lm` | zwasm calls `trunc` / `truncf`, which live in a separate library on glibc older than 2.34. |
+| `-Wl,-z,noexecstack` | Linux only. Zig-emitted objects carry no `.note.GNU-stack` section, so GNU ld assumes an executable stack and prints a deprecation warning (D-312). The link succeeds without it. |
+
+`zig build --help` describes the `static-lib` step and is authoritative for
+the other targets. Cross-compiling the archive works the same way — add
+`-Dtarget=<triple>`.
+
+Runnable: [`docs/examples/c_host/`](examples/c_host/). Reference:
 [`reference/c_api.md`](reference/c_api.md).
 
 ## 6. Coming from v1


### PR DESCRIPTION
Closes #325.

`zig build static-lib` produces `libzwasm.a` and the three public headers, and
no document a C embedder reaches on the way to embedding said so — only
`zig build --help`. Re-measured on `1781da21f`: every tracked mention outside
`.dev/` is still historical (`CHANGELOG.md`) or descriptive
(`README.md:192`, `docs/development.md`'s `-Dcompiler-rt` table row,
`docs/examples/README.md`), never an instruction.

## What changed

- **`docs/tutorial.md` §5** — the build, the link line, and a table saying what
  each of the three non-obvious flags is for. Placed before the two handoffs
  the section used to end on.
- **`README.md`** Building from source — the step, in the block where a source
  consumer looks, plus a pointer to §5 for the link line.
- **`docs/examples/c_host/hello.c`** — its own note said "Build wiring lands in
  §9.3 / 3.9 (`zig build test-c-api`)" and offered `zig cc -c … -o /tmp/hello.o`.
  That wiring landed, and `-c` produces an object nobody can run. It now shows
  the same two commands the tutorial does. Beyond the issue's two suggested
  spots, but inside the problem it states — the reader reaching an example
  "that cannot be compiled" is what this note was doing.

## The flags, measured rather than copied

The issue called the flags "not guessable". Measured on x86_64-linux, Zig
0.16.0, they are also not uniformly required, and the doc says which is which:

| Flag | Measured |
|---|---|
| `-Dcompiler-rt=true` | **Load-bearing at ReleaseSafe.** Without it the link fails: `undefined reference to __zig_probe_stack` (std `debug`, `sort.block`, `Io.Threaded`, …). At the default Debug the same link succeeds — which is what makes the omission easy to miss, and why the docs use the ReleaseSafe line. |
| `-lm` | Not needed on this host's glibc; `trunc` / `truncf` are a separate library only on glibc older than 2.34. Kept, and labelled. |
| `-Wl,-z,noexecstack` | Link succeeds without it; GNU ld prints the D-312 deprecation warning about the missing `.note.GNU-stack`. Kept, and labelled Linux-only. |

Deliberately **not** proposed here, matching the issue: changing what a release
tarball contains.

## Verified (x86_64-linux, Zig 0.16.0)

- The documented pair, run exactly as written:
  `zig build static-lib -Doptimize=ReleaseSafe -Dcompiler-rt=true` then the
  `cc` line → `zwasm c_host: main() returned 42`.
- `zig build test-c-api`, `zig build test-c-api-conformance`,
  `scripts/gate_commit.sh` (no `--fast`) — green.
- The three `doc-truth` checks (`check_engine_default_claims`,
  `check_wasi03_coverage_claims`, `check_doc_fossils`) — green.
- Because `docs/examples/c_host/hello.c` is a non-`.md` file under
  `docs/examples/`, `ci.yml`'s #297 carve-out runs the full 3-OS gate on this
  PR rather than the doc-only skip. (`scripts/gate_commit.sh` locally does take
  the docs-only path for it — it has no such carve-out — so the example's
  compile was covered by the explicit `test-c-api` run above.)
- macOS and Windows were not measurable here. The tutorial marks the link line
  as the x86_64-linux one and marks `-Wl,-z,noexecstack` Linux-only rather than
  inventing the other two platforms' lines.
