### PR TITLE
docs: no account name or host alias in the Windows and Linux host notes

### DIFF
--- a/.claude/skills/debug_jit_auto/RECIPES.md
+++ b/.claude/skills/debug_jit_auto/RECIPES.md
@@ -281,8 +281,8 @@ Common SSH invocation pattern for all Windows recipes:
 
 ```bash
 # From Mac: drop into windowsmini's PowerShell or Git-Bash
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"<cmd>\""
-ssh windowsmini "bash -lc '<cmd>'"
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"<cmd>\""
+ssh <windows-host> "bash -lc '<cmd>'"
 ```
 
 ### Recipe 9 — `lldb -b` first triage on windowsmini (SSH)
@@ -290,7 +290,7 @@ ssh windowsmini "bash -lc '<cmd>'"
 Mirror of Recipe 1, adapted for Win64 PE/COFF:
 
 ```bash
-ssh windowsmini "bash -lc '
+ssh <windows-host> "bash -lc '
   cd ~/Documents/MyProducts/zwasm
   lldb -b \
     -o \"settings set target.x86-disassembly-flavor intel\" \
@@ -330,14 +330,14 @@ scanned at that moment.
 #      spec_assert_runner start)
 
 # Headless (SSH-driven) capture via /BackingFile + /Quiet:
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
-  Start-Process -FilePath 'C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-2026-05-22\Procmon64.exe' \
-    -ArgumentList '/Quiet','/Minimized','/BackingFile','C:\Users\shota\procmon-trace.pml','/AcceptEula'
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
+  Start-Process -FilePath '$env:LOCALAPPDATA\zwasm-tools\sysinternals-2026-05-22\Procmon64.exe' \
+    -ArgumentList '/Quiet','/Minimized','/BackingFile','$env:USERPROFILE\procmon-trace.pml','/AcceptEula'
 \""
 # Run test-all in another SSH session
 # Then:
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
-  & 'C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-2026-05-22\Procmon64.exe' /Terminate
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
+  & '$env:LOCALAPPDATA\zwasm-tools\sysinternals-2026-05-22\Procmon64.exe' /Terminate
 \""
 # Then SCP procmon-trace.pml back to Mac and open with Procmon GUI
 # (Procmon native PML format is not text-readable; export to CSV via GUI for grep)
@@ -359,19 +359,19 @@ transition". Test directly:
 
 ```bash
 # Snapshot of all open handles for a specific process:
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
-  & 'C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-2026-05-22\handle64.exe' \
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
+  & '$env:LOCALAPPDATA\zwasm-tools\sysinternals-2026-05-22\handle64.exe' \
     -p zwasm-spec-runner.exe -accepteula
 \""
 
 # Per-process count (rough):
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
-  & 'C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-2026-05-22\handle64.exe' \
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
+  & '$env:LOCALAPPDATA\zwasm-tools\sysinternals-2026-05-22\handle64.exe' \
     -p zwasm-spec-runner.exe -accepteula 2>\\\$null | Measure-Object -Line
 \""
 
 # All processes with high handle count:
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
   Get-Process | Sort-Object -Property HandleCount -Descending | Select-Object -First 10 Name, HandleCount, Id
 \""
 ```
@@ -387,18 +387,18 @@ bytes are NOT in a PE/COFF file (they live at mmap'd memory),
 the same `--disassemble -b binary` form works:
 
 ```bash
-ssh windowsmini "bash -lc '
+ssh <windows-host> "bash -lc '
   # Hex dump from spike code: write block.bytes to /tmp/jit.bin (via lldb memory write -outfile)
   llvm-objdump --disassemble -b binary -m x86_64 --x86-asm-syntax=intel /tmp/jit.bin
 '"
 
 # To inspect an actual PE/COFF binary (test exe symbols, sections):
-ssh windowsmini "bash -lc '
+ssh <windows-host> "bash -lc '
   llvm-readobj --headers --sections --symbols ./zig-out/bin/zwasm-spec-runner.exe
 '"
 
 # To dump only the .text section disasm:
-ssh windowsmini "bash -lc '
+ssh <windows-host> "bash -lc '
   llvm-objdump --disassemble --section=.text ./zig-out/bin/zwasm-spec-runner.exe | head -200
 '"
 ```
@@ -416,9 +416,9 @@ ADR-0103, instrument the `vehHandler` entry point with
 # Then run the test that triggers VEH
 
 # Programmatic launch:
-ssh windowsmini "powershell -NoLogo -NoProfile -Command \"
-  Start-Process -FilePath 'C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-2026-05-22\Dbgview.exe' \
-    -ArgumentList '/g','/t','/k','/l','C:\Users\shota\veh-trace.log'
+ssh <windows-host> "powershell -NoLogo -NoProfile -Command \"
+  Start-Process -FilePath '$env:LOCALAPPDATA\zwasm-tools\sysinternals-2026-05-22\Dbgview.exe' \
+    -ArgumentList '/g','/t','/k','/l','$env:USERPROFILE\veh-trace.log'
 \""
 ```
 
@@ -434,7 +434,7 @@ Windows Error Reporting auto-drops a `.dmp` file to
 2026-05-22 setup). lldb on Windows can read these:
 
 ```bash
-ssh windowsmini "bash -lc '
+ssh <windows-host> "bash -lc '
   ls -la ~/AppData/Local/CrashDumps/
   lldb -c ~/AppData/Local/CrashDumps/zwasm-spec-runner.exe.<pid>.dmp \
     -o \"thread backtrace all\" \
@@ -451,14 +451,14 @@ or PowerShell ssh if user has admin):
 $reg = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps"
 New-Item -Path "$reg\zwasm-spec-runner.exe" -Force
 Set-ItemProperty -Path "$reg\zwasm-spec-runner.exe" -Name DumpType -Value 2
-Set-ItemProperty -Path "$reg\zwasm-spec-runner.exe" -Name DumpFolder -Value 'C:\Users\shota\AppData\Local\CrashDumps'
+Set-ItemProperty -Path "$reg\zwasm-spec-runner.exe" -Name DumpFolder -Value '$env:LOCALAPPDATA\CrashDumps'
 Set-ItemProperty -Path "$reg\zwasm-spec-runner.exe" -Name DumpCount -Value 10
 ```
 
 (Not yet applied on windowsmini as of 2026-05-22 — add when
 first Win64 crash needs post-mortem analysis.)
 
-### Recipe 15 — `ssh windowsmini cmd /c '...'` stable orchestration (HANG / interactive debug)
+### Recipe 15 — `ssh <windows-host> cmd /c '...'` stable orchestration (HANG / interactive debug)
 
 Codifies the 8-trap learning from D-165 cycle 9
 (`.dev/lessons/2026-05-23-windowsmini-ssh-quoting-traps.md`).
@@ -470,7 +470,7 @@ hard at exactly the wrong moment (during root-cause hunts).
 **Stable form** — bypasses PowerShell + Git-Bash + MSYS:
 
 ```bash
-ssh windowsmini cmd /c "<windows-cmd-with-windows-paths>"
+ssh <windows-host> cmd /c "<windows-cmd-with-windows-paths>"
 ```
 
 Inside the double-quoted string, `cmd /c` interprets
@@ -478,7 +478,7 @@ Windows-native switches (`/F`, `/FI`, `/T`, `/NOBREAK`, etc.)
 without path conversion. Chain commands with cmd `&&`:
 
 ```bash
-ssh windowsmini 'cmd /c "cd /d C:\Users\shota\Documents\MyProducts\zwasm && git fetch origin main && git reset --hard origin/main && zig build install"'
+ssh <windows-host> 'cmd /c "cd /d $env:USERPROFILE\Documents\MyProducts\zwasm && git fetch origin main && git reset --hard origin/main && zig build install"'
 ```
 
 Note: `cd /d <path>` forces drive change too — required when
@@ -541,7 +541,7 @@ D-330 c_sha256 `\n` residual (func 4 putc/`__overflow` region).
 Win64 legacy variant — dump to file, scp back to Mac:
 
 ```bash
-ssh windowsmini 'cmd /c "cd /d <repo> && set ZWASM_DEBUG=jit.dump&& start /B zig-out\bin\zwasm.exe run --engine jit <file.wasm> > %USERPROFILE%\dump.log 2>&1"'
+ssh <windows-host> 'cmd /c "cd /d <repo> && set ZWASM_DEBUG=jit.dump&& start /B zig-out\bin\zwasm.exe run --engine jit <file.wasm> > %USERPROFILE%\dump.log 2>&1"'
 scp -q windowsmini:dump.log /tmp/dump.log
 ```
 

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -2052,7 +2052,7 @@ entries:
       blocked-by: `run_remote_windows.sh` has no bench step. **CORRECTION 2026-06-14: the
       "hyperfine absent" half of this barrier is DISSOLVED** — hyperfine 1.20.0 (the latest
       release) IS installed on windowsmini via `scripts/windows/install_tools.ps1` (verified
-      `C:\Users\shota\AppData\Local\zwasm-tools\hyperfine-1.20.0`). Remaining barrier = the
+      `$env:LOCALAPPDATA\zwasm-tools\hyperfine-1.20.0`). Remaining barrier = the
       missing bench step + ADR-0137 scope: Windows bench *timing* auto-recording into
       `bench/history.yaml` is deferred (§11.2/§11.P re-scoped to 2-host Mac+Linux bench). The
       3-host **correctness** reconcile (windowsmini test-all) is UNAFFECTED — only perf-timing

--- a/.dev/decisions/0077_regalloc_op_scratch_reservation.md
+++ b/.dev/decisions/0077_regalloc_op_scratch_reservation.md
@@ -2,7 +2,7 @@
 
 - **Status**: Closed (implemented)
 - **Date**: 2026-05-20
-- **Author**: autonomous-loop (Claude) + shota.508 (review)
+- **Author**: autonomous-loop (Claude) + chaploud (review)
 - **Tags**: regalloc, ABI, scratch, D-132, D-133, §9.12-C, substrate
 
 ## Context

--- a/.dev/decisions/0174_windowsmini_hardening_then_gate_suspension.md
+++ b/.dev/decisions/0174_windowsmini_hardening_then_gate_suspension.md
@@ -7,7 +7,7 @@
 
 The 3-host gate (Mac aarch64 + ubuntunote x86_64 + windowsmini Win64; ADR-0076)
 runs windowsmini as a background BATCHED gate. In practice the windowsmini
-verification load (the `cm-shota@windowsmini.local` SSH-driven `test-all`) is
+verification load (the `<user>@<windows-host>` SSH-driven `test-all`) is
 **contending with the user's separate ClojureWasmFromScratch development** on the
 same physical windowsmini box. The user wants to stop paying that cost during
 routine feature iteration.

--- a/.dev/lessons/2026-05-23-windowsmini-ssh-quoting-traps.md
+++ b/.dev/lessons/2026-05-23-windowsmini-ssh-quoting-traps.md
@@ -85,7 +85,7 @@ on the ssh side. Or use `setsid <cmd> < /dev/null > /tmp/x.log
 ### 7. lldb attach works without admin
 
 Confirmed via attaching to a spawned `pwsh.exe`. No
-SE_DEBUG_NAME requirement on the windowsmini standard `shota`
+SE_DEBUG_NAME requirement on the windowsmini standard `<user>`
 user. `process interrupt` works, `process detach` works,
 register/backtrace read clean.
 

--- a/.dev/ubuntunote_setup.md
+++ b/.dev/ubuntunote_setup.md
@@ -38,7 +38,7 @@ longer in the per-chunk gate.
 ```
 Host ubuntunote
     HostName ubuntunote.local
-    User shota
+    User <user>
     IdentityFile ~/.ssh/id_ed25519
     IdentitiesOnly yes
     ServerAliveInterval 60

--- a/.dev/windows_ssh_setup.md
+++ b/.dev/windows_ssh_setup.md
@@ -41,7 +41,7 @@ The mini PC must already have, per zwasm v1's setup:
 `rsync` is **not** required on `windowsmini`; v2 syncs via
 `git pull` from `origin`, mirroring zwasm v1.
 
-## `ssh windowsmini cmd /c '...'` — the orchestration short-circuit
+## `ssh <windows-host> cmd /c '...'` — the orchestration short-circuit
 
 **Reach for `cmd /c` first.** windowsmini's default OpenSSH
 shell is PowerShell 7. Nesting `bash -lc` re-enters Git-Bash
@@ -54,14 +54,14 @@ Recipe 15).
 
 ```bash
 # RELIABLE — cmd interprets Windows switches and paths directly
-ssh windowsmini cmd /c "<windows-cmd>"
-ssh windowsmini 'cmd /c "cd /d C:\Users\shota\... && git pull && zig build install"'
+ssh <windows-host> cmd /c "<windows-cmd>"
+ssh <windows-host> 'cmd /c "cd /d $env:USERPROFILE\... && git pull && zig build install"'
 
 # OK for bash-style scripts (single-quoted body)
-ssh windowsmini bash -lc "'<bash-body>'"
+ssh <windows-host> bash -lc "'<bash-body>'"
 
 # AVOID — bare PowerShell interpretation of bash-like input
-ssh windowsmini '<looks-like-bash-but-runs-in-pwsh>'
+ssh <windows-host> '<looks-like-bash-but-runs-in-pwsh>'
 ```
 
 Use `bash -lc "'...'"` only when you genuinely want
@@ -69,7 +69,7 @@ bash/POSIX semantics on Windows (uncommon for debug ops). For
 `taskkill`, `tasklist`, `dir`, log paths, lldb attach, etc.
 use `cmd /c "..."`.
 
-Log path convention: `%USERPROFILE%\<file>.log` (= `C:\Users\shota\<file>.log`).
+Log path convention: `%USERPROFILE%\<file>.log` (= `$env:USERPROFILE\<file>.log`).
 `C:\tmp\` does NOT exist by default.
 
 ## SSH alias
@@ -89,7 +89,7 @@ shell-script body with `bash -lc '...'` when invoking via `ssh`.
 Verification:
 
 ```bash
-ssh windowsmini "echo ok && zig version"
+ssh <windows-host> "echo ok && zig version"
 ```
 
 Expected output: `ok` + `0.16.0` (or whatever pinned Zig version
@@ -101,7 +101,7 @@ The clone lives at the same path as v1's: `~/Documents/MyProducts/`.
 Only the directory name differs.
 
 ```bash
-ssh windowsmini bash -lc "'
+ssh <windows-host> bash -lc "'
   mkdir -p ~/Documents/MyProducts &&
   cd ~/Documents/MyProducts &&
   git clone -b main git@github.com:zwasm/zwasm.git zwasm
@@ -119,7 +119,7 @@ The minimum for §9.0 task 0.3 is:
 
 ```bash
 # from Mac, in zwasm/
-ssh windowsmini bash -lc "'
+ssh <windows-host> bash -lc "'
   cd Documents/MyProducts/zwasm &&
   git fetch origin main &&
   git reset --hard origin/main &&
@@ -207,20 +207,20 @@ suspected to reduce the D-028 test-runner-IPC-timeout flake rate.
 
 **Setup procedure** (one-time, from any SSH session — admin
 elevation surprisingly *not* required on this windowsmini, so
-the standard `shota` SSH user can install these):
+the standard `<user>` SSH user can install these):
 
 ```bash
-ssh windowsmini 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'C:\Users\shota\Documents\MyProducts\zwasm\.zig-cache'"'"'"'
-ssh windowsmini 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'C:\Users\shota\Documents\MyProducts\zwasm\zig-out'"'"'"'
-ssh windowsmini 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'C:\Users\shota\AppData\Local\zig'"'"'"'
-ssh windowsmini 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'C:\Users\shota\AppData\Local\zwasm-tools'"'"'"'
-ssh windowsmini 'powershell -NoProfile -Command "Add-MpPreference -ExclusionProcess '"'"'zig.exe'"'"'"'
+ssh <windows-host> 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'$env:USERPROFILE\Documents\MyProducts\zwasm\.zig-cache'"'"'"'
+ssh <windows-host> 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'$env:USERPROFILE\Documents\MyProducts\zwasm\zig-out'"'"'"'
+ssh <windows-host> 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'$env:LOCALAPPDATA\zig'"'"'"'
+ssh <windows-host> 'powershell -NoProfile -Command "Add-MpPreference -ExclusionPath '"'"'$env:LOCALAPPDATA\zwasm-tools'"'"'"'
+ssh <windows-host> 'powershell -NoProfile -Command "Add-MpPreference -ExclusionProcess '"'"'zig.exe'"'"'"'
 ```
 
 **Verify** (any time):
 
 ```bash
-ssh windowsmini 'powershell -NoProfile -Command "Get-MpPreference | Select-Object -Property ExclusionPath, ExclusionProcess | Format-List"'
+ssh <windows-host> 'powershell -NoProfile -Command "Get-MpPreference | Select-Object -Property ExclusionPath, ExclusionProcess | Format-List"'
 ```
 
 If a fresh windowsmini host is provisioned (or the OS is
@@ -242,7 +242,7 @@ windowsmini.
 Periodic verification on windowsmini:
 
 ```bash
-ssh windowsmini 'cd Documents/MyProducts/zwasm && \
+ssh <windows-host> 'cd Documents/MyProducts/zwasm && \
     bash scripts/run_bench.sh --windows-subset --quick'
 ```
 
@@ -293,13 +293,13 @@ configuration):
 
 **ExclusionPath (8)**:
 - `C:\Program Files\LLVM` (lldb + llvm-objdump / nm / readobj / symbolizer / cxxfilt / etc.)
-- `C:\Users\shota\AppData\Local\zig` (zig global cache)
-- `C:\Users\shota\AppData\Local\zwasm-tools` (wabt / wasmtime / hyperfine / yq / wasm-tools)
-- `C:\Users\shota\AppData\Local\zwasm-tools\sysinternals-<date>` (explicit subpath for clarity)
-- `C:\Users\shota\AppData\Local\CrashDumps` (reserved for WER `.dmp` output)
-- `C:\Users\shota\Documents\MyProducts\zwasm` (repo root)
-- `C:\Users\shota\Documents\MyProducts\zwasm\.zig-cache`
-- `C:\Users\shota\Documents\MyProducts\zwasm\zig-out`
+- `$env:LOCALAPPDATA\zig` (zig global cache)
+- `$env:LOCALAPPDATA\zwasm-tools` (wabt / wasmtime / hyperfine / yq / wasm-tools)
+- `$env:LOCALAPPDATA\zwasm-tools\sysinternals-<date>` (explicit subpath for clarity)
+- `$env:LOCALAPPDATA\CrashDumps` (reserved for WER `.dmp` output)
+- `$env:USERPROFILE\Documents\MyProducts\zwasm` (repo root)
+- `$env:USERPROFILE\Documents\MyProducts\zwasm\.zig-cache`
+- `$env:USERPROFILE\Documents\MyProducts\zwasm\zig-out`
 
 **ExclusionProcess (17)** — all `build.zig::addExecutable` outputs:
 `build.exe`, `test.exe`, `zig.exe`, `zwasm.exe`,
@@ -355,7 +355,7 @@ foreach ($exe in @(
 )) {
     New-Item -Path "$reg\$exe" -Force | Out-Null
     Set-ItemProperty -Path "$reg\$exe" -Name DumpType -Value 2  # 2 = full mini-dump
-    Set-ItemProperty -Path "$reg\$exe" -Name DumpFolder -Value 'C:\Users\shota\AppData\Local\CrashDumps'
+    Set-ItemProperty -Path "$reg\$exe" -Name DumpFolder -Value '$env:LOCALAPPDATA\CrashDumps'
     Set-ItemProperty -Path "$reg\$exe" -Name DumpCount -Value 10
 }
 ```


### PR DESCRIPTION
Doc-only. Replaces the user-profile paths (`C:\Users\<name>\...`) and the SSH user name that one maintainer's machines had left in the JIT debug recipes, the Windows host setup notes, the Linux host notes and one debt row with `$env:USERPROFILE` / `$env:LOCALAPPDATA` and `<windows-host>` / `<user>` placeholders. Historical ADR and lesson text keeps the host aliases the decisions are named after; only account-specific strings change.