### PR TITLE
fix(lint): drop four unused declarations from runner_eh_test.zig

### DIFF
--- a/src/engine/runner_eh_test.zig
+++ b/src/engine/runner_eh_test.zig
@@ -7,17 +7,12 @@
 // FILE-SIZE-EXEMPT: pure test suite already P1+P3-extracted from runner_test.zig (ADR-0128); slicing duplicates fixtures (N4) (investigated 2026-08-12, per ADR-0099)
 
 const std = @import("std");
-const builtin = @import("builtin");
 const testing = std.testing;
-const skip = @import("../test_support/skip.zig");
 
 const runner = @import("runner.zig");
 const runI32Export = runner.runI32Export;
 const runF32Export = runner.runF32Export;
 const JitInstance = runner.JitInstance;
-
-const entry = @import("codegen/shared/entry.zig");
-const heap_mod = @import("../feature/gc/heap.zig");
 
 // ============================================================
 // 10.G GC-on-JIT — i31 op family e2e (ref.i31 / i31.get_s /


### PR DESCRIPTION
Four declarations in `src/engine/runner_eh_test.zig` are imported and never
read: `builtin`, `skip`, `entry`, `heap_mod`. They arrived with #366 and are
the only lint findings in the tree.

They block `scripts/gate_commit.sh`, which runs `zig build lint --
--max-warnings 0`, so anyone touching `src/` locally is stopped by four lines
in a file they did not open.

CI does not stop on them. `ci_gate.sh:126` runs `zig build lint` without
`--max-warnings 0`, so the extended leg on the push that merged #366 printed
all four and the job concluded `success` (run 33318129427, `gate
(x86_64-linux)`). That gap is a separate change and follows straight after
this one — this PR is only the four lines, so the fix reaches v2.6.0's tree
without waiting on a gate-definition review.

`zig build test` and `zig build lint` are green locally with them gone.
