### PR TITLE
fix(capi): the WASI exit status follows the host the instance captured (#345)

### DIFF
--- a/.dev/decisions/0222_wasi_exit_status_host_addressing.md
+++ b/.dev/decisions/0222_wasi_exit_status_host_addressing.md
@@ -135,14 +135,22 @@ through `wasm_func_call`. That makes instantiation a read point of its own, so
 it has to invalidate the previous status exactly as a call does, and it clears
 the host it is making active before running the start function.
 
-Clearing unconditionally rather than only when the config moved is what makes
-the rule statable. Without it, `wasm_instance_new` invalidates the status when
+Clearing whenever an instantiation happens — not only when the config moved,
+and not only when this instance captures a host — is what makes the rule
+statable. Without it, `wasm_instance_new` invalidates the status when
 `zwasm_store_set_wasi` happened to move the setup and preserves it when it did
 not, and two readings measured on `62d9452d5` and unchanged by the addressing
 fix alone are wrong: a second guest built on the SAME config leaves the first
 guest's status readable as if it were the new one's, and a `(start)` that faults
 WITHOUT calling `proc_exit` reads back as the earlier guest's exit. The second
 is #341's exact failure shape at the read point this decision introduces.
+
+The clear cannot hang off the capture branch either: `zwasm_store_set_wasi`
+resets `wasi_host_captured` and leaves `wasi_host` null on a detach, so a module
+with no WASI imports built after a replace or a detach skips that branch. It
+would then leave the previous guest's status readable across the boundary the
+header says closes it — measured on all three engines before the clear was
+lifted out.
 
 The cost is that a status left unread across `wasm_func_call` →
 `wasm_instance_new` is gone. It is accepted: the alternative — not writing at
@@ -152,6 +160,23 @@ is the worse failure because nothing signals it. What moves instead is the rule
 into the Store again, or creating another instance in it — either one clears
 it." Two regression cases pin it, because no other case in that file asks a
 Store anything after building a second instance.
+
+**Only the outermost call owns the status.** A host callback can call back
+into the Store, and a nested `wasm_func_call` would otherwise retarget
+`active_wasi_host` to its own callee — to null, for a `wasm_func_new` one,
+which is the common shape. The outer guest's later `proc_exit` then writes a
+host nothing points at, and a clean termination reads back as a fault:
+`has_code=0` where `62d9452d5` answered `code=7`, on all three engines. That is
+a regression this addressing introduces and the flat `store.wasi_host` read did
+not have, because a single global cannot be retargeted.
+
+`Store.wasi_call_depth` guards it: the outermost `wasm_func_call` records and
+clears, nested ones only count. Instantiation is guarded by the same depth for
+the same reason — an instance created from inside a callback must not close a
+window the call in progress still owns. The counter is decremented in a `defer`,
+so a trap that unwinds through the Zig frame still balances it; the conformance
+suite is what would catch a leak, since a stuck depth makes every later call
+skip the record and report no status.
 
 **Trap classification is untouched, and measured to be.**
 `ZWASM_TRAP_WASI_EXIT` is raised from the engine's own unwind —

--- a/.dev/decisions/0222_wasi_exit_status_host_addressing.md
+++ b/.dev/decisions/0222_wasi_exit_status_host_addressing.md
@@ -130,21 +130,28 @@ would have dropped it silently.
 
 **The read window closes at the next instantiation, not only at the next
 call.** Writing `active_wasi_host` at capture time is what keeps a `(start)`'s
-`proc_exit` readable, and the same write makes a later `wasm_instance_new` move
-the setup the status is read from. A status left unread across
-`call → set_wasi → wasm_instance_new` is therefore gone — and gone as `false`,
-which the header's two bullets classify as a genuine fault. That is the #341
-failure shape reached through a different door, so it is named rather than left
-to be discovered.
+`proc_exit` readable — a `(start)` runs inside `wasm_instance_new`, never
+through `wasm_func_call`. That makes instantiation a read point of its own, so
+it has to invalidate the previous status exactly as a call does, and it clears
+the host it is making active before running the start function.
 
-It is accepted, not removed. Narrowing the write to `wasm_func_call` would
-trade it for silently dropping the start-function status, which is the worse
-failure because nothing signals it. What moves instead is the invalidation rule
-`include/wasi.h` states: it now names both events — "read it before calling
-into the Store again, or creating another instance in it". A regression case
-pins both halves, that the swap alone does not hide the status and that the
-instantiation after it does, because no other case in that file builds a second
-instance after a swap.
+Clearing unconditionally rather than only when the config moved is what makes
+the rule statable. Without it, `wasm_instance_new` invalidates the status when
+`zwasm_store_set_wasi` happened to move the setup and preserves it when it did
+not, and two readings measured on `62d9452d5` and unchanged by the addressing
+fix alone are wrong: a second guest built on the SAME config leaves the first
+guest's status readable as if it were the new one's, and a `(start)` that faults
+WITHOUT calling `proc_exit` reads back as the earlier guest's exit. The second
+is #341's exact failure shape at the read point this decision introduces.
+
+The cost is that a status left unread across `wasm_func_call` →
+`wasm_instance_new` is gone. It is accepted: the alternative — not writing at
+capture time — trades it for silently dropping the start-function status, which
+is the worse failure because nothing signals it. What moves instead is the rule
+`include/wasi.h` states, which now names both events: "read it before calling
+into the Store again, or creating another instance in it — either one clears
+it." Two regression cases pin it, because no other case in that file asks a
+Store anything after building a second instance.
 
 **Trap classification is untouched, and measured to be.**
 `ZWASM_TRAP_WASI_EXIT` is raised from the engine's own unwind —
@@ -155,6 +162,16 @@ measured on `b3d031525` as `kind=18` for control, replaced and detached alike,
 on all three engines (#350). This is the boundary of the change — nothing about
 how a `proc_exit` trap is recognised had to move, only which host the read and
 the clear address.
+
+**A cross-module call still writes a host this record does not name.** When an
+instance imports another instance's export, dispatch enters the SOURCE
+instance's body with the SOURCE instance's WASI binding, so `proc_exit` writes
+the host that instance captured while the record names the called instance's.
+Measured on `interp`, identical before and after this change (`auto` and `jit`
+cannot instantiate a cross-module func import at all). It is #352, not this
+decision: keying on the called instance is right for every call that does not
+leave it, and following the executing runtime instead is a different mechanism
+with its own question.
 
 **`src/cli/run.zig`'s divergence was unreachable and is fixed anyway.** The CLI
 installs one config and never swaps, so the two addressings agreed there. It is
@@ -190,9 +207,13 @@ the first and sufficient check there.
   installed host, and now aims at the captured one.
 - #344 — the third reader of `host.exit_code`, on the component path, out of
   scope here.
+- #352 — a `proc_exit` reached through a cross-module func import writes the
+  SOURCE instance's host, so the guest that exits is not the called instance
+  this decision keys on. Measured identical before and after, on `interp`;
+  fixing it needs the record to follow the runtime that runs `proc_exit`.
 - #348 — `wasi.h`'s "do not branch on the trap kind" paragraph, stale since
   #331. Untouched here; the read-window consequence above is what gives it a
   cost, and is recorded on that issue.
 - `test/c_api_conformance/wasi_exit_code.c` — three regression cases, one per
-  way the config can move on, asserting the code on auto / jit / interp, plus a
-  fourth pinning where the read window closes.
+  way the config can move on, asserting the code on auto / jit / interp, plus
+  two pinning where the read window closes and what instantiation clears.

--- a/.dev/decisions/0222_wasi_exit_status_host_addressing.md
+++ b/.dev/decisions/0222_wasi_exit_status_host_addressing.md
@@ -170,13 +170,28 @@ host nothing points at, and a clean termination reads back as a fault:
 a regression this addressing introduces and the flat `store.wasi_host` read did
 not have, because a single global cannot be retargeted.
 
-`Store.wasi_call_depth` guards it: the outermost `wasm_func_call` records and
-clears, nested ones only count. Instantiation is guarded by the same depth for
-the same reason — an instance created from inside a callback must not close a
-window the call in progress still owns. The counter is decremented in a `defer`,
-so a trap that unwinds through the Zig frame still balances it; the conformance
-suite is what would catch a leak, since a stuck depth makes every later call
-skip the record and report no status.
+`Store.wasi_call_depth` guards it. The rule it encodes is one sentence: **while
+something is running guest code on this Store, that something owns the status.**
+Three writers observe it — the outermost `wasm_func_call` records and clears,
+nested ones only count; instantiation records only outside a call, so an
+instance built from inside a callback does not close a window the call in
+progress still owns; and the `(start)` function raises the depth while it runs,
+because it is itself guest code that can reach `proc_exit` and can invoke a host
+callback that calls back in.
+
+The start arm is the one that is easy to miss, and it was: instantiation records
+the host but is not itself a call, so before this the depth was still zero while
+the start ran, and a callback the start invoked could retarget the record before
+the start's own `proc_exit`. Both engine paths raise it around their start
+execution.
+
+Only two contexts on this Store can reach `proc_exit` — a `wasm_func_call` and
+a `(start)` — and both now raise the depth. Segment initialisation and global
+initialisers cannot call a function, so there is no third.
+
+The counter is decremented in a `defer`, so a trap that unwinds through the Zig
+frame still balances it; the conformance suite is what would catch a leak, since
+a stuck depth makes every later call skip the record and report no status.
 
 **Trap classification is untouched, and measured to be.**
 `ZWASM_TRAP_WASI_EXIT` is raised from the engine's own unwind —

--- a/.dev/decisions/0222_wasi_exit_status_host_addressing.md
+++ b/.dev/decisions/0222_wasi_exit_status_host_addressing.md
@@ -1,0 +1,198 @@
+# 0222 — The WASI exit status is read from the host the called instance captured
+
+- **Status**: Accepted
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, wasi, store, exit-status
+
+## Context
+
+`zwasm_store_wasi_exit_code` resolved the WASI host from `store.wasi_host` —
+whichever config is installed *now*. A guest writes `exit_code` on the host its
+instance captured at instantiate time: `host_call.ctx` per WASI import for the
+interpreter (`src/api/instance.zig` `buildBindings`), `jit.owned.rt.wasi_host`
+for the JIT (`instantiateJit`). ADR-0219 then made `zwasm_store_set_wasi` move
+`store.wasi_host` on while keeping the displaced host alive on
+`retired_wasi_hosts`, precisely because instances still hold its address.
+
+So the writer and the reader address different hosts as soon as the config
+moves, and `include/wasi.h` already tells a C host that an instance keeps using
+the config it was built with. Nothing in the header says the exit status is an
+exception, and a host following the two rules the accessor's comment states
+misclassifies the termination either way.
+
+Measured on `62d9452d5`, x86_64-linux, through the C ABI. One Store; an
+instance built under config A that always calls `proc_exit(7)`; the config then
+moved on; then that instance's `_start`. Expected `code=7`. Identical on auto,
+jit and interp:
+
+| how the config moved on | `62d9452d5` | parent of #341 |
+|---|---|---|
+| replaced, new host never ran | `has_code=0` | `has_code=0` |
+| replaced, new host carries a 5 of its own | `has_code=0` | **`code=5`** |
+| detached with `NULL` | `has_code=0` | `has_code=0` |
+
+The second row is why the regression case asserts the **code**. A check on
+`has_code` alone passes on the `code=5` reading, which is the worse of the two
+failures: one guest's status reported as another's, with nothing to distinguish
+it from a correct answer.
+
+#341 did not cause this and does not reach it. Its per-call clear operates on
+the installed host, so it changed the second row's symptom from a fabricated
+status to no status; the addressing was wrong before it and after it.
+
+**The defect was filed twice, 40 minutes apart** — #345 (07:30Z) and #350
+(08:11Z) — with the same mechanism cited down to the same line numbers. #350
+adds the third row above, the `NULL` detach, which #345's investigation had
+not covered. Both are closed by this decision; the duplication is recorded
+here because the second report is what produced the third case.
+
+## Decision
+
+**The Store records the WASI host each call actually reaches, and the accessor
+reads that. The signature does not change.**
+
+- `Store.active_wasi_host: ?*anyopaque` — the host the most recent call
+  reached. `Instance.wasi_host: ?*anyopaque` — the host that instance captured.
+- Both are written at exactly the two sites that already set
+  `wasi_host_captured`, and **before** the start function runs. Keying on the
+  flag rather than on `wasi_host != null` is what makes the stored pointer
+  safe: the flag is the condition under which ADR-0219 retires the host
+  instead of freeing it.
+- `wasm_func_call` sets `active_wasi_host` from the called instance, then
+  clears that host's status (#341's clear, now aimed at the right host). A
+  `wasm_func_new` handle has no instance, so it records no host.
+- `zwasm_store_wasi_exit_code` resolves through `active_wasi_host`, with **no
+  fallback** to `wasi_host`.
+- `src/cli/run.zig`'s trap-vs-exit branch resolves through the same helper. It
+  was the second Store-mediated reader of the field.
+
+`include/wasi.h` gains the half it was leaving to inference: the status is read
+from the setup the *called* instance was built with, so moving the Store's
+config on neither hides an older instance's status nor lets a newer instance's
+stand in for it.
+
+## Alternatives considered
+
+**Make the accessor instance-scoped (`wasm_instance_t*`).** #341 rejected this
+on sequencing — `zwasm-rust-sdk` was pinning the contract, and changing a
+signature underneath that is backwards. **That reason has expired**: the SDK is
+still pinned at `278587f60`, before `zwasm_store_wasi_exit_code` existed, so no
+published consumer holds the signature and the window is genuinely open. It is
+rejected here on two new grounds instead, and they are the ones that survive
+the window closing:
+
+1. A `wasm_instance_t*` parameter carries no information the Store cannot
+   already resolve. The Store knows which instance made the last call; the
+   caller would be handing back a fact the Store just recorded.
+2. It strands `src/cli/run.zig`. That reader sits after
+   `invoke_args_mod.invokeFormatted` returns and has no instance handle in
+   scope — only the Store. An instance-scoped accessor would leave the CLI on
+   the old addressing, which is the two-readers-disagree shape this decision
+   exists to remove.
+
+Recorded explicitly because the expired reason is the one on the record, and
+without this the option reads as merely deferred.
+
+**Ship both (Store-scoped and instance-scoped).** Rejected for the reasons
+above plus the cost of keeping two contracts in step for one field.
+
+**Clear the status inside `zwasm_store_set_wasi`.** Cheaper, and wrong in the
+direction that matters: it makes the second row read like the first — an
+exited guest reported as a fault — rather than making either correct.
+
+**Fall back to `store.wasi_host` when nothing has been recorded.** Rejected.
+With the recording done at capture time there is no state where the fallback
+reports something true, and it would restore the defect on the direct-callback
+path, where the right answer is "no guest ran".
+
+## Consequences
+
+**Reading a retired host is safe by construction, not by inspection.**
+`active_wasi_host` is only ever set to a host an instantiation captured, which
+is exactly ADR-0219's retire-instead-of-free condition; `wasm_store_delete`
+frees `retired_wasi_hosts` after the instance and zombie cascade. The
+corollary is the rule at the write sites: recording a host that was *not*
+captured is the one thing that could dangle, which is why the condition is the
+flag.
+
+**Over-marking is harmless here and is left in place.** `wasi_host_captured`
+is sticky across instances, so an instance with no WASI imports, built in a
+Store where another instance captured the host, records it too. That host is
+retained by definition, and such an instance cannot record a status — its calls
+only clear one. Same posture as ADR-0219's over-mark, for the same reason.
+
+**A start-function `proc_exit` stays readable.** `(start)` runs during
+`wasm_instance_new`, not through `wasm_func_call`. Setting `active_wasi_host`
+at capture time — before `jit.runStart()` and before the interp start block —
+preserves behaviour that has always worked; recording only in `wasm_func_call`
+would have dropped it silently.
+
+**The read window closes at the next instantiation, not only at the next
+call.** Writing `active_wasi_host` at capture time is what keeps a `(start)`'s
+`proc_exit` readable, and the same write makes a later `wasm_instance_new` move
+the setup the status is read from. A status left unread across
+`call → set_wasi → wasm_instance_new` is therefore gone — and gone as `false`,
+which the header's two bullets classify as a genuine fault. That is the #341
+failure shape reached through a different door, so it is named rather than left
+to be discovered.
+
+It is accepted, not removed. Narrowing the write to `wasm_func_call` would
+trade it for silently dropping the start-function status, which is the worse
+failure because nothing signals it. What moves instead is the invalidation rule
+`include/wasi.h` states: it now names both events — "read it before calling
+into the Store again, or creating another instance in it". A regression case
+pins both halves, that the swap alone does not hide the status and that the
+instantiation after it does, because no other case in that file builds a second
+instance after a swap.
+
+**Trap classification is untouched, and measured to be.**
+`ZWASM_TRAP_WASI_EXIT` is raised from the engine's own unwind —
+`error.WasiExit` from the interp thunk, kind 18 from `src/wasi/jit_dispatch.zig`
+— and `src/api/trap_surface.zig:152` / `:189` map both without reading
+`host.exit_code`. The kind therefore survives a swap that the status did not:
+measured on `b3d031525` as `kind=18` for control, replaced and detached alike,
+on all three engines (#350). This is the boundary of the change — nothing about
+how a `proc_exit` trap is recognised had to move, only which host the read and
+the clear address.
+
+**`src/cli/run.zig`'s divergence was unreachable and is fixed anyway.** The CLI
+installs one config and never swaps, so the two addressings agreed there. It is
+changed because #345 is itself a case of an addressing that looked unreachable
+until someone reconfigured a Store, and because a second reader keyed on
+`wasi_host` is how the halves drifted apart to begin with.
+
+**#344 is not closed by this and is not touched.** The component guards
+(`component_wasi_p2.zig:1995`, `component_wasi_p3.zig:184`) read
+`built.ctx.host.exit_code` on a host their caller handed them, reached through
+`Instance.invoke`, never through `wasm_func_call` or a Store. This decision
+adds state to `Store` and a hook to `wasm_func_call`; the component path has
+neither. Its own question — whether to clear per run or to key the guards on
+something else — is untouched and stays open.
+
+**`src/zwasm/linker.zig` records nothing.** It binds its own host and never
+writes `store.wasi_host` or the flag (`linker.zig:592-598`), so a
+Linker-built instance leaves `active_wasi_host` alone. Correct: its host was
+never the Store's, and this accessor was never the way to read it.
+
+**Not verified on macOS or Windows before merge.** The evidence above is
+x86_64-linux. Nothing in the change is platform-specific — it is pointer
+bookkeeping on structs that already exist — so the 3-OS `ci-required` gate is
+the first and sufficient check there.
+
+## References
+
+- Issues #345 and #350 (the same defect, filed twice).
+- ADR-0219 — the retire-instead-of-free rule that makes a captured host
+  readable after the swap, and the source of the `wasi_host_captured`
+  condition this decision keys on.
+- #341 (`62d9452d5`) — the per-call clear this extends; it aimed at the
+  installed host, and now aims at the captured one.
+- #344 — the third reader of `host.exit_code`, on the component path, out of
+  scope here.
+- #348 — `wasi.h`'s "do not branch on the trap kind" paragraph, stale since
+  #331. Untouched here; the read-window consequence above is what gives it a
+  cost, and is recorded on that issue.
+- `test/c_api_conformance/wasi_exit_code.c` — three regression cases, one per
+  way the config can move on, asserting the code on auto / jit / interp, plus a
+  fourth pinning where the read window closes.

--- a/include/wasi.h
+++ b/include/wasi.h
@@ -153,7 +153,7 @@ WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
  * clears it before running, so a `true` return describes the call
  * you just made, never an earlier guest's. Read it before calling
  * into the Store again, or creating another instance in it —
- * either one moves the setup the status is read from.
+ * either one clears it.
  *
  * It is read from the WASI setup the CALLED instance was built
  * with, which is the setup that instance keeps using. Replacing

--- a/include/wasi.h
+++ b/include/wasi.h
@@ -152,7 +152,14 @@ WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
  * The status is per call: each `wasm_func_call` into this Store
  * clears it before running, so a `true` return describes the call
  * you just made, never an earlier guest's. Read it before calling
- * into the Store again.
+ * into the Store again, or creating another instance in it —
+ * either one moves the setup the status is read from.
+ *
+ * It is read from the WASI setup the CALLED instance was built
+ * with, which is the setup that instance keeps using. Replacing
+ * that setup with `zwasm_store_set_wasi`, or removing it with
+ * `NULL`, therefore neither hides an older instance's exit
+ * status nor lets a newer instance's stand in for it.
  */
 WASM_API_EXTERN bool zwasm_store_wasi_exit_code(const wasm_store_t*, uint32_t* out);
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -847,12 +847,22 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     // imported start is unsupported here → fail so an `.auto` caller can retry on
     // interp rather than silently skip it. Run before `inst` exists so teardown
     // is just the jit (no registry/arena to unwind).
-    jit.runStart() catch |err| {
-        if (trap_out) |to| to.* = jitErrToTrap(err, jit, alloc, store);
-        jit.deinit(alloc);
-        alloc.destroy(jit);
-        return null;
-    };
+    {
+        // #345 — while the start function runs it OWNS the status, exactly as
+        // an outermost `wasm_func_call` does: it can reach `proc_exit`, and a
+        // host callback it invokes can call back into this Store. Without the
+        // depth that nested call would retarget `active_wasi_host` away from
+        // the host recorded just above, and the start's own exit would be
+        // unreadable.
+        store.wasi_call_depth +|= 1;
+        defer store.wasi_call_depth -|= 1;
+        jit.runStart() catch |err| {
+            if (trap_out) |to| to.* = jitErrToTrap(err, jit, alloc, store);
+            jit.deinit(alloc);
+            alloc.destroy(jit);
+            return null;
+        };
+    }
 
     const inst = alloc.create(Instance) catch {
         jit.deinit(alloc);
@@ -1151,6 +1161,11 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
     // (incl. data segments) are initialised. A trap fails instantiation.
     // The start funcidx was range/sig-validated at compile time.
     if (findStartFuncIdx(bytes)) |sfx| {
+        // #345 — the start function owns the status while it runs; see the
+        // JIT arm's note. Covers both shapes below (imported start via
+        // `host_calls`, and a defined one dispatched here).
+        store.wasi_call_depth +|= 1;
+        defer store.wasi_call_depth -|= 1;
         if (sfx < inst.func_ptrs_storage.len) {
             // The start function may be an IMPORTED func (wit-component's
             // start-shim wraps `_initialize` exactly this way); its

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -826,6 +826,13 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     if (store.wasi_host != null) {
         store.wasi_host_captured = true;
         store.active_wasi_host = store.wasi_host;
+        // Instantiating is a read point for the status (a `(start)` can call
+        // `proc_exit`), so it has to invalidate the previous one like a call
+        // does — otherwise a Store whose config did NOT move reports an
+        // earlier call's status as this instantiation's, and a `(start)` that
+        // faults without exiting reads back as that earlier exit. Cleared
+        // before `runStart` so the start's own status survives.
+        if (activeWasiHost(store)) |h| h.exit_code = null;
     }
 
     // Wasm §4.5.4 — run the `(start)` function AFTER setup initialised globals /
@@ -1105,6 +1112,10 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
     if (store.wasi_host_captured) {
         inst.wasi_host = store.wasi_host;
         store.active_wasi_host = store.wasi_host;
+        // Same invalidation as the JIT arm above, and for the same reason:
+        // instantiating moves the setup the status is read from, so it must
+        // clear what was there. Before the start function runs below.
+        if (activeWasiHost(store)) |h| h.exit_code = null;
     }
 
     // D-174 defensive fix: register inst in the store's live-instance

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -823,16 +823,22 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     // #345 — record it as the host this Store's calls now reach, BEFORE
     // `runStart`: a `(start)` that calls `proc_exit` records its status during
     // `wasm_instance_new`, and that has always been readable.
+    // Instantiating is a read point for the status (a `(start)` can call
+    // `proc_exit`), so it invalidates the previous one like a call does —
+    // otherwise a Store whose config did NOT move reports an earlier call's
+    // status as this instantiation's, and a `(start)` that faults without
+    // exiting reads back as that earlier exit. Unconditional, because
+    // `zwasm_store_set_wasi` leaves `wasi_host` null on a detach: a module
+    // that captures nothing must still close the window. Cleared before
+    // `runStart` so the start's own status survives. Skipped inside a call in
+    // progress — that call owns the status until it returns.
+    if (store.wasi_call_depth == 0) {
+        if (activeWasiHost(store)) |h| h.exit_code = null;
+        store.active_wasi_host = null;
+    }
     if (store.wasi_host != null) {
         store.wasi_host_captured = true;
-        store.active_wasi_host = store.wasi_host;
-        // Instantiating is a read point for the status (a `(start)` can call
-        // `proc_exit`), so it has to invalidate the previous one like a call
-        // does — otherwise a Store whose config did NOT move reports an
-        // earlier call's status as this instantiation's, and a `(start)` that
-        // faults without exiting reads back as that earlier exit. Cleared
-        // before `runStart` so the start's own status survives.
-        if (activeWasiHost(store)) |h| h.exit_code = null;
+        if (store.wasi_call_depth == 0) store.active_wasi_host = store.wasi_host;
     }
 
     // Wasm §4.5.4 — run the `(start)` function AFTER setup initialised globals /
@@ -1109,13 +1115,18 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
     // across instances, so this may over-mark an instance with no WASI
     // imports — harmless, since such an instance cannot record a status and
     // its calls only clear one.
+    // Same invalidation as the JIT arm above, and unconditional for the same
+    // reason: `wasi_host_captured` is reset by `zwasm_store_set_wasi`, so a
+    // module with no WASI imports built after a replace or a detach would
+    // otherwise leave the previous guest's status readable. Before the start
+    // function runs below.
+    if (store.wasi_call_depth == 0) {
+        if (activeWasiHost(store)) |h| h.exit_code = null;
+        store.active_wasi_host = null;
+    }
     if (store.wasi_host_captured) {
         inst.wasi_host = store.wasi_host;
-        store.active_wasi_host = store.wasi_host;
-        // Same invalidation as the JIT arm above, and for the same reason:
-        // instantiating moves the setup the status is read from, so it must
-        // clear what was there. Before the start function runs below.
-        if (activeWasiHost(store)) |h| h.exit_code = null;
+        if (store.wasi_call_depth == 0) store.active_wasi_host = store.wasi_host;
     }
 
     // D-174 defensive fix: register inst in the store's live-instance
@@ -2090,13 +2101,22 @@ pub export fn wasm_func_call(
     // `wasm_func_new` func has no instance and so no guest: recording "no host"
     // is what makes its trap read back as "not an exit" rather than as the last
     // guest's status.
-    if (if (handle.instance) |i| i.store else handle.store) |store| {
-        store.active_wasi_host = if (handle.instance) |i| i.wasi_host else null;
-        if (store.active_wasi_host) |host_opaque| {
-            const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
-            host.exit_code = null;
+    //
+    // Only the OUTERMOST call decides this. A host callback can call back in,
+    // and a nested `wasm_func_call` would otherwise retarget the status to its
+    // own callee — to null, for a `wasm_func_new` one — leaving the outer
+    // guest's later `proc_exit` unreadable.
+    const call_store: ?*Store = if (handle.instance) |i| i.store else handle.store;
+    if (call_store) |store| {
+        if (store.wasi_call_depth == 0) {
+            store.active_wasi_host = if (handle.instance) |i| i.wasi_host else null;
+            if (activeWasiHost(store)) |host| host.exit_code = null;
         }
+        store.wasi_call_depth +|= 1;
     }
+    defer if (call_store) |store| {
+        store.wasi_call_depth -|= 1;
+    };
     // #315: a `wasm_func_new[_with_env]` func has no instance — the C callback
     // IS its body, so invoke it here rather than reporting a silent success.
     if (handle.host) |hp| return hostFuncCallDirect(handle, hp, args, results);

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -374,11 +374,22 @@ pub export fn zwasm_store_set_wasi(s: ?*Store, h: ?*wasi_host.Host) callconv(.c)
 /// code is a guest that ended itself, and a trap without one is a fault.
 pub export fn zwasm_store_wasi_exit_code(s: ?*const Store, out: ?*u32) callconv(.c) bool {
     const store = s orelse return false;
-    const host_opaque = store.wasi_host orelse return false;
-    const host: *const wasi_host.Host = @ptrCast(@alignCast(host_opaque));
+    const host = activeWasiHost(store) orelse return false;
     const code = host.exit_code orelse return false;
     if (out) |p| p.* = code;
     return true;
+}
+
+/// #345 — the WASI host to read a call's exit status from: the one the called
+/// instance captured, which `zwasm_store_set_wasi` can have moved
+/// `store.wasi_host` off. Null when nothing has run in this Store yet, or when
+/// the last call was a `wasm_func_new` func with no guest behind it. The single
+/// resolution rule for every Store-mediated reader — the accessor above and
+/// `src/cli/run.zig`'s trap-vs-exit branch — so a second reader cannot drift
+/// back onto `wasi_host`.
+pub fn activeWasiHost(store: *const Store) ?*wasi_host.Host {
+    const host_opaque = store.active_wasi_host orelse return null;
+    return @ptrCast(@alignCast(host_opaque));
 }
 
 // ============================================================
@@ -809,7 +820,13 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     jit.owned.rt.wasi_host = store.wasi_host;
     // Captured for the JitInstance's life. May over-mark (this runs before
     // `runStart`, which can still fail the instantiation) — see buildBindings.
-    if (store.wasi_host != null) store.wasi_host_captured = true;
+    // #345 — record it as the host this Store's calls now reach, BEFORE
+    // `runStart`: a `(start)` that calls `proc_exit` records its status during
+    // `wasm_instance_new`, and that has always been readable.
+    if (store.wasi_host != null) {
+        store.wasi_host_captured = true;
+        store.active_wasi_host = store.wasi_host;
+    }
 
     // Wasm §4.5.4 — run the `(start)` function AFTER setup initialised globals /
     // memory / tables, BEFORE the instance is surfaced. A start trap fails
@@ -834,6 +851,7 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
         .module = module,
         .runtime = null,
         .jit = jit,
+        .wasi_host = store.wasi_host,
     };
 
     // ADR-0200 — surface the JIT's func exports through the C-API discovery path
@@ -1073,6 +1091,21 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
         alloc.destroy(inst);
         return null;
     };
+
+    // #345 — `buildBindings` marks `wasi_host_captured` on the branch that
+    // bakes the host into a WASI binding's `host_call.ctx`. Record the same
+    // address on the instance, and as the host this Store's calls now reach,
+    // BEFORE the start function below can call `proc_exit`. Keyed on
+    // `wasi_host_captured` and not on `wasi_host != null`: the flag is what
+    // guarantees `zwasm_store_set_wasi` retires the host instead of freeing
+    // it, so an unkeyed write is the one that could dangle. It is sticky
+    // across instances, so this may over-mark an instance with no WASI
+    // imports — harmless, since such an instance cannot record a status and
+    // its calls only clear one.
+    if (store.wasi_host_captured) {
+        inst.wasi_host = store.wasi_host;
+        store.active_wasi_host = store.wasi_host;
+    }
 
     // D-174 defensive fix: register inst in the store's live-instance
     // list so wasm_store_delete can cascade-cleanup on reverse-order
@@ -2036,14 +2069,19 @@ pub export fn wasm_func_call(
     // #341 — the WASI exit status describes THIS call, not an earlier guest's.
     // A WASI command exits through `proc_exit` even when it succeeds, so a Store
     // that has run one command carries a `0` — and `0` is what
-    // `zwasm_store_wasi_exit_code` reports as a clean exit. Clearing above every
-    // branch below covers the interp and JIT/AOT arms and the direct-callback
-    // path in one place. A `wasm_func_new` func has no guest at all, so the
-    // clear is what makes its trap read back as "not an exit" rather than as
-    // the last guest's status. Instance-derived handles carry `.instance`,
-    // `wasm_func_new` ones carry `.store`.
+    // `zwasm_store_wasi_exit_code` reports as a clean exit. Recording + clearing
+    // above every branch below covers the interp and JIT/AOT arms and the
+    // direct-callback path in one place. Instance-derived handles carry
+    // `.instance`, `wasm_func_new` ones carry `.store`.
+    //
+    // #345 — the host this call reaches is the one its INSTANCE captured, which
+    // is what `zwasm_store_set_wasi` can move `store.wasi_host` off. A
+    // `wasm_func_new` func has no instance and so no guest: recording "no host"
+    // is what makes its trap read back as "not an exit" rather than as the last
+    // guest's status.
     if (if (handle.instance) |i| i.store else handle.store) |store| {
-        if (store.wasi_host) |host_opaque| {
+        store.active_wasi_host = if (handle.instance) |i| i.wasi_host else null;
+        if (store.active_wasi_host) |host_opaque| {
             const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
             host.exit_code = null;
         }

--- a/src/cli/run.zig
+++ b/src/cli/run.zig
@@ -646,21 +646,22 @@ pub fn runWasmCapturedFull(
     // the requested exit code. Other traps map to 1.
     // For non-exit traps, print the kind + message on stderr so
     // the CLI / `runWasm` callers can see what hit.
-    if (store.wasi_host) |host_opaque| {
-        const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
+    // #345 — resolve the host through the same rule as
+    // `zwasm_store_wasi_exit_code`: the one the called instance captured, not
+    // whichever is installed now. Unreachable divergence here today (the CLI
+    // installs one config and never swaps), but a second reader keyed on
+    // `store.wasi_host` is how the two halves drifted apart in the first place.
+    if (@import("../api/instance.zig").activeWasiHost(store)) |host| {
         if (host.exit_code) |_| {
             // exit_code already carries the status; nothing else to surface.
         } else {
             surfaceTrap(io, trap.?);
         }
-    } else {
-        surfaceTrap(io, trap.?);
-    }
-    if (store.wasi_host) |host_opaque| {
-        const host: *wasi_host.Host = @ptrCast(@alignCast(host_opaque));
         if (host.exit_code) |code| {
             return @intCast(@min(code, std.math.maxInt(u8)));
         }
+    } else {
+        surfaceTrap(io, trap.?);
     }
     return 1;
 }

--- a/src/runtime/instance/instance.zig
+++ b/src/runtime/instance/instance.zig
@@ -102,6 +102,16 @@ pub const Instance = struct {
     /// only flattens the sig + finality; the supertype chain + nested concrete
     /// refs need the whole `Types`. Null when the module has no type section.
     export_src_types: ?sections.Types = null,
+    /// The WASI host this instance captured at instantiate time — the
+    /// same address the interpreter bakes into each WASI binding's
+    /// `host_call.ctx` and the JIT into `jit.owned.rt.wasi_host`.
+    /// `wasi.h` promises an instance keeps using the config it was
+    /// built with, so its exit status has to be read from here and not
+    /// from `Store.wasi_host`. Set only when the instantiation really
+    /// captured the host, so the pointer is one the Store retires
+    /// rather than frees. Erased to `?*anyopaque` for the Zone-1 reason
+    /// `jit` and `module` already carry.
+    wasi_host: ?*anyopaque = null,
     /// C-API host_info slot (wasm.h `WASM_DECLARE_REF_BASE`): an opaque pointer
     /// + finalizer the Zone-3 binding attaches via `wasm_instance_set_host_info`;
     /// the runtime never reads it (fired in `wasm_instance_delete`, Zone 3).

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -56,6 +56,18 @@ pub const Store = struct {
     /// `zombies` and stay callable until store teardown. Cleared only
     /// when a different host is installed.
     wasi_host_captured: bool = false,
+    /// The WASI host the most recent call into this Store actually
+    /// reached — the one the called instance captured at instantiate
+    /// time, NOT whatever `wasi_host` now holds. `zwasm_store_set_wasi`
+    /// can move `wasi_host` on while an older instance keeps calling
+    /// through the host it was built with; this is the field that
+    /// addresses the same host the guest wrote. Only ever set to a host
+    /// an instantiation captured, which is exactly the condition under
+    /// which `zwasm_store_set_wasi` retires rather than frees it — so
+    /// the pointer stays valid until `wasm_store_delete`. Null until
+    /// the first such instantiation. Erased to `*anyopaque` for the
+    /// same Zone-1 reason as `wasi_host`.
+    active_wasi_host: ?*anyopaque = null,
     /// Hosts displaced by `zwasm_store_set_wasi` while captured.
     /// `wasm_store_delete` frees each one exactly like `wasi_host`.
     /// Erased to `*anyopaque` for the same Zone-1 reason.

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -68,6 +68,14 @@ pub const Store = struct {
     /// the first such instantiation. Erased to `*anyopaque` for the
     /// same Zone-1 reason as `wasi_host`.
     active_wasi_host: ?*anyopaque = null,
+    /// Re-entrancy depth of `wasm_func_call` on this Store. Only the
+    /// OUTERMOST call decides which host the exit status is read from and
+    /// which one is cleared: a host callback that calls back in — a nested
+    /// `wasm_func_call`, or a `wasm_instance_new` — must not retarget the
+    /// status away from the guest the embedder actually called. Without it a
+    /// nested call to a `wasm_func_new` func drops `active_wasi_host` to null
+    /// and the outer guest's `proc_exit` becomes unreadable.
+    wasi_call_depth: u32 = 0,
     /// Hosts displaced by `zwasm_store_set_wasi` while captured.
     /// `wasm_store_delete` frees each one exactly like `wasi_host`.
     /// Erased to `*anyopaque` for the same Zone-1 reason.

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include <wasm.h>
 #include <wasi.h>
@@ -63,46 +64,76 @@ static const char* engine_name(uint8_t kind) {
     }
 }
 
-/* One `_start` run inside a store the caller owns. Returns 0 on success; writes
- * the observed outcome into `*trapped` / `*has_code` / `*code`. The store
- * outlives the call, so the same store can be asked more than once. */
-static int run_in_store(wasm_store_t* store, const uint8_t* wasm, size_t wasm_len, uint8_t engine,
-                        bool* trapped, bool* has_code, uint32_t* code) {
-    int rc = 1;
-    wasm_module_t* module = NULL;
-    wasm_instance_t* instance = NULL;
-    wasm_extern_vec_t exports = { 0, NULL };
+/* An instantiated module the caller keeps: `_start` can be called on it later,
+ * after the Store's WASI config has moved on. */
+typedef struct {
+    wasm_module_t* module;
+    wasm_instance_t* instance;
+    wasm_extern_vec_t exports;
+} guest_t;
+
+static void guest_close(guest_t* g) {
+    if (g->exports.data) wasm_extern_vec_delete(&g->exports);
+    if (g->instance) wasm_instance_delete(g->instance);
+    if (g->module) wasm_module_delete(g->module);
+    g->exports.size = 0;
+    g->exports.data = NULL;
+    g->instance = NULL;
+    g->module = NULL;
+}
+
+/* Instantiate `wasm` in `store` under `engine`, leaving the handles with the
+ * caller. Returns 0 on success; `*out` is safe to `guest_close` either way. */
+static int guest_open(wasm_store_t* store, const uint8_t* wasm, size_t wasm_len, uint8_t engine,
+                      guest_t* out) {
+    out->module = NULL;
+    out->instance = NULL;
+    out->exports.size = 0;
+    out->exports.data = NULL;
 
     wasm_byte_vec_t binary = { wasm_len, (wasm_byte_t*) wasm };
-    module = wasm_module_new(store, &binary);
-    if (!module) { fputs("wasm_module_new failed\n", stderr); goto cleanup; }
+    out->module = wasm_module_new(store, &binary);
+    if (!out->module) { fputs("wasm_module_new failed\n", stderr); return 1; }
 
     wasm_extern_vec_t imports = { 0, NULL };
     wasm_trap_t* itrap = NULL;
-    instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
+    out->instance = zwasm_instance_new_ex(store, out->module, &imports, &itrap, engine);
     if (itrap) wasm_trap_delete(itrap);
-    if (!instance) { fputs("zwasm_instance_new_ex failed\n", stderr); goto cleanup; }
+    if (!out->instance) { fputs("zwasm_instance_new_ex failed\n", stderr); return 1; }
 
-    wasm_instance_exports(instance, &exports);
-    if (exports.size < 1 || !exports.data[0] || wasm_extern_kind(exports.data[0]) != WASM_EXTERN_FUNC) {
+    wasm_instance_exports(out->instance, &out->exports);
+    if (out->exports.size < 1 || !out->exports.data[0] ||
+        wasm_extern_kind(out->exports.data[0]) != WASM_EXTERN_FUNC) {
         fputs("missing _start export\n", stderr);
-        goto cleanup;
+        return 1;
     }
+    return 0;
+}
 
+/* Call `_start` on an already-built guest, then read the status back off
+ * `store`. Returns 0 on success. */
+static int guest_call_start(wasm_store_t* store, guest_t* g,
+                            bool* trapped, bool* has_code, uint32_t* code) {
     wasm_val_vec_t no_args = { 0, NULL };
     wasm_val_vec_t no_res = { 0, NULL };
-    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(exports.data[0]), &no_args, &no_res);
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(g->exports.data[0]), &no_args, &no_res);
     *trapped = trap != NULL;
     if (trap) wasm_trap_delete(trap);
 
     *code = 0xdeadbeefu; /* a false return must leave this untouched */
     *has_code = zwasm_store_wasi_exit_code(store, code);
-    rc = 0;
+    return 0;
+}
 
-cleanup:
-    if (exports.data) wasm_extern_vec_delete(&exports);
-    if (instance) wasm_instance_delete(instance);
-    if (module) wasm_module_delete(module);
+/* One `_start` run inside a store the caller owns. Returns 0 on success; writes
+ * the observed outcome into `*trapped` / `*has_code` / `*code`. The store
+ * outlives the call, so the same store can be asked more than once. */
+static int run_in_store(wasm_store_t* store, const uint8_t* wasm, size_t wasm_len, uint8_t engine,
+                        bool* trapped, bool* has_code, uint32_t* code) {
+    guest_t g;
+    int rc = guest_open(store, wasm, wasm_len, engine, &g);
+    if (rc == 0) rc = guest_call_start(store, &g, trapped, has_code, code);
+    guest_close(&g);
     return rc;
 }
 
@@ -223,6 +254,182 @@ cleanup:
     return rc;
 }
 
+/* What the Store's WASI setup looks like by the time the older instance is
+ * finally called. */
+typedef enum {
+    kReplacedIdle,     /* replaced; the new host has never run anything */
+    kReplacedCarries5, /* replaced; a guest of its own exited 5 on the new host */
+    kDetached,         /* removed with NULL — the Store has no WASI setup at all */
+} swap_kind;
+
+static const char* swap_name(swap_kind k) {
+    switch (k) {
+        case kReplacedCarries5: return "config replaced, installed host carries 5";
+        case kDetached: return "config detached with NULL";
+        default: return "config replaced, installed host never ran";
+    }
+}
+
+/* An instance reaches WASI through the host it captured when it was built —
+ * `wasi.h` states an instance keeps using the config it was built with.
+ * Moving the Store's config on must therefore not change which host that
+ * instance's exit status is read from. All three ways it can move are the same
+ * defect, and `zwasm_store_set_wasi`'s own comment documents all three.
+ *
+ * The assertion is on the code, not on `has_code`. `kReplacedCarries5` used to
+ * answer 5 — a `has_code`-only check passes on that, reporting the wrong
+ * guest's status as if it were right. */
+static int expect_status_follows_captured_host(uint8_t engine, swap_kind swap) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    uint8_t exit7[sizeof(kExitWasm)];
+    uint8_t exit5[sizeof(kExitWasm)];
+    guest_t old_guest = { NULL, NULL, { 0, NULL } };
+    guest_t new_guest = { NULL, NULL, { 0, NULL } };
+    const char* what = swap_name(swap);
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    memcpy(exit7, kExitWasm, sizeof(kExitWasm));
+    exit7[kRvalOffset] = 7;
+    memcpy(exit5, kExitWasm, sizeof(kExitWasm));
+    exit5[kRvalOffset] = 5;
+
+    /* Config A, and an instance built under it. */
+    zwasm_wasi_config_t* cfg_a = zwasm_wasi_config_new();
+    if (!cfg_a) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg_a); /* takes ownership */
+    if (guest_open(store, exit7, sizeof(exit7), engine, &old_guest)) goto cleanup;
+
+    /* A moves off the Store. It retires rather than being freed, because an
+     * instantiation captured it (#314) — which is what keeps it readable. */
+    if (swap == kDetached) {
+        zwasm_store_set_wasi(store, NULL);
+    } else {
+        zwasm_wasi_config_t* cfg_b = zwasm_wasi_config_new();
+        if (!cfg_b) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+        zwasm_store_set_wasi(store, cfg_b); /* takes ownership */
+    }
+
+    if (swap == kReplacedCarries5) {
+        if (guest_open(store, exit5, sizeof(exit5), engine, &new_guest)) goto cleanup;
+        if (guest_call_start(store, &new_guest, &trapped, &has_code, &code)) goto cleanup;
+        if (!trapped || !has_code || code != 5) {
+            fprintf(stderr, "[%s] %s: the new config's own guest read back trapped=%d has_code=%d code=%u\n",
+                    engine_name(engine), what, (int) trapped, (int) has_code, code);
+            goto cleanup;
+        }
+    }
+
+    /* The older instance runs now, and exits 7 through the host it captured. */
+    trapped = false;
+    has_code = false;
+    code = 0;
+    if (guest_call_start(store, &old_guest, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped) {
+        fprintf(stderr, "[%s] %s: expected a trap, got none\n", engine_name(engine), what);
+        goto cleanup;
+    }
+    if (!has_code) {
+        fprintf(stderr, "[%s] %s: proc_exit(7) reported no status — a clean exit reads back as a fault\n",
+                engine_name(engine), what);
+        goto cleanup;
+    }
+    if (code != 7) {
+        fprintf(stderr, "[%s] %s: proc_exit(7) read back %u\n", engine_name(engine), what, code);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    guest_close(&new_guest);
+    guest_close(&old_guest);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+/* The read window closes at the next INSTANTIATION, not only at the next call.
+ * Instantiating records the setup the new instance will use — that is what
+ * makes a `(start)` calling `proc_exit` readable — and it moves the setup the
+ * status is read from, exactly as another `wasm_func_call` would. `wasi.h`
+ * states both halves, and this is the only case in this file that builds a
+ * second instance after a swap, so nothing else pins them.
+ *
+ * The middle read is the one that matters: replacing the config alone does NOT
+ * hide the status. The last read is the documented cost of writing the setup
+ * at capture time, asserted so it cannot change silently. */
+static int expect_read_window_closes_at_instantiate(uint8_t engine) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    uint8_t exit7[sizeof(kExitWasm)];
+    uint8_t exit5[sizeof(kExitWasm)];
+    guest_t old_guest = { NULL, NULL, { 0, NULL } };
+    guest_t new_guest = { NULL, NULL, { 0, NULL } };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    memcpy(exit7, kExitWasm, sizeof(kExitWasm));
+    exit7[kRvalOffset] = 7;
+    memcpy(exit5, kExitWasm, sizeof(kExitWasm));
+    exit5[kRvalOffset] = 5;
+
+    zwasm_wasi_config_t* cfg_a = zwasm_wasi_config_new();
+    if (!cfg_a) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg_a); /* takes ownership */
+
+    if (guest_open(store, exit7, sizeof(exit7), engine, &old_guest)) goto cleanup;
+    if (guest_call_start(store, &old_guest, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped || !has_code || code != 7) {
+        fprintf(stderr, "[%s] read window: proc_exit(7) read back trapped=%d has_code=%d code=%u\n",
+                engine_name(engine), (int) trapped, (int) has_code, code);
+        goto cleanup;
+    }
+
+    /* Replace the config WITHOUT calling or instantiating. The status the
+     * embedder has not read yet stays readable. */
+    zwasm_wasi_config_t* cfg_b = zwasm_wasi_config_new();
+    if (!cfg_b) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg_b); /* takes ownership */
+
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (!has_code || code != 7) {
+        fprintf(stderr, "[%s] read window: the swap alone hid the status (has_code=%d code=%u)\n",
+                engine_name(engine), (int) has_code, code);
+        goto cleanup;
+    }
+
+    /* Building another instance moves the setup the status is read from, so
+     * the unread status is gone. This is what `wasi.h` tells the embedder to
+     * read before doing. */
+    if (guest_open(store, exit5, sizeof(exit5), engine, &new_guest)) goto cleanup;
+
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (has_code) {
+        fprintf(stderr, "[%s] read window: a status survived a later instantiation (code=%u)\n",
+                engine_name(engine), code);
+        goto cleanup;
+    }
+    if (code != 0xdeadbeefu) {
+        fprintf(stderr, "[%s] read window: wrote through `out` while returning false\n", engine_name(engine));
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    guest_close(&new_guest);
+    guest_close(&old_guest);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 /* A `wasm_func_new` func called directly has no guest behind it, so its trap
  * carries no exit status — and must not read back as the last guest's. The
  * clear sits above the direct-callback branch for exactly this: without it the
@@ -309,6 +516,10 @@ int main(void) {
         if (expect_no_exit(e, false, "unreachable with no WASI host")) return 1;
         if (expect_per_call(e)) return 1;
         if (expect_direct_call_clears(e)) return 1;
+        if (expect_status_follows_captured_host(e, kReplacedIdle)) return 1;
+        if (expect_status_follows_captured_host(e, kReplacedCarries5)) return 1;
+        if (expect_status_follows_captured_host(e, kDetached)) return 1;
+        if (expect_read_window_closes_at_instantiate(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -54,6 +54,17 @@ static const uint8_t kFaultWasm[] = {
     0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
 };
 
+/* (module (func (export "_start") unreachable) (start 0)) — the start function
+ * faults, so `wasm_instance_new` fails. It never calls `proc_exit`. */
+static const uint8_t kBadStartWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x00,
+    0x08, 0x01, 0x00,
+    0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
+};
+
 static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
 
 static const char* engine_name(uint8_t kind) {
@@ -430,6 +441,100 @@ cleanup:
     return rc;
 }
 
+/* Instantiating invalidates the status, whether or not the config moved.
+ * `wasi.h` names instantiation alongside the next call as the point to read
+ * before, and instantiation IS a read point of its own — a `(start)` can call
+ * `proc_exit`. Both halves have to hold, or the sentence is only true when the
+ * config happens to change:
+ *
+ *   - a second guest built on the SAME config must not leave the first's
+ *     status readable
+ *   - a `(start)` that faults WITHOUT exiting must not read back as the
+ *     earlier guest's exit — that is #341's failure shape at this read point
+ */
+static int expect_instantiate_invalidates(uint8_t engine) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    uint8_t exit7[sizeof(kExitWasm)];
+    guest_t first = { NULL, NULL, { 0, NULL } };
+    guest_t second = { NULL, NULL, { 0, NULL } };
+    wasm_module_t* bad_module = NULL;
+    wasm_instance_t* bad_instance = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    memcpy(exit7, kExitWasm, sizeof(kExitWasm));
+    exit7[kRvalOffset] = 7;
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    if (guest_open(store, exit7, sizeof(exit7), engine, &first)) goto cleanup;
+    if (guest_call_start(store, &first, &trapped, &has_code, &code)) goto cleanup;
+    if (!trapped || !has_code || code != 7) {
+        fprintf(stderr, "[%s] instantiate-invalidates: proc_exit(7) read back trapped=%d has_code=%d code=%u\n",
+                engine_name(engine), (int) trapped, (int) has_code, code);
+        goto cleanup;
+    }
+
+    /* A second guest on the SAME config — nothing replaced, nothing detached. */
+    if (guest_open(store, exit7, sizeof(exit7), engine, &second)) goto cleanup;
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (has_code) {
+        fprintf(stderr, "[%s] instantiate-invalidates: same-config instantiate left the earlier status readable (%u)\n",
+                engine_name(engine), code);
+        goto cleanup;
+    }
+    if (code != 0xdeadbeefu) {
+        fprintf(stderr, "[%s] instantiate-invalidates: wrote through `out` while returning false\n", engine_name(engine));
+        goto cleanup;
+    }
+
+    /* Now leave a status behind again, then fail an instantiation whose start
+     * function faults without calling proc_exit. */
+    if (guest_call_start(store, &second, &trapped, &has_code, &code)) goto cleanup;
+    if (!has_code || code != 7) {
+        fprintf(stderr, "[%s] instantiate-invalidates: second guest read back has_code=%d code=%u\n",
+                engine_name(engine), (int) has_code, code);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t bad_binary = { sizeof(kBadStartWasm), (wasm_byte_t*) kBadStartWasm };
+    bad_module = wasm_module_new(store, &bad_binary);
+    if (!bad_module) { fputs("bad-start module failed to parse\n", stderr); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* itrap = NULL;
+    bad_instance = zwasm_instance_new_ex(store, bad_module, &no_imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (bad_instance) {
+        fprintf(stderr, "[%s] instantiate-invalidates: a faulting start function instantiated\n",
+                engine_name(engine));
+        goto cleanup;
+    }
+
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (has_code) {
+        fprintf(stderr, "[%s] instantiate-invalidates: a faulting start read back as exit %u\n",
+                engine_name(engine), code);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (bad_instance) wasm_instance_delete(bad_instance);
+    if (bad_module) wasm_module_delete(bad_module);
+    guest_close(&second);
+    guest_close(&first);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 /* A `wasm_func_new` func called directly has no guest behind it, so its trap
  * carries no exit status — and must not read back as the last guest's. The
  * clear sits above the direct-callback branch for exactly this: without it the
@@ -520,6 +625,7 @@ int main(void) {
         if (expect_status_follows_captured_host(e, kReplacedCarries5)) return 1;
         if (expect_status_follows_captured_host(e, kDetached)) return 1;
         if (expect_read_window_closes_at_instantiate(e)) return 1;
+        if (expect_instantiate_invalidates(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -94,6 +94,27 @@ static const uint8_t kHostThenExitWasm[] = {
     0x0a, 0x0a, 0x01, 0x08, 0x00, 0x10, 0x00, 0x41, 0x07, 0x10, 0x01, 0x0b,
 };
 
+/* (module
+ *   (import "m" "h" (func $h))
+ *   (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
+ *   (func (call $h) (i32.const 7) (call $exit))
+ *   (start 2))
+ * The start function calls the host func FIRST, so the callback can call back
+ * into the Store before the start exits. Instantiation fails — the start
+ * traps — but the status it requested is still the last thing that ran. */
+static const uint8_t kReentrantStartWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x08, 0x02, 0x60, 0x00, 0x00, 0x60, 0x01, 0x7f, 0x00,
+    0x02, 0x2a, 0x02,
+    0x01, 0x6d, 0x01, 0x68, 0x00, 0x00,
+    0x16, 0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+    0x09, 0x70, 0x72, 0x6f, 0x63, 0x5f, 0x65, 0x78, 0x69, 0x74,
+    0x00, 0x01,
+    0x03, 0x02, 0x01, 0x00,
+    0x08, 0x01, 0x02,
+    0x0a, 0x0a, 0x01, 0x08, 0x00, 0x10, 0x00, 0x41, 0x07, 0x10, 0x01, 0x0b,
+};
+
 static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
 
 static const char* engine_name(uint8_t kind) {
@@ -723,6 +744,74 @@ cleanup:
     return rc;
 }
 
+/* A `(start)` that calls back into the Store keeps its own exit status.
+ * Instantiation is a read point — a `(start)` reaching `proc_exit` is why the
+ * host is recorded at capture time — so while the start runs it owns the
+ * status the same way an outermost `wasm_func_call` does. A host callback the
+ * start invokes can call `wasm_func_call`, and without that ownership the
+ * nested call retargets the record and the start's exit reads back as a
+ * fault. */
+static int expect_reentrant_start_keeps_its_status(uint8_t engine) {
+    int rc = 1;
+    uint32_t code = 0;
+    wasm_functype_t* inner_ft = NULL;
+    wasm_functype_t* outer_ft = NULL;
+    wasm_func_t* outer_host = NULL;
+    wasm_module_t* module = NULL;
+    wasm_instance_t* instance = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    inner_ft = wasm_functype_new_0_0();
+    g_nested_target = inner_ft ? wasm_func_new(store, inner_ft, do_nothing) : NULL;
+    outer_ft = wasm_functype_new_0_0();
+    outer_host = outer_ft ? wasm_func_new(store, outer_ft, call_back_in) : NULL;
+    if (!g_nested_target || !outer_host) { fputs("wasm_func_new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t binary = { sizeof(kReentrantStartWasm), (wasm_byte_t*) kReentrantStartWasm };
+    module = wasm_module_new(store, &binary);
+    if (!module) { fputs("reentrant-start module failed\n", stderr); goto cleanup; }
+
+    wasm_extern_t* import_externs[1] = { wasm_func_as_extern(outer_host) };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (instance) {
+        fprintf(stderr, "[%s] reentrant start: a start calling proc_exit instantiated\n", engine_name(engine));
+        goto cleanup;
+    }
+
+    code = 0xdeadbeefu;
+    if (!zwasm_store_wasi_exit_code(store, &code)) {
+        fprintf(stderr, "[%s] reentrant start: proc_exit(7) reported no status — the nested call took the host\n",
+                engine_name(engine));
+        goto cleanup;
+    }
+    if (code != 7) {
+        fprintf(stderr, "[%s] reentrant start: proc_exit(7) read back %u\n", engine_name(engine), code);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (instance) wasm_instance_delete(instance);
+    if (module) wasm_module_delete(module);
+    if (outer_host) wasm_func_delete(outer_host);
+    if (g_nested_target) wasm_func_delete(g_nested_target);
+    g_nested_target = NULL;
+    if (outer_ft) wasm_functype_delete(outer_ft);
+    if (inner_ft) wasm_functype_delete(inner_ft);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 /* A `wasm_func_new` func called directly has no guest behind it, so its trap
  * carries no exit status — and must not read back as the last guest's. The
  * clear sits above the direct-callback branch for exactly this: without it the
@@ -817,6 +906,7 @@ int main(void) {
         if (expect_non_wasi_instantiate_invalidates(e, false)) return 1;
         if (expect_non_wasi_instantiate_invalidates(e, true)) return 1;
         if (expect_nested_call_keeps_the_outer_host(e)) return 1;
+        if (expect_reentrant_start_keeps_its_status(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -65,6 +65,35 @@ static const uint8_t kBadStartWasm[] = {
     0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
 };
 
+/* (module (func (export "_start") nop)) — imports nothing at all, so
+ * instantiating it captures no WASI host. */
+static const uint8_t kNoWasiWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x00,
+    0x0a, 0x05, 0x01, 0x03, 0x00, 0x01, 0x0b,
+};
+
+/* (module
+ *   (import "m" "h" (func $h))
+ *   (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
+ *   (func (export "_start") (call $h) (i32.const 7) (call $exit)))
+ * The host func runs FIRST, so it can call back into the Store before the
+ * guest exits. */
+static const uint8_t kHostThenExitWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x08, 0x02, 0x60, 0x00, 0x00, 0x60, 0x01, 0x7f, 0x00,
+    0x02, 0x2a, 0x02,
+    0x01, 0x6d, 0x01, 0x68, 0x00, 0x00,
+    0x16, 0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+    0x09, 0x70, 0x72, 0x6f, 0x63, 0x5f, 0x65, 0x78, 0x69, 0x74,
+    0x00, 0x01,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x02,
+    0x0a, 0x0a, 0x01, 0x08, 0x00, 0x10, 0x00, 0x41, 0x07, 0x10, 0x01, 0x0b,
+};
+
 static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
 
 static const char* engine_name(uint8_t kind) {
@@ -535,6 +564,165 @@ cleanup:
     return rc;
 }
 
+/* A module that captures no WASI host still closes the read window.
+ * `zwasm_store_set_wasi` clears `wasi_host_captured`, so the capture branch is
+ * skipped for a module with no WASI imports built after a replace or a detach.
+ * `wasi.h` states the rule without that qualifier — creating an instance
+ * clears the status — so the clear cannot hang off the capture. */
+static int expect_non_wasi_instantiate_invalidates(uint8_t engine, bool detach) {
+    int rc = 1;
+    bool trapped = false, has_code = false;
+    uint32_t code = 0;
+    uint8_t exit7[sizeof(kExitWasm)];
+    guest_t first = { NULL, NULL, { 0, NULL } };
+    guest_t plain = { NULL, NULL, { 0, NULL } };
+    const char* what = detach ? "no-WASI instantiate after detach" : "no-WASI instantiate after replace";
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    memcpy(exit7, kExitWasm, sizeof(kExitWasm));
+    exit7[kRvalOffset] = 7;
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    if (guest_open(store, exit7, sizeof(exit7), engine, &first)) goto cleanup;
+    if (guest_call_start(store, &first, &trapped, &has_code, &code)) goto cleanup;
+    if (!has_code || code != 7) {
+        fprintf(stderr, "[%s] %s: proc_exit(7) read back has_code=%d code=%u\n",
+                engine_name(engine), what, (int) has_code, code);
+        goto cleanup;
+    }
+
+    if (detach) {
+        zwasm_store_set_wasi(store, NULL);
+    } else {
+        zwasm_wasi_config_t* cfg2 = zwasm_wasi_config_new();
+        if (!cfg2) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+        zwasm_store_set_wasi(store, cfg2); /* takes ownership */
+    }
+
+    if (guest_open(store, kNoWasiWasm, sizeof(kNoWasiWasm), engine, &plain)) goto cleanup;
+    code = 0xdeadbeefu;
+    has_code = zwasm_store_wasi_exit_code(store, &code);
+    if (has_code) {
+        fprintf(stderr, "[%s] %s: the earlier status stayed readable (%u)\n",
+                engine_name(engine), what, code);
+        goto cleanup;
+    }
+    if (code != 0xdeadbeefu) {
+        fprintf(stderr, "[%s] %s: wrote through `out` while returning false\n", engine_name(engine), what);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    guest_close(&plain);
+    guest_close(&first);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+/* A host callback that calls back into the Store must not retarget the status.
+ * The embedder made ONE call; the guest behind it exits 7. A nested
+ * `wasm_func_call` from inside the callback has no guest of its own — it is a
+ * `wasm_func_new` func — so recording it would leave the outer guest's exit
+ * unreadable, reporting a clean termination as a fault. */
+static wasm_func_t* g_nested_target = NULL;
+
+static wasm_trap_t* call_back_in(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    (void) args;
+    (void) results;
+    if (g_nested_target) {
+        wasm_val_vec_t no_args = { 0, NULL };
+        wasm_val_vec_t no_res = { 0, NULL };
+        wasm_trap_t* t = wasm_func_call(g_nested_target, &no_args, &no_res);
+        if (t) wasm_trap_delete(t);
+    }
+    return NULL;
+}
+
+static wasm_trap_t* do_nothing(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    (void) args;
+    (void) results;
+    return NULL;
+}
+
+static int expect_nested_call_keeps_the_outer_host(uint8_t engine) {
+    int rc = 1;
+    uint32_t code = 0;
+    wasm_functype_t* inner_ft = NULL;
+    wasm_functype_t* outer_ft = NULL;
+    wasm_func_t* outer_host = NULL;
+    wasm_module_t* module = NULL;
+    wasm_instance_t* instance = NULL;
+    wasm_extern_vec_t exports = { 0, NULL };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    zwasm_wasi_config_t* cfg = zwasm_wasi_config_new();
+    if (!cfg) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg); /* takes ownership */
+
+    inner_ft = wasm_functype_new_0_0();
+    g_nested_target = inner_ft ? wasm_func_new(store, inner_ft, do_nothing) : NULL;
+    outer_ft = wasm_functype_new_0_0();
+    outer_host = outer_ft ? wasm_func_new(store, outer_ft, call_back_in) : NULL;
+    if (!g_nested_target || !outer_host) { fputs("wasm_func_new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t binary = { sizeof(kHostThenExitWasm), (wasm_byte_t*) kHostThenExitWasm };
+    module = wasm_module_new(store, &binary);
+    if (!module) { fputs("host-then-exit module failed\n", stderr); goto cleanup; }
+
+    wasm_extern_t* import_externs[1] = { wasm_func_as_extern(outer_host) };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!instance) { fputs("host-then-exit instantiate failed\n", stderr); goto cleanup; }
+
+    wasm_instance_exports(instance, &exports);
+    if (exports.size < 1 || !exports.data[0]) { fputs("missing _start export\n", stderr); goto cleanup; }
+
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t no_res = { 0, NULL };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(exports.data[0]), &no_args, &no_res);
+    if (!trap) {
+        fprintf(stderr, "[%s] nested call: expected a trap from proc_exit, got none\n", engine_name(engine));
+        goto cleanup;
+    }
+    wasm_trap_delete(trap);
+
+    code = 0xdeadbeefu;
+    if (!zwasm_store_wasi_exit_code(store, &code)) {
+        fprintf(stderr, "[%s] nested call: proc_exit(7) reported no status — the nested call took the host\n",
+                engine_name(engine));
+        goto cleanup;
+    }
+    if (code != 7) {
+        fprintf(stderr, "[%s] nested call: proc_exit(7) read back %u\n", engine_name(engine), code);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (exports.data) wasm_extern_vec_delete(&exports);
+    if (instance) wasm_instance_delete(instance);
+    if (module) wasm_module_delete(module);
+    if (outer_host) wasm_func_delete(outer_host);
+    if (g_nested_target) wasm_func_delete(g_nested_target);
+    g_nested_target = NULL;
+    if (outer_ft) wasm_functype_delete(outer_ft);
+    if (inner_ft) wasm_functype_delete(inner_ft);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 /* A `wasm_func_new` func called directly has no guest behind it, so its trap
  * carries no exit status — and must not read back as the last guest's. The
  * clear sits above the direct-callback branch for exactly this: without it the
@@ -626,6 +814,9 @@ int main(void) {
         if (expect_status_follows_captured_host(e, kDetached)) return 1;
         if (expect_read_window_closes_at_instantiate(e)) return 1;
         if (expect_instantiate_invalidates(e)) return 1;
+        if (expect_non_wasi_instantiate_invalidates(e, false)) return 1;
+        if (expect_non_wasi_instantiate_invalidates(e, true)) return 1;
+        if (expect_nested_call_keeps_the_outer_host(e)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */


### PR DESCRIPTION
Closes #345.
Closes #350.

**#345 and #350 are the same defect, filed 40 minutes apart** (07:30Z / 08:11Z)
with the same mechanism cited down to the same line numbers. #350 contributed
the `NULL`-detach case that #345's investigation had not covered, so this
closes both rather than closing one as a duplicate.

`zwasm_store_wasi_exit_code` read `store.wasi_host`; a guest writes the host its
instance captured at instantiate time. `zwasm_store_set_wasi` moves the Store's
pointer on and keeps the old host alive (#314 / ADR-0219), so the writer and the
reader address different hosts as soon as the config moves.

The Store now records the host each call reaches — written where the capture is
already marked, so it is only ever a host the Store retires rather than frees —
and the accessor reads that. `src/cli/run.zig` was the second Store-mediated
reader and resolves through the same helper.

## Why not an instance-scoped accessor

#341 rejected it on sequencing: `zwasm-rust-sdk` was pinning the contract. That
reason has expired — the SDK is still at `278587f60`, before this accessor
existed — so ADR-0222 rejects it on new grounds instead: a `wasm_instance_t*`
adds nothing the Store cannot resolve, and it would strand `src/cli/run.zig`,
which reads the status with no instance handle in scope. Signature unchanged.

## Measured

auto / jit / interp, all three ways the config can move on. Expected `code=7` —
the older instance's own `proc_exit`:

| how the config moved on | before | after |
|---|---|---|
| replaced, new host never ran | `has_code=0` | `code=7` |
| replaced, new host carries a 5 | `has_code=0` (`code=5` before #341) | `code=7` |
| detached with `NULL` | `has_code=0` | `code=7` |

The cases assert the code. A `has_code`-only check passes on the 5.

Writing the setup at capture time is what keeps a `(start)`'s `proc_exit`
readable — `(start)` runs inside `wasm_instance_new`, never through
`wasm_func_call`. That makes instantiation a read point of its own, so it clears
the status like a call does, and an unread status does not survive one. Kept
rather than avoided: not writing at capture time would silently drop the
start-function status instead. `wasi.h`'s per-call rule names both events, and
two more cases pin it — that a replacement alone does not hide the status, that
the instantiation after it does, and that a second guest on the SAME config, or
a `(start)` that faults without exiting, does not read back as the earlier
guest's exit.

`src/cli/run.zig`'s change is behaviour-preserving: the CLI installs one config
and never swaps, so the two addressings agreed there. **The divergence is
unreachable today** — it is changed so a second reader cannot drift back onto
`store.wasi_host`.

## Not in scope

#344 — `component_wasi_p2.zig` / `component_wasi_p3.zig` read the same field off
a host they were handed, reached through `Instance.invoke`, never through
`wasm_func_call` or a Store. Nothing here reaches them and the issue stays open.

#352 — a `proc_exit` reached through a cross-module func import writes the
SOURCE instance's WASI host, so the guest that exits is not the called instance
this PR keys on. Measured identical on `62d9452d5` and on this branch, on
`interp`; `auto` and `jit` cannot instantiate a cross-module func import at all.
Not a regression here and not reachable by this mechanism. (Devin Review
flagged the shape; #352 carries the measurement.)

#348 — `wasi.h`'s "do not branch on the trap kind" paragraph. Untouched here,
and the two bullet rules around it are unchanged. Two things measured on this
branch belong to that issue rather than this one: the same claim is in
`test/c_api_conformance/wasi_exit_code.c`'s file header in a sharper form that
is also false (`proc_exit` is kind 18, `unreachable` is kind 1, on all three
engines at `62d9452d5`), and the read-window paragraph above gives it a cost —
`kind=18, has_code=0` is what the bullets classify as a genuine fault.
