### PR TITLE
fix(jit): decline an unaligned fp instead of dereferencing it (#323)

### DIFF
--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -5,8 +5,13 @@
 # never verify LESS than the per-host gate. It checks the CURRENT host only;
 # multi-host fan-out is the caller's job (the CI matrix / gate_merge's SSH legs).
 #
-#   Core (every OS):  zig fmt --check (src/ + bench/latency/) + zig build test-all
-#                     + bench-latency-build
+#   Core — every OS: zig fmt --check (src/ + bench/latency/ + tools/) +
+#     zig build test-all + bench-latency-build + test-discovery guard +
+#     spec-manifest shape guard + ReleaseSafe-runner floor
+#   Core — Linux only: run-rust-host (D-254). Still core — it runs on every
+#     PR — but only where the runner's gnu-target rustc is ABI-compatible
+#     with zig's native libzwasm.a. Listed separately because "every OS"
+#     above is load-bearing: anything added here is verified on ONE leg.
 #   Extended (ZWASM_CI_EXTENDED=1; Unix legs): lint + build-option DCE +
 #     ReleaseSafe JIT smoke (D-245) + AOT cross-compile portability +
 #     external system-linker consumer (test_extlink.sh) + zone_check +

--- a/src/engine/codegen/arm64/frame_chain.zig
+++ b/src/engine/codegen/arm64/frame_chain.zig
@@ -17,10 +17,13 @@
 //! trampoline converts the LR through the per-function
 //! code-map lookup before calling `unwind.walk`).
 //!
-//! Top-of-Wasm-stack sentinel: the entry shim plants `fp == 0`
-//! when it enters the JIT body so the unwinder can detect "no
-//! more Wasm frames" deterministically. `loadFrame(0)` returns
-//! null; the trampoline interprets this as `.uncaught`.
+//! Unreadable frame pointer → null, which the trampoline
+//! interprets as `.uncaught`. Two cases produce it: `fp == 0`, the
+//! top-of-Wasm-stack sentinel the entry shim plants when it enters
+//! the JIT body so the unwinder can detect "no more Wasm frames"
+//! deterministically; and a non-zero `fp` that is not
+//! machine-word-aligned, which cannot be a frame pointer at all
+//! (see `readableFrame`).
 //!
 //! INVARIANT (paired with ADR-0114 D5 + ADR-0112 D7): this
 //! function performs only two pointer-relative loads, no
@@ -43,6 +46,16 @@ pub const RawFrameLink = struct {
     caller_lr: usize,
 };
 
+/// A frame prefix is only readable at a machine-word-aligned `fp`. `fp == 0` is
+/// the entry shim's top-of-Wasm-stack sentinel; a non-zero misaligned `fp` is
+/// not a frame pointer at all — the chain escaped into host frames and the read
+/// picked up a garbage stack word. Both mean "no caller frame this reader can
+/// trust": return null and let `unwind.walk` report `.uncaught`. Dereferencing
+/// instead panics ("incorrect alignment") in every safety-checked build.
+inline fn readableFrame(fp: usize) bool {
+    return fp != 0 and std.mem.isAligned(fp, @alignOf(usize));
+}
+
 /// Read the AAPCS64 frame prefix at `[fp, 0]` + `[fp, 8]`.
 /// Returns null for the top-of-Wasm-stack sentinel (`fp == 0`)
 /// planted by the entry shim.
@@ -52,7 +65,7 @@ pub const RawFrameLink = struct {
 /// the trampoline's captured throw-site X29 or a walk-traversed
 /// `caller_fp` from a prior step).
 pub fn loadFrame(fp: usize) ?RawFrameLink {
-    if (fp == 0) return null;
+    if (!readableFrame(fp)) return null;
     const slots: [*]const usize = @ptrFromInt(fp);
     return .{
         .caller_fp = slots[0],
@@ -108,4 +121,18 @@ test "loadFrame: chained read — outer frame points at inner frame's prefix" {
     const outer_link = loadFrame(inner_link.caller_fp).?;
     try testing.expectEqual(@as(usize, 0), outer_link.caller_fp);
     try testing.expectEqual(@as(usize, 0x1111), outer_link.caller_lr);
+}
+
+test "loadFrame: unaligned fp → null (never dereferenced)" {
+    // #323's twin on this arch. The x86_64 reader panicked ("incorrect
+    // alignment") on a garbage `caller_fp` picked up once the chain escaped
+    // into optimized host frames; AAPCS64 reaches the same reader through the
+    // same `unwind.walk` loop, so it declines a misaligned `fp` the same way it
+    // declines the `fp == 0` sentinel. Every misalignment 1..7 is covered: a
+    // guard written against a narrower alignment would let +2 / +4 through.
+    var frame: [2]usize = .{ 0xDEADBEEFCAFE, 0xFEEDFACE0001 };
+    const aligned_fp: usize = @intFromPtr(&frame);
+    for (1..@alignOf(usize)) |off| {
+        try testing.expectEqual(@as(?RawFrameLink, null), loadFrame(aligned_fp + off));
+    }
 }

--- a/src/engine/codegen/x86_64/frame_chain.zig
+++ b/src/engine/codegen/x86_64/frame_chain.zig
@@ -14,9 +14,12 @@
 //! the trampoline composes both into a
 //! `unwind.FrameChainLoader` per host via a PC-normalization callback.
 //!
-//! Top-of-Wasm-stack sentinel: `fp == 0` returns null. The entry
-//! shim plants this sentinel so the unwinder terminates
-//! deterministically at the Wasm boundary.
+//! Unreadable frame pointer → null, which the unwinder reads as
+//! "no more Wasm frames" (`.uncaught`). Two cases produce it:
+//! `fp == 0`, the top-of-Wasm-stack sentinel the entry shim plants
+//! so the unwinder terminates deterministically at the Wasm
+//! boundary; and a non-zero `fp` that is not machine-word-aligned,
+//! which cannot be a frame pointer at all (see `readableFrame`).
 //!
 //! INVARIANT (paired with ADR-0114 D5 + ADR-0112 D7): two
 //! pointer-relative loads, no allocator calls, no host-call
@@ -38,10 +41,21 @@ pub const RawFrameLink = struct {
     caller_rip: usize,
 };
 
+/// A frame prefix is only readable at a machine-word-aligned `fp`. `fp == 0` is
+/// the entry shim's top-of-Wasm-stack sentinel; a non-zero misaligned `fp` is
+/// not a frame pointer at all — the chain escaped into host frames and the
+/// standard-layout default handed back whatever word sat in `slots[0]`.
+/// Both mean "no caller frame this reader can trust": return null and let
+/// `unwind.walk` report `.uncaught`. Dereferencing instead panics
+/// ("incorrect alignment") in every safety-checked build.
+inline fn readableFrame(fp: usize) bool {
+    return fp != 0 and std.mem.isAligned(fp, @alignOf(usize));
+}
+
 /// Read the x86_64 frame prefix at `[fp, 0]` + `[fp, 8]`.
 /// Returns null for the top-of-Wasm-stack sentinel (`fp == 0`).
 pub fn loadFrame(fp: usize) ?RawFrameLink {
-    if (fp == 0) return null;
+    if (!readableFrame(fp)) return null;
     const slots: [*]const usize = @ptrFromInt(fp);
     return .{
         .caller_fp = slots[0],
@@ -69,7 +83,7 @@ pub fn loadFrameSniffed(
     fp: usize,
     code_map: *const @import("../shared/code_map.zig").CodeMap,
 ) ?RawFrameLink {
-    if (fp == 0) return null;
+    if (!readableFrame(fp)) return null;
     const slots: [*]const usize = @ptrFromInt(fp);
     // Sniff standard layout first (most caller frames in EH chain
     // do NOT push R15 between RBP-save and MOV; non-throwing
@@ -109,7 +123,7 @@ pub fn loadFrameSniffedPred(
     local_code_map: ?*const @import("../shared/code_map.zig").CodeMap,
     is_code: *const fn (usize) bool,
 ) ?RawFrameLink {
-    if (fp == 0) return null;
+    if (!readableFrame(fp)) return null;
     const slots: [*]const usize = @ptrFromInt(fp);
     // Code membership = the THROWING instance's own CodeMap (always available
     // via the adapter's normalize_ctx, even for a single instance NOT
@@ -266,4 +280,51 @@ test "loadFrameSniffedPred x86_64: union prefers EITHER source — global-only s
     const link = loadFrameSniffedPred(fp, &cm, testIsCode5xxxx).?; // 0x50080 ∈ global
     try testing.expectEqual(@as(usize, 0x7FFF_2222_0000), link.caller_fp);
     try testing.expectEqual(@as(usize, 0x50080), link.caller_rip);
+}
+
+// ---------------------------------------------------------------------
+// #323 — an unaligned `fp` is not a frame pointer. It is reached when the
+// chain escapes into optimized host frames: the sniff finds code at neither
+// candidate slot and hands back the standard-layout default, whose `slots[0]`
+// is then whatever word that host frame happened to hold. Dereferencing it
+// panics ("incorrect alignment") in every safety-checked build. Each reader
+// must decline it exactly as it declines the `fp == 0` sentinel — null, which
+// `unwind.walk` turns into `.uncaught`.
+//
+// The loops cover every misalignment 1..7, not just +1: a guard written
+// against a narrower alignment (`fp & 1`, `fp & 3`) would let +2 / +4 through
+// and re-open the panic.
+// ---------------------------------------------------------------------
+
+test "loadFrame x86_64: unaligned fp → null (never dereferenced)" {
+    var frame: [3]usize = .{ 0xAAAA, 0xBBBB, 0xCCCC };
+    const aligned_fp: usize = @intFromPtr(&frame);
+    for (1..@alignOf(usize)) |off| {
+        try testing.expectEqual(@as(?RawFrameLink, null), loadFrame(aligned_fp + off));
+    }
+}
+
+test "loadFrameSniffed x86_64: unaligned fp → null (never dereferenced)" {
+    const code_map_mod = @import("../shared/code_map.zig");
+    var entries = [_]code_map_mod.Entry{.{ .start_addr = 0x50000, .len = 0x100, .func_idx = 0 }};
+    const cm = code_map_mod.CodeMap{ .entries = &entries };
+    var frame: [3]usize = .{ 0x7FFF_1111_0000, 0x7FFF_2222_0000, 0x50080 };
+    const aligned_fp: usize = @intFromPtr(&frame);
+    for (1..@alignOf(usize)) |off| {
+        try testing.expectEqual(@as(?RawFrameLink, null), loadFrameSniffed(aligned_fp + off, &cm));
+    }
+}
+
+test "loadFrameSniffedPred x86_64: unaligned fp → null (the #323 panic site)" {
+    // The stack trace in #323 names this function: engine.runner_test's two JIT
+    // EH end-to-end cases walk out of the JIT into the ReleaseSafe-optimized
+    // unit-test harness frames, and the next `caller_fp` comes back unaligned.
+    var frame: [3]usize = .{ 0x7FFF_1111_0000, 0x7FFF_2222_0000, 0x50080 };
+    const aligned_fp: usize = @intFromPtr(&frame);
+    for (1..@alignOf(usize)) |off| {
+        try testing.expectEqual(
+            @as(?RawFrameLink, null),
+            loadFrameSniffedPred(aligned_fp + off, null, testIsCode5xxxx),
+        );
+    }
 }


### PR DESCRIPTION
Closes #323.

## What broke

`loadFrameSniffedPred` dereferenced `fp` after checking only `fp == 0`. When
the EH walk escapes the JIT into host frames, neither candidate slot resolves
as code, so the reader returns the standard-layout default and the next
`caller_fp` is whatever word that host frame held. The shipped CLI path is
unaffected: `eh_call_ref_catch.wasm` returns 77 on both engines.

## What the fix does

An unaligned `fp` is not a frame pointer, so each reader declines it the way
it declines the `fp == 0` sentinel — `null`, which `unwind.walk` reports as
`.uncaught`. All four frame-prefix readers are guarded: three in
`x86_64/frame_chain.zig` and the arm64 twin, which the same `unwind.walk` loop
reaches on that host. Alignment is `@alignOf(usize)`, not 16 — the
`PUSH RBP; PUSH R15; MOV RBP, RSP` prologue lands RBP at 8 mod 16 by
construction, so a 16-byte guard would reject the D-238 layout.

## Measured

It is not only a ReleaseSafe safety check. The same two `engine.runner_test`
EH cases crash in every optimized mode at `1781da21f`, and ReleaseFast /
ReleaseSmall die at exit 70 without naming a cause:

| mode | `1781da21f` | with the guard |
|---|---|---|
| ReleaseSafe | 2 crashed | green |
| ReleaseFast | 6 failed + 2 crashed | 6 failed, no crash |
| ReleaseSmall | 5 failed + 2 crashed | 5 failed, no crash |

The remaining failures are unrelated and identical at `1781da21f`: 5
`support.dbg` tests that `enabled()` disables at comptime in those two modes,
plus `collector_mark_sweep`'s native-stack scan under ReleaseFast.

`test-all`, `zig fmt --check src/` and `scripts/check_jit_releasesafe.sh` stay
green. macOS and Windows are not available locally; the 3-OS gate is their
first run.

The regression tests call the readers directly with a misaligned `fp`, so they
are red in Debug — they do not wait for an optimized lane.

## Still open

The coverage gap #323 also names is untouched: no lane runs `zig build test`
at any optimization level, so this class of defect still reaches `main`
unseen. Costed but not implemented here — see #347.

The second commit is unrelated to the defect and stands on its own: costing
that lane meant reading `ci_gate.sh`, whose header lists as "every OS" a core
set that already has a Linux-only member (`run-rust-host`). Comment only.
