### PR TITLE
docs: the release notes' surroundings tell the truth at the tag (#335, #217, D-583)

### DIFF
--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -401,6 +401,17 @@ entries:
       between the two measurements. Split into sub-rows once the first
       root cause is known, not before.
       ---
+      Re-measured 2026-08-30 at `2adca93c3` (`zig build
+      test-wasi-p1-official`): aarch64-macos and x86_64-linux **72/72** on
+      both engines. x86_64-windows is the open host: **65/72** on CI's
+      windows-2022 runner and **64/72** on a Windows 11 host, the same
+      symlink / hardlink / readdir family on both engines (#290):
+      `fd_readdir`, `nofollow_errors`, `path_exists`, `path_link`,
+      `readlink`, `symlink_create`, `symlink_filestat`, plus
+      `path_symlink_trailing_slashes` on Windows 11 only. The Windows number
+      was not measurable before #313 — the runner died mid-corpus and the
+      advisory step reported the leg green.
+      ---
       **`dangling_symlink` looks flaky and is not.** It fails on a clean
       preopen tree (20/20), leaves `dangling_symlink_symlink.cleanup` behind,
       and that leftover makes every later run against the same tree pass. The
@@ -424,7 +435,7 @@ entries:
       deliberate, time-boxed advisory in the sense of ADR-0174 ("NOT a silent
       skip"), not an indefinite workaround.
     first_raised: "2026-08-14"
-    last_reviewed: "2026-08-24"
+    last_reviewed: "2026-08-30"
     refs: |-
       src/wasi/** (preview1 syscall implementations); test/wasi/wasip1_official/**;
       ROADMAP §11.1 (syscall surface 46/46); ADR-0161 (preview1 completion

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ now (demand-driven).
 |-----------------------------------------------------------------------------------------------------------------|---------|----------------------------------------------------------|
 | Wasm 1.0                                                                                                        | ✅ 100% | spec testsuite green on the 3-OS CI matrix                |
 | Wasm 2.0 (multi-value, SIMD-128, bulk-memory, reference-types, non-trapping FP→int, sign-ext, mutable globals) | ✅ 100% | `skip-impl == 0`; bit-identical across hosts             |
-| Wasm 3.0 (GC, EH, tail-call, memory64, multi-memory, typed func refs, extended-const, relaxed-simd, custom annotations) | ✅ 100% | all 9 proposals; spec testsuite green on the 3-OS CI matrix |
+| Wasm 3.0 (GC, EH, tail-call, memory64, multi-memory, typed func refs, extended-const, relaxed-simd, custom annotations) | ✅ 100% | all 9 proposals; spec testsuite green on the 3-OS CI matrix (extended-const: unit-tested, its corpus lane is pending #217) |
 
 ### WASI
 

--- a/build.zig
+++ b/build.zig
@@ -1227,8 +1227,9 @@ pub fn build(b: *std.Build) void {
 
     // `zig build test-wasi-p1-official` — the OFFICIAL wasi-testsuite
     // wasm32-wasip1 corpus (D-582). Deliberately NOT in `test-all` yet: the
-    // corpus reports 14 engine-independent failures (D-583), so folding it
-    // into the blocking gate now would red every PR. CI runs it as an ADVISORY
+    // corpus is not green on every OS (D-583 carries the live count — no copy
+    // here, a copy is what went stale), so folding it into the blocking gate
+    // now would red every PR. CI runs it as an ADVISORY
     // step in the `gate` job (step-level `continue-on-error`); this step joins
     // `test-all` when D-583 discharges, which is that row's exit condition.
     //

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,19 +123,31 @@ its own (ADR-0156). Three manual steps; the rest is the `release` workflow.
 1. **Bump `.version` in `build.zig.zon`.** SemVer against the previous tag —
    `git log v<previous>..main --no-merges` is the input to that call.
 2. **Add the CHANGELOG section** for the new version, dated.
-3. **Push the tag.** `git tag vX.Y.Z && git push origin vX.Y.Z`.
+3. **Push the tag.** `git tag -a vX.Y.Z -m "<one-paragraph summary>" &&
+   git push origin vX.Y.Z`. Annotated, on the merge commit of the release
+   PR: the message is what `git show vX.Y.Z` prints, and it is the only
+   place a reader sees the release described without the CHANGELOG open.
 
 Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds
 and packages all four targets in ReleaseSafe (macOS aarch64, Linux
 x86_64/aarch64, Windows x86_64), then creates the GitHub Release with the
-archives and `SHA256SUMS`. Nothing else in this repository needs touching.
+archives and `SHA256SUMS`. The workflow runs no tests: the tag's
+correctness rests on the `main` run that already verified the commit
+under it, so check that run completed before pushing the tag. The Release
+notes are GitHub's generated pull-request list unless a Release for the tag
+already exists — to hand-write them, create the Release (with the CHANGELOG
+section as its body) before the workflow reaches that step, or edit it
+after. Nothing else in this repository needs touching.
 
 **One step is outside this repository and is not automated: the Homebrew
 formula.** `zwasm/homebrew-tap`'s `Formula/zwasm.rb` pins the release URL
 and its sha256, so until it is updated `brew install zwasm/tap/zwasm` still
 installs the previous version — while the README points readers at exactly
-that command. Update the formula as part of the release, not after someone
-reports it.
+that command. The formula carries three URLs and three sha256 values; take
+them from the Release's `SHA256SUMS`, not from a local build. Update the
+formula as part of the release, not after someone reports it. Downstream
+bindings that vendor this repository (`zwasm-rust-sdk`) pin the tag in
+their own docs and are their maintainers' step, not this one.
 
 ## Git hooks (recommended)
 

--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -1183,7 +1183,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
             // equality on concrete→concrete (cross-rec-group identity).
             &types,
         ) catch |err| {
-            std.debug.print("compileWasm: func[{d}] params={d} results={d} → validate {s}\n", .{
+            dbg.print("codegen", "compileWasm: func[{d}] params={d} results={d} → validate {s}\n", .{
                 wasm_idx,
                 sig.params.len,
                 sig.results.len,
@@ -1213,7 +1213,7 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
             bounds_elided,
             table_idx_types,
         ) catch |err| {
-            std.debug.print("compileWasm: func[{d}] params={d} results={d} → {s}\n", .{
+            dbg.print("codegen", "compileWasm: func[{d}] params={d} results={d} → {s}\n", .{
                 wasm_idx,
                 sig.params.len,
                 sig.results.len,

--- a/src/zwasm/module.zig
+++ b/src/zwasm/module.zig
@@ -129,10 +129,10 @@ pub const Module = struct {
         /// D-332 — host cap on a table's INITIAL declared element count (mirrors
         /// `max_memory_pages`; extends the grow-time `store_table_elements_max`).
         max_table_elements: Budget = .{ .limited = default_max_table_elements },
-        /// ADR-0200 — per-instance engine selection. `.auto` (default) routes to
-        /// interp until the JIT host-import bridge lands; `.jit` opts into the
-        /// native JIT engine (no-import compute modules this increment); `.interp`
-        /// forces the interpreter.
+        /// ADR-0200 — per-instance engine selection. `.auto` (default) prefers
+        /// the JIT and falls back to the interpreter for a module the JIT
+        /// declines; `.jit` requires the JIT (instantiation fails where it would
+        /// have fallen back); `.interp` forces the interpreter.
         engine: _api_instance.EngineKind = .auto,
     };
 


### PR DESCRIPTION
Stacked on the fixes PR (base: `develop/default-path-fixes`). Fixes #335. Touches #217 (README wording only) and D-583 (ledger measurement).

Pre-tag corrections to the files a reader opens next to the v2.6.0 CHANGELOG:

- `src/zwasm/module.zig`: `InstantiateOpts.engine`'s doc comment said `.auto` routes to the interpreter "until the JIT host-import bridge lands"; it has preferred the JIT since ADR-0200, and this is the one file a Zig embedder reads for that fact (#335).
- README: the Wasm 3.0 row claimed every proposal is spec-testsuite green on CI; extended-const has no corpus lane yet (#217), so the row says so.
- `docs/development.md`: the release steps record what every release since v2.4.0 actually did — an annotated tag on the release PR's merge commit, checking that the `main` run completed (the release workflow runs no tests), how the Release notes come to be, and where the tap formula's sha256 values come from.
- `src/engine/compile.zig`: two `std.debug.print` calls on the JIT-decline path were ungated, so the default engine wrote a diagnostic line to stderr in release builds whenever it fell back to the interpreter. They are on the `codegen` debug channel now.
- `build.zig` / D-583: the corpus comment carried a failure count that had gone stale twice; it points at the ledger row, which records the 2026-08-30 measurement (macOS/Linux 72/72; Windows 65/72 on the CI runner, 64/72 on a Windows 11 host).

Doc-only apart from the debug-channel gating, which `zig build test` covers.
