### PR TITLE
docs(reference): the C API page catches up with #345 and #352 (#355)

### DIFF
--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -59,14 +59,12 @@ alone cannot separate a clean termination from a fault, and
 
 The status is **per call** — each `wasm_func_call` into the Store clears it
 before running, so a `true` describes the call just made and never an earlier
-guest's (#341). Read it before calling into the Store again.
+guest's (#341). Read it before calling into the Store again, or creating
+another instance in it — either one clears it.
 
-One exception is open: an instance binds its WASI host at instantiation, so
-after `zwasm_store_set_wasi` replaces or detaches the Store's setup, an
-older instance's `proc_exit` writes where this accessor no longer reads. Its
-clean exit then reads back as a fault on every engine (#350). A host that
-reconfigures WASI under a live instance cannot rely on the `false` rule until
-that closes.
+Which of a Store's WASI setups a `true` is read from — when it has held more
+than one, or had one replaced or detached mid-run — is contract, stated once in
+[`include/wasi.h`](../../include/wasi.h) (#345) and not restated here.
 
 `zwasm_trap_kind` answers a different question and does not replace this one:
 since ADR-0218 it reports `ZWASM_TRAP_WASI_EXIT` for a `proc_exit` on every

--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -68,8 +68,7 @@ than one, or had one replaced or detached mid-run — is contract, stated once i
 
 `zwasm_trap_kind` answers a different question and does not replace this one:
 since ADR-0218 it reports `ZWASM_TRAP_WASI_EXIT` for a `proc_exit` on every
-engine, so it does say *that* the guest terminated itself — but it never
-carries the status, which is what an embedder needs.
+engine, but it never carries the status, which is what an embedder needs.
 
 ## `zwasm.h` extensions
 


### PR DESCRIPTION
The exit-status section was last written before #345 (`3583e2db1`) and #352
(`408d47250`) landed.

- The "one exception is open" paragraph *is* the exception #345 closed;
  `include/wasi.h:158-164` now guarantees the opposite for the same function.
- It cited `#350`, which is closed as a duplicate. Dropped — #345 is the one
  with substance.
- The per-call sentence missed #345's second clearing site: creating another
  instance in the Store clears the status too (`src/api/instance.zig:894`,
  `:1176`).

The exception is dropped, not replaced by a restatement of wasi.h's
multi-setup guarantee. Every sentence copied from a header is an unwatched
staleness point — the doc-truth guards are per-lie anchor sweeps, not a
general prose-vs-code check — and #348 and #355 are both what that costs. So
the page keeps why the accessor exists and how to read its two answers, and
sends the contract to `include/wasi.h` by pointer. Restating it would save a
reader one hop; rejected as a fourth copy of a rule nothing watches.

`zwasm_trap_kind`'s paragraph loses one clause. "It does say *that* the guest
terminated itself" is the converse of what ADR-0218 pins, and #357 measures it
false: after a `proc_exit`, an out-of-bounds `return_call_indirect` on the same
instance reports `ZWASM_TRAP_WASI_EXIT` on JIT and AUTO. The forward direction
stays — that is what the #331 tests hold. #356 owns the trap-kind advice in
`include/wasi.h`; it states only the forward direction, so it needs no matching
cut.

Docs only. `scripts/gate_commit.sh` and the three `doc-truth` guards green.

Closes #355.
