### PR TITLE
fix(capi): the WASI exit status follows the runtime that ran proc_exit (#352)

### DIFF
--- a/.dev/decisions/0224_wasi_exit_status_executing_runtime.md
+++ b/.dev/decisions/0224_wasi_exit_status_executing_runtime.md
@@ -1,0 +1,209 @@
+# 0224 — The WASI exit status is read from the host that was written, not from an addressed one
+
+- **Status**: Proposed
+- **Date**: 2026-08-29
+- **Author**: Junji Takakura
+- **Tags**: c-abi, wasi, store, exit-status
+
+## Context
+
+ADR-0222 made `zwasm_store_wasi_exit_code` resolve through
+`Store.active_wasi_host` — the WASI host the *called* instance captured. That
+is the right host for every call that stays inside the instance it entered, and
+ADR-0222 recorded the case where it is not: an instance that imports another
+instance's export runs the SOURCE instance's body with the SOURCE instance's
+WASI binding, so `proc_exit` writes the host that instance captured while the
+record names the called one.
+
+The decision this replaces is not wrong. Its granularity is: it keys on the
+instance that was called, and the thing that writes the status is the runtime
+that ran `proc_exit`.
+
+Measured on `3583e2db1`, x86_64-linux, through the C ABI. One Store; `I1`
+built under config A exits 7; the config moves on; `I2` is built under config B,
+reaches into `I1`, and is called. Expected `code=7`.
+
+| how `I2` reaches `I1` | dispatch site | before | after |
+|---|---|---|---|
+| `call` on an imported func | `src/api/cross_module.zig:53` | `has_code=0` | `code=7` |
+| `call_indirect` on an imported table | `src/interp/mvp.zig:518` | `has_code=0` | `code=7` |
+
+The second row is why this is not a wiring change to
+`cross_module.CallCtx`. That path carries `source_rt` and could be made to
+retarget the record; the table path carries no `CallCtx`, has no Store in
+scope, and is a different function. Reading `src/interp/mvp.zig`, they are two
+of **seven** places where interp dispatch enters another instance's guest code:
+
+| site | shape |
+|---|---|
+| `src/api/cross_module.zig:53` | `call` → imported func's body |
+| `src/interp/mvp.zig:507` | `call_indirect` → foreign instance's own import thunk |
+| `src/interp/mvp.zig:518` | `call_indirect` → foreign body |
+| `src/interp/mvp.zig:568` | `call_ref` → foreign instance's own import thunk |
+| `src/interp/mvp.zig:577` | `call_ref` → foreign body |
+| `src/interp/mvp.zig:675` | `return_call_ref` → foreign instance's own import thunk |
+| `src/interp/mvp.zig:655`, `:717` | `return_call_ref` / `return_call_indirect` → foreign body |
+
+Two are measured; the other five are the same branch in a sibling handler. The
+count is the point: any decision that repairs the record AT the dispatch site
+has to be re-applied at each of them, and at the next one added. ADR-0222 has
+already recorded what that costs — "a second reader keyed on `wasi_host` is how
+the halves drifted apart to begin with".
+
+`auto` and `jit` cannot instantiate the caller in either shape: `buildBindings`
+resolves a cross-module import through the source instance's interpreter
+runtime (`src/api/instance.zig:576`) and a JIT-backed instance has none
+(ADR-0200). The defect is therefore unreachable on those engines today. That is
+a separate defect with its own fix and is **not** addressed here; the
+regression cases report it rather than skipping it, and assert in full the
+moment the instantiation starts succeeding.
+
+## Decision
+
+**The status is read from whichever of this Store's WASI hosts a `proc_exit`
+actually wrote. Nothing addresses a host in advance.**
+
+The Store's set of hosts is closed and already materialised: `Store.wasi_host`
+plus `Store.retired_wasi_hosts`. Every host an instance in this Store can write
+came from `Store.wasi_host` at capture time, and `zwasm_store_set_wasi` either
+retires it onto that list (captured) or frees it (never captured — so nothing
+can write it). `wasm_store_delete` already walks exactly this set.
+
+Three rules, one per role:
+
+- **Write — unchanged.** `src/wasi/proc.zig:62` stays the single place a
+  guest's exit status is recorded, on the host the executing runtime holds.
+  Both engines reach it: the interp thunk (`src/api/wasi.zig:191`) and the JIT
+  stub (`src/wasi/jit_dispatch.zig:335`) call the same `procExit`.
+- **Clear.** Any Store-mediated entry into guest code clears `exit_code` on
+  every host in the set on the way in; a *nested* one also clears on the way
+  out. `Store.wasi_call_depth` is what "nested" means, and keeps its ADR-0222
+  role.
+- **Read.** `activeWasiHost` becomes a scan of the set for the one host
+  carrying an `exit_code`. `zwasm_store_wasi_exit_code` and
+  `src/cli/run.zig`'s trap-vs-exit branch keep going through it, so the two
+  readers still cannot drift.
+
+`Store.active_wasi_host` and `Instance.wasi_host` are removed, along with the
+capture-time recording at `src/api/instance.zig:835-841`, `:1133-1139` and
+`:2126-2127`. They existed only to name a host in advance, which is the part
+that was too coarse. The signature does not change.
+
+**At most one host in the set carries a code at any read point.** A `proc_exit`
+unwinds the whole call, so the guest that wrote one cannot run again and no
+second write can follow it inside that call. The one way two could coexist is a
+host callback that makes a nested `wasm_func_call`, swallows the trap its guest
+raised, and returns to an outer guest that then exits on a different host —
+which is what the clear-on-the-way-out of a nested entry removes. It is safe to
+clear there because the outer guest cannot already hold a status: if it had
+exited, the callback would never have run.
+
+`include/wasi.h` states the read rule without naming an instance: the status is
+whichever exit this Store's last call or instantiation produced, and the
+embedder does not have to know which of its setups the guest reached.
+
+## Alternatives considered
+
+**Retarget `Store.active_wasi_host` at the cross-module dispatch point.** The
+obvious fix: `cross_module.CallCtx` already carries `source_rt`, so the thunk
+could point the record at the source instance's host and restore it on a normal
+return. Rejected on the measurement above — it repairs one of seven sites, and
+the `call_indirect` case stays red. The five unmeasured siblings would each
+need the same three lines, in a Zone (`src/interp/`) that has no Store; getting
+it there means a back-pointer on `Runtime` and the rule restated at every
+dispatch handler. A rule that has to be restated per site is the failure mode
+ADR-0222 already paid for once.
+
+**Carry the host on the trap, and resolve the accessor through it.** Rejected.
+By the time a trap object exists the identity is gone: the interp unwinds with
+a bare `error.WasiExit` and the JIT with `trap_kind = 18`, neither of which
+carries a pointer. Putting one there means threading a host through
+`invokeCrossRuntime`'s error path and through the JIT's trap fields — the same
+per-site enumeration as above, in a second place. It also does not reach the
+readers: both `zwasm_store_wasi_exit_code` and `src/cli/run.zig:653` are handed
+a Store, not a trap, and `src/cli/run.zig` has no trap object in scope at all.
+
+**Make the accessor instance-scoped.** Rejected again, and now for a third
+reason on top of ADR-0222's two: the instance the embedder holds is `I2`, and
+`I2` is precisely the instance that did not exit. An instance-scoped accessor
+would make the caller name the wrong instance by construction.
+
+**Keep `active_wasi_host` and fall back to a scan when it carries no code.**
+Rejected. Two resolution rules where one suffices, and the fallback fires in
+exactly the case the primary rule gets wrong — so the primary rule is never
+load-bearing and only obscures which one answered.
+
+## Consequences
+
+**The record stops modelling which instance was called.** What the Store keeps
+is "clear before running", which is engine-independent, dispatch-independent,
+and does not grow a case when a new cross-instance dispatch shape is added.
+That is the whole reason to prefer it: the seven sites in the census need no
+knowledge of the status at all.
+
+**Reading a retired host stays safe by construction**, for ADR-0219's reason
+unchanged: the set is `wasi_host` plus `retired_wasi_hosts`, and
+`wasm_store_delete` frees the latter after the instance and zombie cascade.
+This decision reads more of that list than ADR-0222 did but adds nothing to it.
+
+**The clear and the read are O(number of setups this Store has held).** One for
+an embedder that installs a config and leaves it, one more per
+`zwasm_store_set_wasi` that displaced a captured host. It is the same list
+`wasm_store_delete` already walks, and the work is a null store and a null
+compare per entry. An embedder that swaps configs in a loop without deleting
+the Store pays for it on every call; recorded because nothing else in the C
+surface has a per-call cost that grows with embedder history.
+
+**The read window is unchanged.** `zwasm_store_set_wasi` still does not clear,
+so a status the embedder has not read yet survives a bare swap; the next call
+or instantiation still closes the window, because both still clear. ADR-0222's
+two regression cases pin that and keep passing unmodified.
+
+**Trap classification is untouched.** `ZWASM_TRAP_WASI_EXIT` comes from the
+engine's own unwind and never reads `host.exit_code`
+(`src/api/trap_surface.zig:152` / `:189`). This decision moves only which host
+the read and the clear reach.
+
+**`src/zwasm/linker.zig` still records nothing, and now for a stated reason.**
+Its host is bound directly (`linker.zig:592-608`) and never becomes
+`store.wasi_host`, so it is not in the set and the accessor does not see it.
+Same answer as ADR-0222 gave, arrived at by the set membership rather than by a
+flag that happened not to be written.
+
+**#344 is still not closed and still not touched.** The component guards
+(`component_wasi_p2.zig:1995`, `component_wasi_p3.zig:184`) read
+`built.ctx.host.exit_code` on a host their caller handed them, reached through
+`Instance.invoke` and never through a Store. Neither the clear nor the read
+here is on that path. Its own question stays open.
+
+**AOT is unreachable from this defect and is left alone.** The AOT run path
+(`src/engine/runner.zig:379` / `:482` / `:703`) sets one `wasi_host` on one
+runtime per run and is not Store-mediated; and the cross-module import that
+produces the mismatch cannot be built on a JIT-backed instance at all, which is
+what AOT loads.
+
+**Not verified on macOS or Windows before merge.** The evidence above is
+x86_64-linux — `zig build test-all` and `test-c-api-conformance` green in Debug
+and `test` / `test-c-api-conformance` green in ReleaseSafe, on that host only. The change is pointer bookkeeping on structs that already exist,
+with no platform-conditional code, so the 3-OS `ci-required` gate is the first
+and sufficient check there.
+
+## References
+
+- Issue #352 — the report, and the two questions it left open: whether the
+  record should move at all, and whether the accessor should resolve through
+  the trap instead. Both are answered above: it should not move, and it should
+  not.
+- ADR-0222 — the addressing this replaces. Its consequence
+  "a cross-module call still writes a host this record does not name" is the
+  defect; the decision itself stands, at a granularity that turned out to be
+  one level too coarse.
+- ADR-0219 — the retire-instead-of-free rule that makes the Store's host set
+  closed, which is what this decision resolves through.
+- ADR-0200 — why a JIT-backed instance has no interpreter runtime, hence why
+  `auto` / `jit` cannot build the caller and are unmeasured here.
+- #344 — the third reader of `host.exit_code`, on the component path, out of
+  scope.
+- `test/c_api_conformance/wasi_exit_code.c` — two regression cases, one per
+  dispatch shape, asserting the code (not `has_code`) on auto / jit / interp,
+  alongside ADR-0222's five.

--- a/.dev/decisions/0224_wasi_exit_status_executing_runtime.md
+++ b/.dev/decisions/0224_wasi_exit_status_executing_runtime.md
@@ -146,6 +146,19 @@ unchanged: the set is `wasi_host` plus `retired_wasi_hosts`, and
 `wasm_store_delete` frees the latter after the instance and zombie cascade.
 This decision reads more of that list than ADR-0222 did but adds nothing to it.
 
+**The retirement slot is reserved at capture, which is new here.** ADR-0219
+made the retirement append tolerate its own OOM — the host leaks rather than
+dangling. That was sufficient while ADR-0222 held the address on
+`Instance.wasi_host` as well: a host missing from the list was still findable.
+It is not sufficient once the list IS the addressing, because a host that fails
+to reach it is unreadable while its instances stay callable, and their exits
+report nothing. So a capture reserves the one retirement slot it can cause
+(`retired_wasi_hosts.ensureUnusedCapacity(1)` at both sites that set
+`wasi_host_captured`), which moves the failure onto the instantiation, where
+the C surface already reports it by returning NULL. The append itself stays
+fallible rather than assuming the capacity: a library that panics on a violated
+internal invariant is worse than one that degrades to ADR-0219's behaviour.
+
 **The clear and the read are O(number of setups this Store has held).** One for
 an embedder that installs a config and leaves it, one more per
 `zwasm_store_set_wasi` that displaced a captured host. It is the same list

--- a/include/wasi.h
+++ b/include/wasi.h
@@ -155,11 +155,13 @@ WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
  * into the Store again, or creating another instance in it —
  * either one clears it.
  *
- * It is read from the WASI setup the CALLED instance was built
- * with, which is the setup that instance keeps using. Replacing
- * that setup with `zwasm_store_set_wasi`, or removing it with
- * `NULL`, therefore neither hides an older instance's exit
- * status nor lets a newer instance's stand in for it.
+ * It is read from whichever of this Store's WASI setups the guest
+ * that exited actually used — you do not have to know which
+ * instance ran. A call that reaches another instance's export
+ * therefore reports that instance's status, and replacing the
+ * Store's setup with `zwasm_store_set_wasi`, or removing it with
+ * `NULL`, neither hides an older instance's exit status nor lets
+ * a newer instance's stand in for it.
  */
 WASM_API_EXTERN bool zwasm_store_wasi_exit_code(const wasm_store_t*, uint32_t* out);
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -380,16 +380,54 @@ pub export fn zwasm_store_wasi_exit_code(s: ?*const Store, out: ?*u32) callconv(
     return true;
 }
 
-/// #345 — the WASI host to read a call's exit status from: the one the called
-/// instance captured, which `zwasm_store_set_wasi` can have moved
-/// `store.wasi_host` off. Null when nothing has run in this Store yet, or when
-/// the last call was a `wasm_func_new` func with no guest behind it. The single
-/// resolution rule for every Store-mediated reader — the accessor above and
-/// `src/cli/run.zig`'s trap-vs-exit branch — so a second reader cannot drift
-/// back onto `wasi_host`.
+/// #352 / ADR-0224 — discard any recorded exit status across this Store, on
+/// the way into guest code, so what a reader sees afterwards describes that
+/// entry alone.
+///
+/// Clearing every host rather than one addressed host IS the decision: which
+/// host a call reaches is not knowable before it runs, because dispatch can
+/// leave the instance it entered and run another one's body with that
+/// instance's WASI binding.
+///
+/// Written as a drain of the accessor below so the SET has exactly one
+/// definition — a third source of hosts would otherwise have to be added to
+/// two walks and one of them would be missed. Each pass strictly reduces the
+/// number of hosts carrying a status, so it terminates; by the accessor's
+/// invariant it is normally one clear plus one confirming scan.
+pub fn clearWasiExitStatus(store: *const Store) void {
+    while (activeWasiHost(store)) |h| h.exit_code = null;
+}
+
+/// #352 / ADR-0224 — the WASI host to read an exit status from: whichever one
+/// a `proc_exit` actually wrote. Null when no guest in this Store has exited
+/// since the last entry into guest code.
+///
+/// The set walked here is every host a guest in this Store can write, and it
+/// is closed: an instance's host always came from `store.wasi_host` at capture
+/// time, and `zwasm_store_set_wasi` frees a host nothing captured on the spot
+/// rather than retiring it, so that one can never be written afterwards. It is
+/// the same set `wasm_store_delete` frees.
+///
+/// Scanning is sound because AT MOST ONE host in it carries a status at any
+/// read point. A `proc_exit` unwinds the whole call, so the guest that wrote
+/// one cannot run again and nothing can write after it; the one way two could
+/// coexist — a host callback that swallows a nested call's exit trap and
+/// returns to an outer guest that exits on a different host — is removed by
+/// the nested entry clearing again on its way out.
+///
+/// The single resolution rule for every Store-mediated reader: this accessor
+/// and `src/cli/run.zig`'s trap-vs-exit branch, so a second reader cannot
+/// drift onto `wasi_host` alone.
 pub fn activeWasiHost(store: *const Store) ?*wasi_host.Host {
-    const host_opaque = store.active_wasi_host orelse return null;
-    return @ptrCast(@alignCast(host_opaque));
+    if (store.wasi_host) |h| {
+        const typed: *wasi_host.Host = @ptrCast(@alignCast(h));
+        if (typed.exit_code != null) return typed;
+    }
+    for (store.retired_wasi_hosts.items) |h| {
+        const typed: *wasi_host.Host = @ptrCast(@alignCast(h));
+        if (typed.exit_code != null) return typed;
+    }
+    return null;
 }
 
 // ============================================================
@@ -820,26 +858,18 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     jit.owned.rt.wasi_host = store.wasi_host;
     // Captured for the JitInstance's life. May over-mark (this runs before
     // `runStart`, which can still fail the instantiation) — see buildBindings.
-    // #345 — record it as the host this Store's calls now reach, BEFORE
-    // `runStart`: a `(start)` that calls `proc_exit` records its status during
-    // `wasm_instance_new`, and that has always been readable.
-    // Instantiating is a read point for the status (a `(start)` can call
-    // `proc_exit`), so it invalidates the previous one like a call does —
-    // otherwise a Store whose config did NOT move reports an earlier call's
-    // status as this instantiation's, and a `(start)` that faults without
-    // exiting reads back as that earlier exit. Unconditional, because
-    // `zwasm_store_set_wasi` leaves `wasi_host` null on a detach: a module
-    // that captures nothing must still close the window. Cleared before
-    // `runStart` so the start's own status survives. Skipped inside a call in
-    // progress — that call owns the status until it returns.
-    if (store.wasi_call_depth == 0) {
-        if (activeWasiHost(store)) |h| h.exit_code = null;
-        store.active_wasi_host = null;
-    }
-    if (store.wasi_host != null) {
-        store.wasi_host_captured = true;
-        if (store.wasi_call_depth == 0) store.active_wasi_host = store.wasi_host;
-    }
+    if (store.wasi_host != null) store.wasi_host_captured = true;
+    // #352 / ADR-0224 — instantiating is an entry into guest code: a `(start)`
+    // can call `proc_exit`. Clear before `runStart`, so the start's own status
+    // is what reads back and an earlier call's cannot stand in for it.
+    // Unconditional, because `zwasm_store_set_wasi` leaves `wasi_host` null on
+    // a detach: a module that captures nothing must still close the window.
+    // Clear again on the way out when this instantiation was itself nested
+    // inside a call in progress — that call owns the status, so a guest a host
+    // callback built must not leave one behind.
+    const nested_entry = store.wasi_call_depth > 0;
+    clearWasiExitStatus(store);
+    defer if (nested_entry) clearWasiExitStatus(store);
 
     // Wasm §4.5.4 — run the `(start)` function AFTER setup initialised globals /
     // memory / tables, BEFORE the instance is surfaced. A start trap fails
@@ -850,10 +880,9 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     {
         // #345 — while the start function runs it OWNS the status, exactly as
         // an outermost `wasm_func_call` does: it can reach `proc_exit`, and a
-        // host callback it invokes can call back into this Store. Without the
-        // depth that nested call would retarget `active_wasi_host` away from
-        // the host recorded just above, and the start's own exit would be
-        // unreadable.
+        // host callback it invokes can call back into this Store. The depth is
+        // what makes that callback's own call nested, so its guest's status is
+        // dropped on the way out instead of standing in for the start's.
         store.wasi_call_depth +|= 1;
         defer store.wasi_call_depth -|= 1;
         jit.runStart() catch |err| {
@@ -874,7 +903,6 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
         .module = module,
         .runtime = null,
         .jit = jit,
-        .wasi_host = store.wasi_host,
     };
 
     // ADR-0200 — surface the JIT's func exports through the C-API discovery path
@@ -1115,29 +1143,15 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
         return null;
     };
 
-    // #345 — `buildBindings` marks `wasi_host_captured` on the branch that
-    // bakes the host into a WASI binding's `host_call.ctx`. Record the same
-    // address on the instance, and as the host this Store's calls now reach,
-    // BEFORE the start function below can call `proc_exit`. Keyed on
-    // `wasi_host_captured` and not on `wasi_host != null`: the flag is what
-    // guarantees `zwasm_store_set_wasi` retires the host instead of freeing
-    // it, so an unkeyed write is the one that could dangle. It is sticky
-    // across instances, so this may over-mark an instance with no WASI
-    // imports — harmless, since such an instance cannot record a status and
-    // its calls only clear one.
-    // Same invalidation as the JIT arm above, and unconditional for the same
-    // reason: `wasi_host_captured` is reset by `zwasm_store_set_wasi`, so a
-    // module with no WASI imports built after a replace or a detach would
-    // otherwise leave the previous guest's status readable. Before the start
-    // function runs below.
-    if (store.wasi_call_depth == 0) {
-        if (activeWasiHost(store)) |h| h.exit_code = null;
-        store.active_wasi_host = null;
-    }
-    if (store.wasi_host_captured) {
-        inst.wasi_host = store.wasi_host;
-        if (store.wasi_call_depth == 0) store.active_wasi_host = store.wasi_host;
-    }
+    // #352 / ADR-0224 — same entry rule as the JIT arm above: instantiating
+    // enters guest code, because the start function below can call
+    // `proc_exit`. Clear on the way in, unconditionally — a module with no
+    // WASI imports, built after a replace or a detach, must still close the
+    // window — and again on the way out when this instantiation was itself
+    // nested inside a call in progress.
+    const nested_entry = store.wasi_call_depth > 0;
+    clearWasiExitStatus(store);
+    defer if (nested_entry) clearWasiExitStatus(store);
 
     // D-174 defensive fix: register inst in the store's live-instance
     // list so wasm_store_delete can cascade-cleanup on reverse-order
@@ -1164,6 +1178,8 @@ pub fn instantiateInternal(store: *Store, module: *const Module, builder_state: 
         // #345 — the start function owns the status while it runs; see the
         // JIT arm's note. Covers both shapes below (imported start via
         // `host_calls`, and a defined one dispatched here).
+        // The depth is also what makes a `wasm_func_call` a host callback
+        // makes from inside the start a NESTED entry (ADR-0224).
         store.wasi_call_depth +|= 1;
         defer store.wasi_call_depth -|= 1;
         if (sfx < inst.func_ptrs_storage.len) {
@@ -2111,26 +2127,27 @@ pub export fn wasm_func_call(
     // direct-callback path in one place. Instance-derived handles carry
     // `.instance`, `wasm_func_new` ones carry `.store`.
     //
-    // #345 — the host this call reaches is the one its INSTANCE captured, which
-    // is what `zwasm_store_set_wasi` can move `store.wasi_host` off. A
-    // `wasm_func_new` func has no instance and so no guest: recording "no host"
-    // is what makes its trap read back as "not an exit" rather than as the last
+    // #352 / ADR-0224 — this call is an entry into guest code, so it discards
+    // any status still standing across this Store's hosts. Which host it will
+    // reach is not knowable here: dispatch can leave the instance it entered
+    // and run another one's body with that instance's WASI binding. A
+    // `wasm_func_new` func has no guest behind it at all, and the same clear is
+    // what makes its trap read back as "not an exit" rather than as the last
     // guest's status.
     //
-    // Only the OUTERMOST call decides this. A host callback can call back in,
-    // and a nested `wasm_func_call` would otherwise retarget the status to its
-    // own callee — to null, for a `wasm_func_new` one — leaving the outer
-    // guest's later `proc_exit` unreadable.
+    // A NESTED call clears again on the way out. A host callback can call back
+    // in, swallow the trap its guest raised, and return to an outer guest that
+    // then exits on a different host; without the second clear both would carry
+    // a status and the scan would have two answers.
     const call_store: ?*Store = if (handle.instance) |i| i.store else handle.store;
+    const nested_call = if (call_store) |store| store.wasi_call_depth > 0 else false;
     if (call_store) |store| {
-        if (store.wasi_call_depth == 0) {
-            store.active_wasi_host = if (handle.instance) |i| i.wasi_host else null;
-            if (activeWasiHost(store)) |host| host.exit_code = null;
-        }
+        clearWasiExitStatus(store);
         store.wasi_call_depth +|= 1;
     }
     defer if (call_store) |store| {
         store.wasi_call_depth -|= 1;
+        if (nested_call) clearWasiExitStatus(store);
     };
     // #315: a `wasm_func_new[_with_env]` func has no instance — the C callback
     // IS its body, so invoke it here rather than reporting a silent success.

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -343,7 +343,11 @@ pub export fn zwasm_store_set_wasi(s: ?*Store, h: ?*wasi_host.Host) callconv(.c)
         if (store.wasi_host_captured) {
             // `c_allocator` is what `zwasm_wasi_config_new` used for every
             // host this list can hold, and what `wasm_store_delete` frees
-            // them with.
+            // them with. The slot is already reserved: whatever set
+            // `wasi_host_captured` reserved one and the flag is cleared below,
+            // so each capture funds exactly the one retirement it can cause
+            // (ADR-0224). Kept fallible rather than assuming the capacity so a
+            // violated reservation degrades instead of panicking in a library.
             // EXEMPT-FALLBACK: ADR-0014 — an append OOM accepts the leak over the UAF, mirroring parkAsZombie.
             store.retired_wasi_hosts.append(std.heap.c_allocator, old_opaque) catch {};
         } else {
@@ -403,10 +407,12 @@ pub fn clearWasiExitStatus(store: *const Store) void {
 /// since the last entry into guest code.
 ///
 /// The set walked here is every host a guest in this Store can write, and it
-/// is closed: an instance's host always came from `store.wasi_host` at capture
-/// time, and `zwasm_store_set_wasi` frees a host nothing captured on the spot
-/// rather than retiring it, so that one can never be written afterwards. It is
-/// the same set `wasm_store_delete` frees.
+/// is closed on both sides: an instance's host always came from
+/// `store.wasi_host` at capture time, `zwasm_store_set_wasi` frees a host
+/// nothing captured on the spot rather than retiring it, and a capture
+/// reserves the retirement slot it may later need — so a displaced host cannot
+/// fall out of the list and become unreadable while its instances stay
+/// callable. It is the same set `wasm_store_delete` frees.
 ///
 /// Scanning is sound because AT MOST ONE host in it carries a status at any
 /// read point. A `proc_exit` unwinds the whole call, so the guest that wrote
@@ -542,6 +548,15 @@ fn buildBindings(
             // on `store.zombies`. May over-mark (this also runs on the
             // throwaway arena in `collectHostFuncTargets`); over-marking
             // only defers a free, so nothing compensates for it.
+            //
+            // ADR-0224 — reserve the retirement slot HERE, at capture, not at
+            // the swap. `activeWasiHost` finds a displaced host only through
+            // `retired_wasi_hosts`, so a host that fails to reach that list is
+            // not merely leaked (the pre-ADR-0224 cost) but unreadable: its
+            // instances stay callable and their exits report nothing.
+            // Reserving at capture puts the allocation failure on the
+            // instantiation, which can and does report it.
+            try store.retired_wasi_hosts.ensureUnusedCapacity(std.heap.c_allocator, 1);
             store.wasi_host_captured = true;
             bindings[idx] = .{ .func = .{
                 .host_call = .{ .fn_ptr = thunk, .ctx = wasi_host_ptr },
@@ -857,8 +872,16 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     }
     jit.owned.rt.wasi_host = store.wasi_host;
     // Captured for the JitInstance's life. May over-mark (this runs before
-    // `runStart`, which can still fail the instantiation) — see buildBindings.
-    if (store.wasi_host != null) store.wasi_host_captured = true;
+    // `runStart`, which can still fail the instantiation) — see buildBindings,
+    // including why the retirement slot is reserved at capture.
+    if (store.wasi_host != null) {
+        store.retired_wasi_hosts.ensureUnusedCapacity(std.heap.c_allocator, 1) catch {
+            jit.deinit(alloc);
+            alloc.destroy(jit);
+            return null;
+        };
+        store.wasi_host_captured = true;
+    }
     // #352 / ADR-0224 — instantiating is an entry into guest code: a `(start)`
     // can call `proc_exit`. Clear before `runStart`, so the start's own status
     // is what reads back and an earlier call's cannot stand in for it.

--- a/src/runtime/instance/instance.zig
+++ b/src/runtime/instance/instance.zig
@@ -102,16 +102,6 @@ pub const Instance = struct {
     /// only flattens the sig + finality; the supertype chain + nested concrete
     /// refs need the whole `Types`. Null when the module has no type section.
     export_src_types: ?sections.Types = null,
-    /// The WASI host this instance captured at instantiate time — the
-    /// same address the interpreter bakes into each WASI binding's
-    /// `host_call.ctx` and the JIT into `jit.owned.rt.wasi_host`.
-    /// `wasi.h` promises an instance keeps using the config it was
-    /// built with, so its exit status has to be read from here and not
-    /// from `Store.wasi_host`. Set only when the instantiation really
-    /// captured the host, so the pointer is one the Store retires
-    /// rather than frees. Erased to `?*anyopaque` for the Zone-1 reason
-    /// `jit` and `module` already carry.
-    wasi_host: ?*anyopaque = null,
     /// C-API host_info slot (wasm.h `WASM_DECLARE_REF_BASE`): an opaque pointer
     /// + finalizer the Zone-3 binding attaches via `wasm_instance_set_host_info`;
     /// the runtime never reads it (fired in `wasm_instance_delete`, Zone 3).

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -56,25 +56,14 @@ pub const Store = struct {
     /// `zombies` and stay callable until store teardown. Cleared only
     /// when a different host is installed.
     wasi_host_captured: bool = false,
-    /// The WASI host the most recent call into this Store actually
-    /// reached — the one the called instance captured at instantiate
-    /// time, NOT whatever `wasi_host` now holds. `zwasm_store_set_wasi`
-    /// can move `wasi_host` on while an older instance keeps calling
-    /// through the host it was built with; this is the field that
-    /// addresses the same host the guest wrote. Only ever set to a host
-    /// an instantiation captured, which is exactly the condition under
-    /// which `zwasm_store_set_wasi` retires rather than frees it — so
-    /// the pointer stays valid until `wasm_store_delete`. Null until
-    /// the first such instantiation. Erased to `*anyopaque` for the
-    /// same Zone-1 reason as `wasi_host`.
-    active_wasi_host: ?*anyopaque = null,
-    /// Re-entrancy depth of `wasm_func_call` on this Store. Only the
-    /// OUTERMOST call decides which host the exit status is read from and
-    /// which one is cleared: a host callback that calls back in — a nested
-    /// `wasm_func_call`, or a `wasm_instance_new` — must not retarget the
-    /// status away from the guest the embedder actually called. Without it a
-    /// nested call to a `wasm_func_new` func drops `active_wasi_host` to null
-    /// and the outer guest's `proc_exit` becomes unreadable.
+    /// Re-entrancy depth of Store-mediated entry into guest code — a
+    /// `wasm_func_call`, or a `wasm_instance_new` whose `(start)` runs.
+    /// ADR-0224: every such entry clears the exit status across this Store's
+    /// hosts on the way in, and a NESTED one clears again on the way out.
+    /// That second clear is what keeps at most one host carrying a status: a
+    /// host callback can make a nested call, swallow the trap its guest
+    /// raised, and return to an outer guest that then exits on a different
+    /// host. Only the outermost entry's status is the embedder's to read.
     wasi_call_depth: u32 = 0,
     /// Hosts displaced by `zwasm_store_set_wasi` while captured.
     /// `wasm_store_delete` frees each one exactly like `wasi_host`.

--- a/test/c_api_conformance/wasi_exit_code.c
+++ b/test/c_api_conformance/wasi_exit_code.c
@@ -115,6 +115,54 @@ static const uint8_t kReentrantStartWasm[] = {
     0x0a, 0x0a, 0x01, 0x08, 0x00, 0x10, 0x00, 0x41, 0x07, 0x10, 0x01, 0x0b,
 };
 
+/* (module
+ *   (import "m1" "_start" (func $f))
+ *   (func (export "_start") (call $f)))
+ * Calls another instance's export and nothing else. Paired with `kExitWasm`
+ * patched to 7 as the exporter, so the guest that reaches `proc_exit` is the
+ * IMPORTED instance, not the one `wasm_func_call` was handed. */
+static const uint8_t kCrossFuncCallerWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+    0x02, 0x0d, 0x01,
+    0x02, 0x6d, 0x31,
+    0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74,
+    0x00, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x01,
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+};
+
+/* (module
+ *   (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
+ *   (func $run (call $exit (i32.const 7)))
+ *   (table (export "t") 1 funcref)
+ *   (elem (i32.const 0) $run))
+ * The same exit-7 guest as `kExitWasm`, reached through an exported TABLE
+ * rather than an exported func — the wit-bindgen shim shape (D-325). */
+static const uint8_t kCrossTableExporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x60, 0x01, 0x7f, 0x00, 0x60,
+    0x00, 0x00, 0x02, 0x24, 0x01, 0x16, 0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73,
+    0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31, 0x09, 0x70, 0x72, 0x6f,
+    0x63, 0x5f, 0x65, 0x78, 0x69, 0x74, 0x00, 0x00, 0x03, 0x02, 0x01, 0x01, 0x04, 0x04, 0x01, 0x70,
+    0x00, 0x01, 0x07, 0x05, 0x01, 0x01, 0x74, 0x01, 0x00, 0x09, 0x07, 0x01, 0x00, 0x41, 0x00, 0x0b,
+    0x01, 0x01, 0x0a, 0x08, 0x01, 0x06, 0x00, 0x41, 0x07, 0x10, 0x00, 0x0b,
+};
+
+/* (module
+ *   (type $v (func))
+ *   (import "m1" "t" (table 1 funcref))
+ *   (func (export "_start") (i32.const 0) (call_indirect (type $v))))
+ * Reaches the other instance through `call_indirect` on an imported table.
+ * That dispatch never touches `cross_module.CallCtx`, so a fix confined to the
+ * imported-func thunk leaves this case red. */
+static const uint8_t kCrossTableCallerWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x02, 0x0a,
+    0x01, 0x02, 0x6d, 0x31, 0x01, 0x74, 0x01, 0x70, 0x00, 0x01, 0x03, 0x02, 0x01, 0x00, 0x07, 0x0a,
+    0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x41,
+    0x00, 0x11, 0x00, 0x00, 0x0b,
+};
+
 static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
 
 static const char* engine_name(uint8_t kind) {
@@ -647,6 +695,175 @@ cleanup:
     return rc;
 }
 
+/* How the caller reaches the other instance's guest code. Both shapes leave
+ * the called instance and run the SOURCE instance's body with the SOURCE
+ * instance's WASI binding; they share nothing else. */
+typedef enum {
+    kViaImportedFunc,  /* `call` on an imported func — src/api/cross_module.zig */
+    kViaImportedTable, /* `call_indirect` on an imported table — src/interp/mvp.zig */
+} cross_kind;
+
+static const char* cross_name(cross_kind k) {
+    return k == kViaImportedTable ? "cross-module via imported table"
+                                  : "cross-module via imported func";
+}
+
+/* #352 — a `proc_exit` reached through another instance writes the SOURCE
+ * instance's WASI host, while the record ADR-0222 keeps names the instance
+ * `wasm_func_call` was handed.
+ *
+ * `I1` is built under config A and exits 7. The Store's config then moves on,
+ * and `I2` — built under config B, doing nothing but reaching into `I1` — is
+ * built and called. Dispatch enters `I1`'s body with `I1`'s WASI binding, so
+ * `proc_exit` writes host A; the record names `I2`, which captured nothing. A
+ * clean exit of 7 reads back as a fault.
+ *
+ * The granularity the status needs is the runtime that actually RAN
+ * `proc_exit`, not the instance that was called. Nothing here contradicts
+ * ADR-0222: for every call that does not leave the called instance the two are
+ * the same runtime.
+ *
+ * BOTH shapes are asserted because they share no dispatch code. The imported
+ * func goes through `cross_module.CallCtx`; the imported table goes through
+ * `call_indirect`'s foreign-`fe.runtime` branch, which has no `CallCtx` and no
+ * Store in scope. A fix confined to the first leaves the second red, so the
+ * record cannot be repaired by retargeting at the dispatch sites one by one.
+ *
+ * The assertion is on the code, not on `has_code`, for #345's reason — a
+ * `has_code`-only check passes on another guest's status.
+ *
+ * The JIT-backed engines cannot build `I2` in either shape: `buildBindings`
+ * resolves a cross-module import through the source instance's interpreter
+ * runtime, and a JIT-backed instance has none, so the instantiation fails.
+ * That is a separate defect with its own fix, NOT this one. It is reported
+ * here rather than skipped, and these assertions run in full as soon as the
+ * instantiation starts succeeding. */
+static int expect_status_follows_the_executing_runtime(uint8_t engine, cross_kind kind) {
+    int rc = 1;
+    uint8_t exit7[sizeof(kExitWasm)];
+    const uint8_t* exporter_wasm;
+    size_t exporter_len;
+    const uint8_t* caller_wasm;
+    size_t caller_len;
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* caller_module = NULL;
+    wasm_instance_t* caller = NULL;
+    wasm_extern_vec_t caller_exports = { 0, NULL };
+    const char* what = cross_name(kind);
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    memcpy(exit7, kExitWasm, sizeof(kExitWasm));
+    exit7[kRvalOffset] = 7;
+    if (kind == kViaImportedTable) {
+        exporter_wasm = kCrossTableExporterWasm;
+        exporter_len = sizeof(kCrossTableExporterWasm);
+        caller_wasm = kCrossTableCallerWasm;
+        caller_len = sizeof(kCrossTableCallerWasm);
+    } else {
+        exporter_wasm = exit7;
+        exporter_len = sizeof(exit7);
+        caller_wasm = kCrossFuncCallerWasm;
+        caller_len = sizeof(kCrossFuncCallerWasm);
+    }
+
+    /* Config A, and the exporter built under it. */
+    zwasm_wasi_config_t* cfg_a = zwasm_wasi_config_new();
+    if (!cfg_a) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg_a); /* takes ownership */
+
+    wasm_byte_vec_t exporter_binary = { exporter_len, (wasm_byte_t*) exporter_wasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fputs("exporter module failed to parse\n", stderr); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) {
+        fprintf(stderr, "[%s] %s: the exporter failed to instantiate\n", engine_name(engine), what);
+        goto cleanup;
+    }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] %s: the exporter exposed nothing\n", engine_name(engine), what);
+        goto cleanup;
+    }
+
+    /* The config moves on. A retires rather than being freed — the exporter
+     * captured it — which is what keeps its status readable at all. */
+    zwasm_wasi_config_t* cfg_b = zwasm_wasi_config_new();
+    if (!cfg_b) { fputs("wasi config new failed\n", stderr); goto cleanup; }
+    zwasm_store_set_wasi(store, cfg_b); /* takes ownership */
+
+    /* The caller, built under B, importing the exporter's func or table. */
+    wasm_byte_vec_t caller_binary = { caller_len, (wasm_byte_t*) caller_wasm };
+    caller_module = wasm_module_new(store, &caller_binary);
+    if (!caller_module) { fputs("caller module failed to parse\n", stderr); goto cleanup; }
+    wasm_extern_t* caller_import_externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t caller_imports = { 1, caller_import_externs };
+    wasm_trap_t* ctrap = NULL;
+    caller = zwasm_instance_new_ex(store, caller_module, &caller_imports, &ctrap, engine);
+    if (ctrap) wasm_trap_delete(ctrap);
+    if (!caller) {
+        if (engine == ZWASM_ENGINE_INTERP) {
+            fprintf(stderr, "[interp] %s: the caller failed to instantiate\n", what);
+            goto cleanup;
+        }
+        /* The separate defect named above. Not this case's subject, and not
+         * silently passed over: it is why this engine contributes no evidence
+         * here. */
+        fprintf(stderr,
+                "[%s] %s: a cross-module import cannot be built against a JIT-backed "
+                "instance, so this engine is unmeasured\n",
+                engine_name(engine), what);
+        rc = 0;
+        goto cleanup;
+    }
+    wasm_instance_exports(caller, &caller_exports);
+    if (caller_exports.size < 1 || !caller_exports.data[0] ||
+        wasm_extern_kind(caller_exports.data[0]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] %s: the caller is missing its _start export\n", engine_name(engine), what);
+        goto cleanup;
+    }
+
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t no_res = { 0, NULL };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(caller_exports.data[0]), &no_args, &no_res);
+    if (!trap) {
+        fprintf(stderr, "[%s] %s: expected a trap, got none\n", engine_name(engine), what);
+        goto cleanup;
+    }
+    wasm_trap_delete(trap);
+
+    uint32_t code = 0xdeadbeefu;
+    if (!zwasm_store_wasi_exit_code(store, &code)) {
+        fprintf(stderr,
+                "[%s] %s: proc_exit(7) reported no status — the write went to the host the "
+                "exporting instance captured and the read followed the called one\n",
+                engine_name(engine), what);
+        goto cleanup;
+    }
+    if (code != 7) {
+        fprintf(stderr, "[%s] %s: proc_exit(7) read back %u\n", engine_name(engine), what, code);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (caller_exports.data) wasm_extern_vec_delete(&caller_exports);
+    if (caller) wasm_instance_delete(caller);
+    if (caller_module) wasm_module_delete(caller_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 /* A host callback that calls back into the Store must not retarget the status.
  * The embedder made ONE call; the guest behind it exits 7. A nested
  * `wasm_func_call` from inside the callback has no guest of its own — it is a
@@ -907,6 +1124,8 @@ int main(void) {
         if (expect_non_wasi_instantiate_invalidates(e, true)) return 1;
         if (expect_nested_call_keeps_the_outer_host(e)) return 1;
         if (expect_reentrant_start_keeps_its_status(e)) return 1;
+        if (expect_status_follows_the_executing_runtime(e, kViaImportedFunc)) return 1;
+        if (expect_status_follows_the_executing_runtime(e, kViaImportedTable)) return 1;
     }
 
     /* Null-arg discipline, matching the rest of the extension surface. */


### PR DESCRIPTION
`zwasm_store_wasi_exit_code` reads the exit status from the WASI host the
CALLED instance captured (ADR-0222). A call that reaches another instance's
export never stays in the called instance: dispatch enters the source
instance's body with the source instance's WASI binding, so `proc_exit` writes
a host the record does not name, and a clean exit reads back as a fault.

Measured on `3583e2db1`, x86_64-linux, `interp`. One Store, `I1` under config A
exits 7, the config moves on, `I2` under config B reaches into `I1`:

| how `I2` reaches `I1` | dispatch site | before |
|---|---|---|
| `call` on an imported func | `src/api/cross_module.zig:53` | `has_code=0` |
| `call_indirect` on an imported table | `src/interp/mvp.zig:518` | `has_code=0` |

Both shapes are regression cases here because they share no dispatch code — a
fix confined to the imported-func thunk leaves the table one red. They are two
of seven sites where interp dispatch enters another instance's guest code
(census in the ADR), which is why the fix is not to retarget the record at the
dispatch point.

Instead nothing addresses a host in advance. The Store's set of hosts is
already closed — `wasi_host` plus `retired_wasi_hosts`, by ADR-0219's
retire-instead-of-free rule — so every entry into guest code clears the exit
status across the set on the way in, and the accessor reads back whichever host
was written. `Store.active_wasi_host` and `Instance.wasi_host` are removed;
`src/wasi/proc.zig` stays the single write site and `src/cli/run.zig` keeps
resolving through the same helper.

`auto` and `jit` cannot instantiate the caller in either shape — a cross-module
import resolves through the source instance's interpreter runtime, and a
JIT-backed instance has none (ADR-0200). That is a separate defect, not fixed
here; the cases report it on stderr rather than skipping, and assert in full as
soon as instantiation starts succeeding.

Not verified on macOS or Windows — the 3-OS `ci-required` gate is the first
check there.

Closes #352.
