### PR TITLE
fix(capi): the WASI exit status is per call, not per Store (#341)

### DIFF
--- a/include/wasi.h
+++ b/include/wasi.h
@@ -149,8 +149,10 @@ WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
  * `proc_exit` trap carries differs between engines and is not part
  * of this contract.
  *
- * The status belongs to the Store, not to an instance, and it
- * persists until the Store's WASI setup is replaced.
+ * The status is per call: each `wasm_func_call` into this Store
+ * clears it before running, so a `true` return describes the call
+ * you just made, never an earlier guest's. Read it before calling
+ * into the Store again.
  */
 WASM_API_EXTERN bool zwasm_store_wasi_exit_code(const wasm_store_t*, uint32_t* out);
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -2033,22 +2033,26 @@ pub export fn wasm_func_call(
     results: ?*ValVec,
 ) callconv(.c) ?*Trap {
     const handle = f orelse return null;
+    // #341 — the WASI exit status describes THIS call, not an earlier guest's.
+    // A WASI command exits through `proc_exit` even when it succeeds, so a Store
+    // that has run one command carries a `0` — and `0` is what
+    // `zwasm_store_wasi_exit_code` reports as a clean exit. Clearing above every
+    // branch below covers the interp and JIT/AOT arms and the direct-callback
+    // path in one place. A `wasm_func_new` func has no guest at all, so the
+    // clear is what makes its trap read back as "not an exit" rather than as
+    // the last guest's status. Instance-derived handles carry `.instance`,
+    // `wasm_func_new` ones carry `.store`.
+    if (if (handle.instance) |i| i.store else handle.store) |store| {
+        if (store.wasi_host) |host_opaque| {
+            const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
+            host.exit_code = null;
+        }
+    }
     // #315: a `wasm_func_new[_with_env]` func has no instance — the C callback
     // IS its body, so invoke it here rather than reporting a silent success.
     if (handle.host) |hp| return hostFuncCallDirect(handle, hp, args, results);
     const inst = handle.instance orelse return null;
     const store = inst.store orelse return null;
-    // #341 — the WASI exit status describes THIS call, not an earlier guest's.
-    // A WASI command exits through `proc_exit` even when it succeeds, so a Store
-    // that has run one command carries a `0` — and `0` is what
-    // `zwasm_store_wasi_exit_code` reports as a clean exit. Clearing here, above
-    // the engine branch, covers the interp and the JIT/AOT arms in one place.
-    // The `wasm_func_new` host-func path returned above, so a direct callback
-    // call cannot wipe a status the embedder has not read yet.
-    if (store.wasi_host) |host_opaque| {
-        const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
-        host.exit_code = null;
-    }
     const alloc = storeAllocator(store) orelse return null;
     // ADR-0200 — JIT-backed instance: route to the native engine. JIT invoke is
     // by-NAME, so reverse-map func_idx → export name via exports_storage (a

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -368,9 +368,10 @@ pub export fn zwasm_store_set_wasi(s: ?*Store, h: ?*wasi_host.Host) callconv(.c)
 /// `zwasm_store_wasi_exit_code(*Store, *u32)` — read the exit status
 /// a WASI guest requested through `proc_exit`. Returns false, leaving
 /// `out` untouched, when the Store has no WASI host or the guest never
-/// called `proc_exit`. `src/cli/run.zig` applies the same rule: a trap
-/// that carries an exit code is a guest that ended itself, and a trap
-/// without one is a fault.
+/// called `proc_exit`. The status is per call: `wasm_func_call` clears
+/// it before running, so what this reports is the call just made.
+/// `src/cli/run.zig` applies the same rule: a trap that carries an exit
+/// code is a guest that ended itself, and a trap without one is a fault.
 pub export fn zwasm_store_wasi_exit_code(s: ?*const Store, out: ?*u32) callconv(.c) bool {
     const store = s orelse return false;
     const host_opaque = store.wasi_host orelse return false;
@@ -2037,6 +2038,17 @@ pub export fn wasm_func_call(
     if (handle.host) |hp| return hostFuncCallDirect(handle, hp, args, results);
     const inst = handle.instance orelse return null;
     const store = inst.store orelse return null;
+    // #341 — the WASI exit status describes THIS call, not an earlier guest's.
+    // A WASI command exits through `proc_exit` even when it succeeds, so a Store
+    // that has run one command carries a `0` — and `0` is what
+    // `zwasm_store_wasi_exit_code` reports as a clean exit. Clearing here, above
+    // the engine branch, covers the interp and the JIT/AOT arms in one place.
+    // The `wasm_func_new` host-func path returned above, so a direct callback
+    // call cannot wipe a status the embedder has not read yet.
+    if (store.wasi_host) |host_opaque| {
+        const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
+        host.exit_code = null;
+    }
     const alloc = storeAllocator(store) orelse return null;
     // ADR-0200 — JIT-backed instance: route to the native engine. JIT invoke is
     // by-NAME, so reverse-map func_idx → export name via exports_storage (a

--- a/src/wasi/proc.zig
+++ b/src/wasi/proc.zig
@@ -13,11 +13,13 @@
 //! supplied bad pointers.
 //!
 //! `proc_exit` is the odd one out: it has no return value
-//! (witx `noreturn`). We model it by setting `host.exit_code`
-//! to the supplied code; the §9.4 / 4.7 import-resolution code
-//! checks this after every host-call return and short-circuits
-//! the dispatch loop when it's set, surfacing the exit code as
-//! a Trap variant in the C-API binding.
+//! (witx `noreturn`). We model it by recording `host.exit_code`
+//! and unwinding through a channel of the engine's own — the
+//! interp thunk returns `error.WasiExit` (`src/api/wasi.zig`),
+//! the JIT stub raises the trap flag (`jit_dispatch.zig`).
+//! Neither reads `host.exit_code` back: it is the recorded
+//! status, not the unwind signal. Both surface as a trap at the
+//! C-API binding.
 //!
 //! Zone 2 (`src/wasi/`) — same zone as `host.zig` and `p1.zig`.
 
@@ -49,10 +51,13 @@ fn writeBytes(mem: []u8, offset: u32, src: []const u8) p1.Errno {
 // ============================================================
 
 /// `proc_exit(rval) -> noreturn` — request termination of the
-/// instance with exit code `rval`. The handler sets
-/// `host.exit_code` and returns `Errno.success`; the dispatch
-/// surface checks `host.exit_code` after each host-call return
-/// and short-circuits accordingly.
+/// instance with exit code `rval`. The handler only records
+/// `host.exit_code` and returns `Errno.success`; unwinding is the
+/// caller's, per engine (`error.WasiExit` from the interp thunk,
+/// the trap flag from the JIT stub). The recorded status is what
+/// `zwasm_store_wasi_exit_code` and `src/cli/run.zig` read, and
+/// `wasm_func_call` clears it before each call so it describes
+/// that call alone (#341).
 pub fn procExit(host: *Host, rval: u32) p1.Errno {
     host.exit_code = rval;
     return .success;

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -223,6 +223,80 @@ cleanup:
     return rc;
 }
 
+/* A `wasm_func_new` func called directly has no guest behind it, so its trap
+ * carries no exit status — and must not read back as the last guest's. The
+ * clear sits above the direct-callback branch for exactly this: without it the
+ * trap reports a clean exit of 0 that no guest ever requested. */
+static const char kRefusal[] = "host refused";
+static wasm_store_t* g_refuse_store = NULL;
+
+static wasm_trap_t* refuse(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    (void) args;
+    (void) results;
+    wasm_byte_vec_t msg = { sizeof(kRefusal) - 1, (wasm_byte_t*) kRefusal };
+    return wasm_trap_new(g_refuse_store, &msg);
+}
+
+static int expect_direct_call_clears(uint8_t engine) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    wasm_functype_t* ft = NULL;
+    wasm_func_t* fn = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+    g_refuse_store = store;
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    /* A guest exits cleanly, leaving a status on the Store. */
+    kExitWasm[kRvalOffset] = 0;
+    if (run_in_store(store, kExitWasm, sizeof(kExitWasm), engine, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped || !has_code || code != 0) {
+        fprintf(stderr, "[%s] direct-call setup: proc_exit(0) read back trapped=%d has_code=%d code=%u\n",
+                engine_name(engine), (int) trapped, (int) has_code, code);
+        goto cleanup;
+    }
+
+    /* A host func of our own, called with no instance in between, traps. */
+    ft = wasm_functype_new_0_0();
+    fn = ft ? wasm_func_new(store, ft, refuse) : NULL;
+    if (!fn) { fputs("wasm_func_new failed\n", stderr); goto cleanup; }
+
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t no_res = { 0, NULL };
+    wasm_trap_t* trap = wasm_func_call(fn, &no_args, &no_res);
+    if (!trap) {
+        fprintf(stderr, "[%s] direct call: expected the callback's trap, got none\n", engine_name(engine));
+        goto cleanup;
+    }
+    wasm_trap_delete(trap);
+
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (has_code) {
+        fprintf(stderr, "[%s] direct call: host-func trap reported exit code %u — no guest ran\n",
+                engine_name(engine), code);
+        goto cleanup;
+    }
+    if (code != 0xdeadbeefu) {
+        fprintf(stderr, "[%s] direct call: wrote through `out` while returning false\n", engine_name(engine));
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (fn) wasm_func_delete(fn);
+    if (ft) wasm_functype_delete(ft);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    g_refuse_store = NULL;
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
         const uint8_t e = kEngines[i];
@@ -234,6 +308,7 @@ int main(void) {
         if (expect_no_exit(e, true, "unreachable with a WASI host")) return 1;
         if (expect_no_exit(e, false, "unreachable with no WASI host")) return 1;
         if (expect_per_call(e)) return 1;
+        if (expect_direct_call_clears(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -63,23 +63,15 @@ static const char* engine_name(uint8_t kind) {
     }
 }
 
-/* One `_start` run. Returns 0 on success; writes the observed outcome into
- * `*trapped` / `*has_code` / `*code`. */
-static int run_start(const uint8_t* wasm, size_t wasm_len, uint8_t engine, bool with_wasi,
-                     bool* trapped, bool* has_code, uint32_t* code) {
+/* One `_start` run inside a store the caller owns. Returns 0 on success; writes
+ * the observed outcome into `*trapped` / `*has_code` / `*code`. The store
+ * outlives the call, so the same store can be asked more than once. */
+static int run_in_store(wasm_store_t* store, const uint8_t* wasm, size_t wasm_len, uint8_t engine,
+                        bool* trapped, bool* has_code, uint32_t* code) {
     int rc = 1;
-    wasm_engine_t* eng = wasm_engine_new();
-    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
     wasm_module_t* module = NULL;
     wasm_instance_t* instance = NULL;
     wasm_extern_vec_t exports = { 0, NULL };
-    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
-
-    if (with_wasi) {
-        zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
-        if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
-        zwasm_store_set_wasi(store, cfg); /* takes ownership */
-    }
 
     wasm_byte_vec_t binary = { wasm_len, (wasm_byte_t*) wasm };
     module = wasm_module_new(store, &binary);
@@ -111,6 +103,26 @@ cleanup:
     if (exports.data) wasm_extern_vec_delete(&exports);
     if (instance) wasm_instance_delete(instance);
     if (module) wasm_module_delete(module);
+    return rc;
+}
+
+/* One `_start` run in a store of its own. */
+static int run_start(const uint8_t* wasm, size_t wasm_len, uint8_t engine, bool with_wasi,
+                     bool* trapped, bool* has_code, uint32_t* code) {
+    int rc = 1;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    if (with_wasi) {
+        zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+        if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+        zwasm_store_set_wasi(store, cfg); /* takes ownership */
+    }
+
+    rc = run_in_store(store, wasm, wasm_len, engine, trapped, has_code, code);
+
+cleanup:
     if (store) wasm_store_delete(store);
     if (eng) wasm_engine_delete(eng);
     return rc;
@@ -157,6 +169,60 @@ static int expect_no_exit(uint8_t engine, bool with_wasi, const char* what) {
     return 0;
 }
 
+/* One Store, one WASI setup, two guests. The status must describe the call
+ * just made, not an earlier guest's. This is the case every function above is
+ * structurally unable to reach: they each build a fresh engine + store, so no
+ * store is ever asked twice. It matters because a WASI command exits through
+ * `proc_exit` even when it succeeds, so one run leaves a "0" behind — and 0 is
+ * exactly the value an embedder reads as success. */
+static int expect_per_call(uint8_t engine) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    /* 1. a guest that exits cleanly. */
+    kExitWasm[kRvalOffset] = 0;
+    if (run_in_store(store, kExitWasm, sizeof(kExitWasm), engine, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped || !has_code || code != 0) {
+        fprintf(stderr, "[%s] same-store run 1: proc_exit(0) read back trapped=%d has_code=%d code=%u\n",
+                engine_name(engine), (int) trapped, (int) has_code, code);
+        goto cleanup;
+    }
+
+    /* 2. a genuine fault in the SAME store. No guest called proc_exit on this
+     * call, so there is no status to report. */
+    trapped = false;
+    has_code = false;
+    code = 0;
+    if (run_in_store(store, kFaultWasm, sizeof(kFaultWasm), engine, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped) {
+        fprintf(stderr, "[%s] same-store run 2: expected a trap, got none\n", engine_name(engine));
+        goto cleanup;
+    }
+    if (has_code) {
+        fprintf(stderr, "[%s] same-store run 2: unreachable reported exit code %u — run 1's status is stale\n",
+                engine_name(engine), code);
+        goto cleanup;
+    }
+    if (code != 0xdeadbeefu) {
+        fprintf(stderr, "[%s] same-store run 2: wrote through `out` while returning false\n", engine_name(engine));
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
         const uint8_t e = kEngines[i];
@@ -167,6 +233,7 @@ int main(void) {
         if (expect_exit(e, 42)) return 1;
         if (expect_no_exit(e, true, "unreachable with a WASI host")) return 1;
         if (expect_no_exit(e, false, "unreachable with no WASI host")) return 1;
+        if (expect_per_call(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */


### PR DESCRIPTION
Closes #341.

`zwasm_store_wasi_exit_code` reported a genuine fault as a clean exit once any
guest in the Store had exited. `host.exit_code` was assigned and never cleared,
so it lived for the Store's whole life; a WASI command exits through `proc_exit`
even when it succeeds, so one run left a `0` behind, and `0` is what the header
tells an embedder to read as success.

`wasm_func_call` clears the status before running — above the engine branch, so
interp and JIT/AOT are covered in one place, and below the `wasm_func_new`
direct-callback return, so a host func cannot wipe a status not yet read.
`wasi.h`'s two bullet rules are unchanged; only its closing lifetime claim,
which was the false part, becomes the per-call rule. No signature changes.

The clear is wider than the issue's option A, which scoped it to a
`wasm_func_call` entering a WASI-bound instance: sitting above the engine
branch, it fires for every `wasm_func_call` into a Store that has a WASI setup,
WASI-bound instance or not. That is deliberate — covering the engines by
structure rather than by enumerating them removes the failure mode where
interp, JIT or AOT is the one arm someone forgets, now or when a fourth is
added.

The consequence is intended: calling a non-WASI export after a WASI guest has
exited clears the status at that call, so the "read it before calling into the
Store again" rule the header now states is what an embedder relies on. Narrowing
the clear to WASI-bound instances would not avoid it either — a second instance
in the same Store would still leave the first one's status readable, which is
the bug.

The clear sits above the direct-callback branch, so it covers a `wasm_func_new`
func called straight on its handle as well. That func has no guest behind it,
and without the clear its trap reported the last guest's status — the same
fabricated clean exit, on the one path a narrower placement missed. Raised in
review; the case is in the same file.

The conformance case was structurally unable to catch this — every case built a
fresh engine and store, so none asked one store twice. That case is added first
and observed red (`same-store run 2: unreachable reported exit code 0`) before
the fix, on auto, jit and interp.

Alternatives, from the issue: scoping the status to the exiting instance is the
more correct semantics but changes `zwasm_store_wasi_exit_code`'s signature,
which is the wrong move while `zwasm-rust-sdk` is about to pin this contract.
Publishing an explicit clear moves the same forget-to-reset failure into
embedder code — the failure this issue is about. No ADR: #330 introduced the
contract without one, and this restores it rather than changing it.

`src/wasi/proc.zig`'s doc comments said the dispatch surface polls
`host.exit_code` after each host-call return. It does not — the interp thunk
returns `error.WasiExit`, the JIT stub raises the trap flag — and that
distinction is why the staleness only misled readers instead of ending a later
guest's run. Corrected in the same commit, since it is the comment that made
the field look shorter-lived than it was.

The `== null` guards in `component_wasi_p2.zig` / `component_wasi_p3.zig` read
the same field, and after this change the two paths disagree about how long its
value lives: per call on the C-API surface, per host on the component path. No
caller runs two guests on one host today, so it is unreachable rather than
absent — measured here and filed as #344 rather than fixed, since the component
path has no single entry point to clear at.

One more reader is out of scope and filed as #345: the accessor reads whichever
host is currently installed, so an instance that captured a host later retired
by `zwasm_store_set_wasi` writes one host and is read from another. The mismatch
predates this change; keying the status to the captured host is the
instance-scoped option rejected above.

What this change does alter there is the symptom, and only when the installed
host already carries a status. Measured on both engines — cfg A, instantiate,
swap to cfg B, run a guest under B to exit 5, then run the old instance to
exit 7: the parent reports `true` with code 5, this branch reports `false`.
Both are wrong. Reporting a status no guest requested is the failure this issue
exists to remove, and it is silent; declining to report one is loud. Fixing it
properly is #345.

Not verified locally: macOS and Windows — the 3-OS gate is the first check.
