### PR TITLE
docs(reference): the C API page missed three shipped capabilities

### DIFF
--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -7,8 +7,8 @@ headers in [`include/`](../../include/):
 | Header                             | Origin                                                           | Status                                                                                                                  |
 |------------------------------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
 | [`wasm.h`](../../include/wasm.h)   | Upstream `WebAssembly/wasm-c-api`, vendored read-only (ADR-0004) | **Complete** — every declared `extern` function is implemented (293/293; `scripts/capi_surface_gap.sh` enforces gap=0) |
-| [`wasi.h`](../../include/wasi.h)   | Hand-authored project extension (ADR-0005)                       | WASI 0.1 host-setup (`zwasm_wasi_config_*`, `zwasm_store_set_wasi`) — no canonical upstream `wasi.h` exists            |
-| [`zwasm.h`](../../include/zwasm.h) | Hand-authored project extension (ADR-0179 #3a-4)                 | Instance sandboxing setters (fuel / memory cap / interrupt) + `zwasm_trap_kind` + per-instance engine selection (`zwasm_instance_new_ex`) + `zwasm_instance_get_func` — see below |
+| [`wasi.h`](../../include/wasi.h)   | Hand-authored project extension (ADR-0005)                       | WASI 0.1 host-setup (`zwasm_wasi_config_*`, `zwasm_store_set_wasi`) + the guest's exit status (`zwasm_store_wasi_exit_code`) — no canonical upstream `wasi.h` exists |
+| [`zwasm.h`](../../include/zwasm.h) | Hand-authored project extension (ADR-0179 #3a-4)                 | Runtime version (`zwasm_version`) + instance sandboxing setters (fuel / memory cap / interrupt) + `zwasm_trap_kind` + per-instance engine selection (`zwasm_instance_new_ex`) + `zwasm_instance_get_func` — see below |
 
 The header IS the reference — `wasm.h` is the upstream standard
 documented at <https://github.com/WebAssembly/wasm-c-api>. This page
@@ -46,7 +46,33 @@ ownership). See the worked example in
 [`include/wasi.h`](../../include/wasi.h) and
 [`docs/examples/c_host/`](../examples/c_host/).
 
+**Reading the exit status.** A WASI command ends by calling `proc_exit` —
+including when it succeeds, since a `wasi-libc` `_start` that returns normally
+calls `proc_exit(0)` — and zwasm surfaces that as a trap. So `wasm_func_call`
+alone cannot separate a clean termination from a fault, and
+`zwasm_store_wasi_exit_code(store, &out)` is what does:
+
+- trap **and** `true` — the guest terminated itself; `*out` is its status, and
+  `0` there means success.
+- trap **and** `false` — a genuine fault (unreachable, out of bounds, …).
+  `wasm_trap_message` / `zwasm_trap_kind` describe it.
+
+The status is **per call** — each `wasm_func_call` into the Store clears it
+before running, so a `true` describes the call just made and never an earlier
+guest's (#341). Read it before calling into the Store again.
+
+`zwasm_trap_kind` answers a different question and does not replace this one:
+since ADR-0218 it reports `ZWASM_TRAP_WASI_EXIT` for a `proc_exit` on every
+engine, so it does say *that* the guest terminated itself — but it never
+carries the status, which is what an embedder needs.
+
 ## `zwasm.h` extensions
+
+**Runtime version.** `zwasm_version()` returns the linked library's semantic
+version — `build.zig.zon`'s `.version`, as `MAJOR.MINOR.PATCH` — NUL-terminated
+in static storage, never NULL, nothing to free. Semver alone, not build identity: `-Dwasm` / `-Dwasi` / `-Dengine` change
+what the library can do, and two builds of one commit differing in all three
+return the same string (ADR-0221).
 
 Instance-level budget setters (ADR-0179 #3a-4) mirroring the Zig facade —
 post-instantiate and re-armable mid-workload (v1's config-level
@@ -65,7 +91,7 @@ with `ZWASM_ENGINE_AUTO` / `ZWASM_ENGINE_JIT` / `ZWASM_ENGINE_INTERP`.
 | `zwasm_instance_fuel_remaining(i, &out)`                            | remaining budget; returns `false` when unmetered                                                                                         |
 | `zwasm_instance_set_memory_pages_limit(i, p)` / `…_clear_…(i)`    | host ceiling below the declared max; `memory.grow` past it returns the spec `-1`                                                         |
 | `zwasm_instance_interrupt(i)` / `zwasm_instance_clear_interrupt(i)` | cooperative cancel/timeout from any thread; traps `interrupted` (kind 16) at the next poll                                               |
-| `zwasm_trap_kind(trap)`                                             | machine-readable trap kind beside wasm.h's message-only surface (`ZWASM_TRAP_INTERRUPTED`/`ZWASM_TRAP_OUT_OF_FUEL` macros); `-1` on NULL |
+| `zwasm_trap_kind(trap)`                                             | machine-readable trap kind beside wasm.h's message-only surface (`ZWASM_TRAP_INTERRUPTED`/`ZWASM_TRAP_OUT_OF_FUEL` macros); `-1` on NULL. Host-originated traps are separable from guest faults on every engine — `ZWASM_TRAP_WASI_EXIT` (18) for a `proc_exit`, `ZWASM_TRAP_BINDING_ERROR` (0) for a host callback's own trap (ADR-0218) |
 
 ## Not shipped (`zwasm.h` residuals)
 

--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -61,6 +61,13 @@ The status is **per call** — each `wasm_func_call` into the Store clears it
 before running, so a `true` describes the call just made and never an earlier
 guest's (#341). Read it before calling into the Store again.
 
+One exception is open: an instance binds its WASI host at instantiation, so
+after `zwasm_store_set_wasi` replaces or detaches the Store's setup, an
+older instance's `proc_exit` writes where this accessor no longer reads. Its
+clean exit then reads back as a fault on every engine (#350). A host that
+reconfigures WASI under a live instance cannot rely on the `false` rule until
+that closes.
+
 `zwasm_trap_kind` answers a different question and does not replace this one:
 since ADR-0218 it reports `ZWASM_TRAP_WASI_EXIT` for a `proc_exit` on every
 engine, so it does say *that* the guest terminated itself — but it never


### PR DESCRIPTION
`docs/reference/c_api.md` is the page that maps the C surface, and three merged
capabilities never reached it. Measured on `1bcc0edae` — `git grep` across
`docs/` and `README.md` for `zwasm_version`, `zwasm_store_wasi_exit_code` and
`ZWASM_TRAP_WASI_EXIT` returns nothing.

It matters now because #325 just made the embedder path complete, and
`docs/tutorial.md` §5 ends by sending the reader here.

## What changed

- **Runtime version** (#237) — a short paragraph opening the `zwasm.h` section,
  since it is the one library-level member among instance-level ones. Described
  by shape (`build.zig.zon`'s `.version`, as `MAJOR.MINOR.PATCH`) rather than by
  value: writing `"2.5.0"` into a doc is the dual maintenance ADR-0221 declined
  macros for.
- **WASI exit status** (#234) — a paragraph in the WASI section, stating the
  per-call rules as `62d9452d5` (#341) left them: a trap plus `true` is the
  guest terminating itself with `*out` as its status, a trap plus `false` is a
  genuine fault, and each `wasm_func_call` clears the status before running.
  With the exception that is still open: an instance binds its WASI host at
  instantiation, so after `zwasm_store_set_wasi` replaces or detaches the
  Store's setup, an older instance's clean exit reads back as a fault on every
  engine (#350 — raised by Devin Review on this PR, reproduced through the C
  ABI with a no-replacement control row before being written down).
- **Host-originated trap kinds** (#331 / ADR-0218) — the `zwasm_trap_kind` row
  now records that `proc_exit` and a host callback's own trap are separable from
  a guest fault on every engine, and the WASI section says what that does *not*
  give an embedder: the kind never carries the status.
- The two header-summary rows at the top grew to match.

## Scope

Held to capabilities the page's own summary claims to cover. The individual
`ZWASM_TRAP_*` constants and every `zwasm_wasi_config_*` setter stay
undocumented here on purpose — the page opens with "The header IS the
reference" and maps families, not symbols. A mechanical symbol sweep would
turn it into a worse copy of `include/`.

## Verified (x86_64-linux, Zig 0.16.0)

- `scripts/gate_commit.sh` (no `--fast`) — green.
- The three `doc-truth` checks (`check_engine_default_claims`,
  `check_wasi03_coverage_claims`, `check_doc_fossils`) — green.
- Doc-only diff, so CI takes the doc-only path; `ci-required` still reports.

## Adjacent, not fixed here

`include/wasi.h:148-150` still tells an embedder that a `proc_exit` trap's kind
"differs between engines and is not part of this contract" — written in
`5d56a3991` (#330), when it was true, and left standing by `c47a00b2f`
(#331 / ADR-0218), which made the kind `ZWASM_TRAP_WASI_EXIT` on all three
engines. `include/zwasm.h:99-101` now says the opposite a few lines away. Filed
as #348; changing `include/` is out of scope for a doc-only PR. This page states
the post-#331 position rather than copying the stale sentence.
