### PR TITLE
docs(capi): the wasi.h trap-kind advice catches up with ADR-0218 (#348)

### DIFF
--- a/include/wasi.h
+++ b/include/wasi.h
@@ -145,9 +145,10 @@ WASM_API_EXTERN void zwasm_store_set_wasi(wasm_store_t*, zwasm_wasi_config_t*);
  *     a failure; `wasm_trap_message` and `zwasm_trap_kind` describe
  *     it.
  *
- * Do not branch on the trap kind to tell those two apart. The kind a
- * `proc_exit` trap carries differs between engines and is not part
- * of this contract.
+ * Prefer this function over the trap kind. `ZWASM_TRAP_WASI_EXIT`
+ * names this case but never carries the status — an exit of 0 and
+ * an exit of 3 are the same kind — so a host that needs the number
+ * reads it here anyway, and one read answers both questions.
  *
  * The status is per call: each `wasm_func_call` into this Store
  * clears it before running, so a `true` return describes the call


### PR DESCRIPTION
`include/wasi.h`'s comment on `zwasm_store_wasi_exit_code` steered embedders
away from a `proc_exit` trap's kind, because the kind differed between engines.
ADR-0218 (#331) removed that difference one merge later, and
`include/zwasm.h`'s `ZWASM_TRAP_WASI_EXIT` has said the opposite a few lines
away ever since.

The advice survives; only its reason was stale. The kind never carries the
status — an exit of `0` and an exit of `3` are the same kind — so a host that
needs the number reads this accessor regardless, and one read answers both
"did the guest terminate itself" and "with what".

That reason rests on `ZWASM_TRAP_*` being append-only stable, not on the three
engines agreeing, so the replacement names the constant without restating
engine behaviour: the sentence that rotted was one asserting cross-engine
agreement, and re-asserting it with the opposite polarity would leave the same
seam. It also stops short of recommending a kind-based branch — the reader is
pointed at the accessor, which answers both questions at once.

Dropping the paragraph instead would leave `wasi.h`'s own `false` bullet naming
`zwasm_trap_kind` with nothing orienting the reader, and would put the only
surviving word on the subject in `zwasm.h`, which defines the constant and says
nothing about when to prefer it. `docs/reference/c_api.md` (#346) already
prefers the accessor for the same reason this does — the kind carries no
status.

The two bullet rules and the per-call and multi-setup paragraphs around it are
untouched. Comment only — no `src/` change, no behaviour change.

Closes #348.
