### PR TITLE
ci: the authoritative gate stops on a lint warning, as the optional one does

### DIFF
--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -123,7 +123,7 @@ bash scripts/check_releasesafe_runners.sh
 
 if [ "${ZWASM_CI_EXTENDED:-0}" = "1" ]; then
     echo "[ci_gate] extended: zig build lint"
-    zig build lint
+    zig build lint -- --max-warnings 0
 
     echo "[ci_gate] extended: build-option DCE / level-separation (9 combos)"
     bash scripts/check_build_dce.sh --gate


### PR DESCRIPTION
`zig build lint` is stricter in the optional gate than in the authoritative
one:

```
scripts/gate_commit.sh:359   zig build lint -- --max-warnings 0
scripts/ci_gate.sh:126       zig build lint
```

`.claude/CLAUDE.md` puts it the other way round — CI's `ci-required` is the
merge gate and `gate_commit.sh` is "an **optional** pre-PR pre-flight". A rule
that lives only in the optional gate holds only for whoever chooses to run it.

## It has already run one way

The extended leg of the push that merged #366 printed four `no_unused`
warnings from `src/engine/runner_eh_test.zig` and the job concluded `success`
(run 33318129427, `gate (x86_64-linux)`). Nothing was wrong with the findings —
the declarations were genuinely unread, and #373 removed them. What the run
demonstrates is that a lint finding on `main` is a line of log output rather
than a stop.

The four then blocked `gate_commit.sh` for the next person to touch `src/`
locally, which is the inversion: the optional gate refused a commit over four
lines the authoritative one had already waved through.

## Not the first time the tier hid a finding

#199 is the same shape, from your side of it. `no_deprecated` flagged
`std.fs.path.basename` in the spec runner and nobody saw it, and your body said
why:

> lint runs only in the **extended** CI tier, which `ci.yml` gates on
> push-to-main. The line landed with ADR-0210, whose own push run was
> superseded-cancelled by the next merge, and every push since has been
> doc-only (skips the heavy legs).

Three things kept that finding out of sight: the tier, the cancelled run, and
the doc-only skip. #363 closed the cancellation. This closes the fourth one you
did not have to name then, because you were reading the log yourself — that a
finding which does reach the log still does not stop anything.

## Why this does not red main

- **The tree is clean.** #373 removed the only findings; `zig build lint --
  --max-warnings 0` reports `No issues!` on `2f94bf0aa`.
- **zlinter cannot bump under us.** `tools/lint/build.zig.zon` pins it by
  commit hash (`git+…#9b4d67b9…`) with a content hash beside it, so a new rule
  arrives only when someone changes that line.
- **Lint stays extended-only.** This does not add lint to PRs; it changes what
  the push-to-`main` leg does with a finding it already prints.

The adjacent caution at `ci_gate.sh:37-41` is about `zig fmt` recursing into
`tools/lint/zig-pkg`, not about lint warnings, and is untouched.

## Sign-off

This is a gate definition, so it is one of ADR-0212 D1's four. Requesting
review rather than self-merging. Nothing waits on it — #362 is independent, and
its branch already carries #373.
