### PR TITLE
ci: keep every main run alive, and run the unit tests ReleaseSafe on Linux (#312, #347)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -79,8 +79,9 @@ text or code identifiers.
   is PR-only, and CI's `ci-required` runs `scripts/ci_gate.sh` on **all 3 OSes**
   (aarch64-macos + x86_64-linux + x86_64-windows) for **every** PR. That IS the
   merge gate. A PR run gets the **core** gate — zig fmt + `test-all` +
-  `bench-latency-build` (compile-only, ADR-0209) + `run-rust-host` + the
-  test-discovery guard. The **extended** checks (lint /
+  `bench-latency-build` (compile-only, ADR-0209) + the test-discovery guard,
+  plus on the Linux leg only `run-rust-host` and the unit tests built
+  ReleaseSafe (#347). The **extended** checks (lint /
   build-option DCE / ReleaseSafe JIT smoke / AOT cross-compile / `zone_check` /
   `spill_aware`) are gated on `ZWASM_CI_EXTENDED`, which `ci.yml` sets only on
   the **push to `main`** — they are up to ~20 cold-cache ReleaseSafe builds and

--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -872,9 +872,11 @@ any `Frame` field the emit's `Label` has but liveness pins to a constant
 
 **Trigger.** A lane is green at the default optimize level and fails at
 `-Doptimize=Release*`. `ci_gate.sh` runs `test-all` at the default optimize
-level; the one ReleaseSafe build it does run, `check_jit_releasesafe.sh`, sits
-in the `ZWASM_CI_EXTENDED` leg, which fires on the push to `main` and not on a
-PR. So this class reaches `main` before any lane sees it.
+level; the unit tests also run ReleaseSafe on every PR's Linux leg (#347), so
+check that leg's log first — it names the failing test. The integration
+runners have no optimized lane on a PR: `check_jit_releasesafe.sh` sits in the
+`ZWASM_CI_EXTENDED` leg, which fires on the push to `main`, so a runner-only
+instance of this class still reaches `main` before any lane sees it.
 
 **First: settle whether it is the optimizer or the mode.** Run all four.
 Debug-only-green with every Release mode failing identically points at the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,10 @@ permissions:
 # merge its own group, so runs overlap instead of cancelling. A queue
 # (`cancel-in-progress: false` with a shared group) would not do: GitHub keeps
 # only the newest pending run per group, so a burst of merges would still
-# drop the middle ones.
+# drop the middle ones. The event name is part of the key so that a manual
+# dispatch on `main` (core-only) cannot cancel the push run for the same SHA.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}-{1}', github.event_name, github.sha) || '' }}
   cancel-in-progress: true
 
 jobs:
@@ -272,7 +273,8 @@ jobs:
       # JIT smoke + AOT cross-compile) are up to ~20 cold-cache ReleaseSafe builds
       # and dominate wall-clock (~2.5-4.5 min/build on hosted runners), so they
       # run ONLY on the merge to `main` (push) — not on every PR / dispatch, which
-      # get the fast core gate (fmt + test-all, ~10 min). windows is always core.
+      # get the core gate (fmt + test-all + the Linux-only ReleaseSafe unit tests
+      # and rust-host; see ci_gate.sh's header). windows is always core.
       - name: ci_gate.sh
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,18 @@ on:
 permissions:
   contents: read
 
+# A superseded PR run is waste, so PR runs share one group per ref and the
+# newer run cancels the older. A `main` run is different: each covers a
+# distinct merged commit, and the extended checks it carries run nowhere
+# else — cancelling it leaves that commit with no lint / DCE / ReleaseSafe-JIT
+# / AOT verification and nothing reports the gap (#312: 46% of `main` runs
+# were cancelled this way). Keying the `main` group on the SHA gives every
+# merge its own group, so runs overlap instead of cancelling. A queue
+# (`cancel-in-progress: false` with a shared group) would not do: GitHub keeps
+# only the newest pending run per group, so a burst of merges would still
+# drop the middle ones.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}', github.sha) || '' }}
   cancel-in-progress: true
 
 jobs:

--- a/build.zig
+++ b/build.zig
@@ -164,12 +164,14 @@ pub fn build(b: *std.Build) void {
     // TEST RUNNERS only. Debug host execution is ~5-10x slower; the runners
     // (spec / realworld / wast / edge corpus) are run-time-dominated, so they
     // build ReleaseSafe for iteration speed (still full safety checks). The
-    // `core_tests` UNIT suite stays on Debug `core` (it calls raw `module.entry`
-    // fn-ptrs that violate the JIT host-boundary callee-saved contract under an
-    // optimized host — a test-harness pattern, not a production path; production
-    // routes through the cohort trampoline). Production (`exe`/lib) keeps `core`
-    // honouring `-Doptimize`. Floor at ReleaseSafe so a plain Debug build still
-    // runs runners fast; a higher `-Doptimize` (ReleaseFast) wins.
+    // `core_tests` UNIT suite stays on `core` honouring `-Doptimize`: Debug by
+    // default (leak-detecting allocator), and ReleaseSafe on CI's Linux leg
+    // (`ci_gate.sh`, #347) — so a unit test must reach JIT code through the
+    // cohort trampoline (`callEntrySafe`), never a raw `module.entry` fn-ptr,
+    // which violates the host-boundary callee-saved contract under an optimized
+    // host. Production (`exe`/lib) keeps `core` honouring `-Doptimize`. Floor
+    // at ReleaseSafe so a plain Debug build still runs runners fast; a higher
+    // `-Doptimize` (ReleaseFast) wins.
     const core_rs = b.createModule(.{
         .root_source_file = b.path("src/zwasm.zig"),
         .target = target,

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,7 +92,8 @@ required **`ci-required`** status check. CI runs
 [`scripts/ci_gate.sh`](../scripts/ci_gate.sh) on **all three supported OSes** —
 macOS aarch64, Linux x86_64, Windows x86_64. Your PR gets the *core* gate: fmt
 + `test-all` + the rust-host consumer + the test-discovery guard + the
-ReleaseSafe-runner floor guard (ADR-0177). The extended
+ReleaseSafe-runner floor guard (ADR-0177) + the unit tests built
+ReleaseSafe (Linux leg only; the mode every release binary is built in). The extended
 static/build checks (lint, the build-option DCE matrix, AOT cross-compile,
 `zone_check`) run on the merge to `main`, not per PR — they are up to ~20
 cold-cache builds and would dominate every PR's wall-clock. All three legs are

--- a/scripts/check_releasesafe_runners.sh
+++ b/scripts/check_releasesafe_runners.sh
@@ -14,8 +14,9 @@
 #       corpus in test-all) regresses from `runner_optimize` back to raw
 #       `optimize` (= Debug) — the 2026-06-14 gap.
 #
-# Debug-by-design allowlist (verified intentional): `core` itself (self-import),
-# `core_tests` (leak-detecting DebugAllocator), `exe` AS THE INSTALLED ARTIFACT
+# Honours-`-Doptimize` allowlist (verified intentional): `core` itself
+# (self-import), `core_tests` (leak-detecting DebugAllocator by default; CI's
+# Linux leg also runs it ReleaseSafe, #347), `exe` AS THE INSTALLED ARTIFACT
 # (the shipped CLI honours -Doptimize) — but NOT as a runner's engine, which is
 # what (a2) checks — the light unit-test mods, the trivial single-wasm examples.
 set -euo pipefail

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -8,10 +8,13 @@
 #   Core — every OS: zig fmt --check (src/ + bench/latency/ + tools/) +
 #     zig build test-all + bench-latency-build + test-discovery guard +
 #     spec-manifest shape guard + ReleaseSafe-runner floor
-#   Core — Linux only: run-rust-host (D-254). Still core — it runs on every
-#     PR — but only where the runner's gnu-target rustc is ABI-compatible
-#     with zig's native libzwasm.a. Listed separately because "every OS"
-#     above is load-bearing: anything added here is verified on ONE leg.
+#   Core — Linux only: run-rust-host (D-254) + ReleaseSafe unit tests
+#     (zig build test -Doptimize=ReleaseSafe, #347). Still core — they run on
+#     every PR — but only on the leg that has the wall-clock headroom for
+#     them (rust-host also needs the runner's gnu-target rustc to be
+#     ABI-compatible with zig's native libzwasm.a). Listed separately because
+#     "every OS" above is load-bearing: anything added here is verified on
+#     ONE leg.
 #   Extended (ZWASM_CI_EXTENDED=1; Unix legs): lint + build-option DCE +
 #     ReleaseSafe JIT smoke (D-245) + AOT cross-compile portability +
 #     external system-linker consumer (test_extlink.sh) + zone_check +
@@ -68,6 +71,23 @@ if [ "$(uname -s)" = "Linux" ]; then
     else
         echo "[ci_gate] (skip run-rust-host — rustc not on PATH; needs the .#rust-host shell)"
     fi
+fi
+
+# ReleaseSafe unit tests (#347). The Debug `test` lane cannot see a defect that
+# only an optimized host frame layout produces — #323 (an unaligned frame
+# pointer dereferenced by the EH sniffer) reached `main` that way, and every
+# release binary is built ReleaseSafe. ReleaseSafe and not ReleaseFast /
+# ReleaseSmall: `support.dbg` is comptime-disabled in those two, so five of its
+# tests fail there by construction, and ReleaseSafe is the mode that names the
+# fault instead of exiting 70 silently. LINUX-only: the leg finishes ~12 min
+# before aarch64-macos, so the ~5 min this adds does not move the gate's
+# wall-clock. Core, not extended — extended does not run on every PR, which is
+# not a regression barrier. `--summary all` for the same reason `test-all`
+# carries it. No graceful-skip arm: unlike rust-host this needs no external
+# toolchain.
+if [ "$(uname -s)" = "Linux" ]; then
+    echo "[ci_gate] ReleaseSafe unit tests (Linux-only core, #347)"
+    zig build test -Doptimize=ReleaseSafe --summary all
 fi
 
 # Test-discovery guard (sweep S5): a named test block that no test step


### PR DESCRIPTION
Fixes #347. Addresses #312 direction 2 (direction 3, notification, stays open).

## Why

- A merge that lands while the previous merge's `main` run is still going cancels it, and the extended checks run nowhere else. Measured in #312: 46% of `main` runs ended `cancelled`, and the release-candidate tree at the time of writing had a code change with no completed `main` run at all. The `main` concurrency group is now keyed on the SHA so runs overlap instead of cancelling. A shared group with `cancel-in-progress: false` would still drop runs — GitHub retains only the newest pending run per group. PR refs are unchanged.
- No lane ran the unit tests at any optimization level; every release binary is ReleaseSafe. The core gate now runs `zig build test -Doptimize=ReleaseSafe` on the Linux leg, beside `run-rust-host`. Costed in #347 at ~5 min on the leg with the most headroom; the gate's wall-clock does not move. ReleaseSafe and not ReleaseFast/ReleaseSmall for the reason in #347 (`support.dbg` is comptime-disabled there).

## Verified

- `actionlint` on the workflow.
- `zig build test -Doptimize=ReleaseSafe` passes on aarch64-macos and x86_64-linux at `2adca93c3`.
- This PR's own Linux leg is the first CI run of the lane.
