### PR TITLE
test(diff): gate the outcomes both differential lanes already printed

### DIFF
--- a/.github/versions.lock
+++ b/.github/versions.lock
@@ -1,6 +1,10 @@
 # versions.lock — mirror of the pinned tool versions used by zwasm CI.
 #
-# Source of truth: flake.nix (Linux/macOS via the nix devshell + direnv).
+# Source of truth: flake.nix (Linux/macOS via the nix devshell + direnv) —
+# EXCEPT WASMTIME_VERSION. flake.nix takes `pkgs.wasmtime` unversioned, so the
+# dev shell floats with nixpkgs and the value below is CI's pin alone. The
+# realworld differential prints the wasmtime it actually ran against and
+# annotates a mismatch against this line rather than failing on it.
 # This file mirrors the same pins for environments that cannot use Nix —
 # primarily the GitHub-hosted CI runners and Windows native installs that
 # need a version string before nix is available. Sourced as a bash file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 # CI — the host-local gate on the 3 supported OSes, mirroring the local
 # 3-host gate (Mac aarch64 + Linux x86_64 + Windows x86_64). Each matrix leg
 # runs `scripts/ci_gate.sh` so CI verifies exactly what the maintainer runs
-# per host (single source of truth); the differential oracle uses wasmtime
-# when the install step succeeds.
+# per host (single source of truth); the differential oracle is wasmtime, and
+# its install is required.
 #
 # Triggers: pull_request (any target) + push to `main` + manual dispatch.
 # `main` is the trunk and is ruleset-protected: no direct pushes — every change
@@ -212,11 +212,16 @@ jobs:
         shell: pwsh
         run: Add-Content -Path $env:GITHUB_PATH -Value "$HOME\.local\zig-0.16.0"
 
-      # Reference oracle for the interp-vs-JIT-vs-wasmtime differential. Best
-      # effort: the differential runner degrades to a SKIP when it is absent,
-      # so a download hiccup must not fail the gate.
-      - name: Install wasmtime (reference oracle, best effort)
-        continue-on-error: true
+      # Reference oracle for the interp-vs-JIT-vs-wasmtime differential.
+      # REQUIRED, not best effort (issue #213): the runner degrades to a SKIP
+      # when wasmtime is absent and a skipped lane still exits 0, so a download
+      # hiccup bought a leg that was green and had checked nothing. The step's
+      # `conclusion` is what `ci-required` reads, so only a failing step makes
+      # that visible through the API. A flake now reds the leg and is re-run —
+      # measured 0 failures in 144 step runs (3 OSes x 48 runs, 2026-09-01).
+      # The symmetry argument for best-effort is spent: `wasm-tools` below is
+      # installed without `continue-on-error` (ADR-0212 D4).
+      - name: Install wasmtime (reference oracle, required)
         shell: bash
         run: |
           set -euo pipefail
@@ -267,7 +272,7 @@ jobs:
         run: |
           zig version
           wasm-tools --version
-          wasmtime --version || echo "wasmtime absent — differential will SKIP"
+          wasmtime --version
 
       # Extended checks (lint + 9-combo × 2-arch build-DCE matrix + ReleaseSafe
       # JIT smoke + AOT cross-compile) are up to ~20 cold-cache ReleaseSafe builds

--- a/build.zig
+++ b/build.zig
@@ -1073,6 +1073,8 @@ pub fn build(b: *std.Build) void {
     });
     const run_realworld_diff = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff.addArg(b.pathFromRoot("test/realworld/wasm"));
+    // The pinned oracle version the run annotates itself against (issue #213).
+    run_realworld_diff.addArgs(&.{ "--versions-lock", b.pathFromRoot(".github/versions.lock") });
     run_realworld_diff.has_side_effects = true; // fixture-only changes must re-run (cyc216 gap)
     // Nothing in the build graph depends on this step any more — `test-all`
     // takes `test-realworld-diff-jit`, which is the same runner plus `--jit`.
@@ -1090,6 +1092,7 @@ pub fn build(b: *std.Build) void {
     // now (triages AOT-WASI corpus coverage); a follow-up gates it once clean.
     const run_realworld_diff_aot = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff_aot.addArg(b.pathFromRoot("test/realworld/wasm"));
+    run_realworld_diff_aot.addArgs(&.{ "--versions-lock", b.pathFromRoot(".github/versions.lock") });
     run_realworld_diff_aot.addArg("--aot");
     run_realworld_diff_aot.has_side_effects = true;
     const test_realworld_diff_aot_step = b.step("test-realworld-diff-aot", "Realworld differential incl. the opt-in AOT lane (D-283)");
@@ -1121,6 +1124,7 @@ pub fn build(b: *std.Build) void {
     // (wasmer is not in the x86_64 dev shells), graceful skip off-Mac.
     const run_realworld_diff_wasmer = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff_wasmer.addArg(b.pathFromRoot("test/realworld/wasm"));
+    run_realworld_diff_wasmer.addArgs(&.{ "--versions-lock", b.pathFromRoot(".github/versions.lock") });
     run_realworld_diff_wasmer.addArg("--wasmer");
     run_realworld_diff_wasmer.has_side_effects = true;
     const test_realworld_diff_wasmer_step = b.step("test-realworld-diff-wasmer", "Realworld differential incl. the opt-in wasmer second-oracle lane (§9.6 A3)");
@@ -1144,6 +1148,7 @@ pub fn build(b: *std.Build) void {
     // lane's cost class). Full-corpus coverage: `test-realworld-diff-interp`.
     const run_realworld_diff_jit = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff_jit.addArg(b.pathFromRoot("test/realworld/wasm"));
+    run_realworld_diff_jit.addArgs(&.{ "--versions-lock", b.pathFromRoot(".github/versions.lock") });
     run_realworld_diff_jit.addArg("--jit");
     run_realworld_diff_jit.addArg("--interp");
     run_realworld_diff_jit.has_side_effects = true;
@@ -1157,6 +1162,7 @@ pub fn build(b: *std.Build) void {
     // Debug. One command re-derives interp-vs-wasmtime for all 56.
     const run_realworld_diff_interp = b.addRunArtifact(realworld_diff_runner_exe);
     run_realworld_diff_interp.addArg(b.pathFromRoot("test/realworld/wasm"));
+    run_realworld_diff_interp.addArgs(&.{ "--versions-lock", b.pathFromRoot(".github/versions.lock") });
     run_realworld_diff_interp.addArg("--interp-all");
     run_realworld_diff_interp.has_side_effects = true;
     const test_realworld_diff_interp_step = b.step("test-realworld-diff-interp", "Full-corpus forced-interp differential incl. the enumerated-slow fixtures (manual; not in test-all)");

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -317,7 +317,6 @@ fn run(init: std.process.Init) !u8 {
             for (seen_content.items) |h| {
                 if (std.mem.eql(u8, &h, &content_hash)) duplicate_content = true;
             }
-            if (!duplicate_content) try seen_content.append(gpa, content_hash);
 
             const stored_before = try countStoredArtifacts(io, cwd, cache_root_rel);
             var lane_miss = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
@@ -357,6 +356,11 @@ fn run(init: std.process.Init) !u8 {
                     .{ entry.name, stored_after_hit - stored_after_miss },
                 );
             }
+            // Recorded only once both cache lanes have run. A fixture whose
+            // lane could not be launched `continue`s above without creating an
+            // entry, so recording it earlier would make the next identical
+            // fixture's real first store read as a duplicate's forbidden one.
+            if (!duplicate_content) try seen_content.append(gpa, content_hash);
 
             const equal = lane_a.exit == lane_b.exit and std.mem.eql(u8, lane_a.stdout, lane_b.stdout);
             const cache_equal = lane_a.exit == lane_miss.exit and

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -109,13 +109,25 @@ fn runLane(
     };
 }
 
-/// `.cwasm` entries under the cache-lane root. Called per fixture (before the
-/// miss, after the miss, after the hit) rather than once per run: a store that
-/// works for one fixture and fails for the other 63 satisfies a whole-run
-/// "at least one was stored" check, while `cache_equal` stays true because a
-/// never-stored entry simply recompiles to identical bytes.
-fn countStoredArtifacts(io: std.Io, cwd: std.Io.Dir, root_rel: []const u8) !u32 {
-    var n: u32 = 0;
+/// One walk of the cache-lane root: how many `.cwasm` entries it holds, and
+/// whether the entry for `key_hex` is one of them.
+///
+/// Per fixture, not once per run: a store that works for one fixture and
+/// fails for the other 63 satisfies a whole-run "at least one was stored"
+/// check, while `cache_equal` stays true because a never-stored entry simply
+/// recompiles to identical bytes.
+///
+/// Asks whether THIS fixture's entry exists rather than whether the count
+/// grew, which is what keeps the answer independent of what earlier fixtures
+/// in the run did. `src/cli/cache.zig` `keyHex` is SHA-256 of the module
+/// bytes and the codegen-affecting knobs live in the subdirectory name, so
+/// `<key>.cwasm` under any subdirectory is this module's artifact — and two
+/// byte-identical fixtures share it, the second one's miss lane legitimately
+/// storing nothing.
+const CacheScan = struct { total: u32, has_key: bool };
+
+fn scanCache(io: std.Io, cwd: std.Io.Dir, root_rel: []const u8, key_hex: []const u8) !CacheScan {
+    var scan: CacheScan = .{ .total = 0, .has_key = false };
     var root_dir = try cwd.openDir(io, root_rel, .{ .iterate = true });
     defer root_dir.close(io);
     var root_it = root_dir.iterate();
@@ -125,10 +137,14 @@ fn countStoredArtifacts(io: std.Io, cwd: std.Io.Dir, root_rel: []const u8) !u32 
         defer sub_dir.close(io);
         var sub_it = sub_dir.iterate();
         while (try sub_it.next(io)) |e| {
-            if (std.mem.endsWith(u8, e.name, ".cwasm")) n += 1;
+            if (!std.mem.endsWith(u8, e.name, ".cwasm")) continue;
+            scan.total += 1;
+            if (e.name.len == key_hex.len + ".cwasm".len and std.mem.startsWith(u8, e.name, key_hex)) {
+                scan.has_key = true;
+            }
         }
     }
-    return n;
+    return scan;
 }
 
 pub fn main(init: std.process.Init) !void {
@@ -203,15 +219,6 @@ fn run(init: std.process.Init) !u8 {
     var unsound_reported: u32 = 0;
     var unexpected: u32 = 0; // gate
     var ratchet_flips: u32 = 0; // gate (a known_table entry now matches)
-
-    // Content hashes of the fixtures whose cache entry this run has already
-    // created. The cache is keyed by module CONTENT (`src/cli/cache.zig`
-    // `keyHex` = SHA-256 of the bytes), so two byte-identical fixtures — same
-    // name or not, same directory or not — share one entry: the second one's
-    // "miss" lane is a hit and stores nothing, which the store check below
-    // would otherwise read as a broken store.
-    var seen_content: std.ArrayList([32]u8) = .empty;
-    defer seen_content.deinit(gpa);
 
     var n_dirs: u32 = 0;
     var corpus_empty = false;
@@ -309,58 +316,40 @@ fn run(init: std.process.Init) !u8 {
                 &.{ cli, "run", cache_flag, "--dir", p, entry.name }
             else
                 &.{ cli, "run", cache_flag, entry.name };
+            // This fixture's cache key — see `scanCache`.
             const fixture_bytes = try dir.readFileAlloc(io, entry.name, gpa, .limited(64 << 20));
             defer gpa.free(fixture_bytes);
             var content_hash: [32]u8 = undefined;
             std.crypto.hash.sha2.Sha256.hash(fixture_bytes, &content_hash, .{});
-            var duplicate_content = false;
-            for (seen_content.items) |h| {
-                if (std.mem.eql(u8, &h, &content_hash)) duplicate_content = true;
-            }
+            const key_hex = std.fmt.bytesToHex(content_hash, .lower);
 
-            const stored_before = try countStoredArtifacts(io, cwd, cache_root_rel);
             var lane_miss = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
                 try stdout.print("SKIP-SPAWN  {s}: lane C miss: {s}\n", .{ entry.name, @errorName(err) });
                 skipped_spawn += 1;
                 continue;
             };
             defer lane_miss.deinit(gpa);
-            const stored_after_miss = try countStoredArtifacts(io, cwd, cache_root_rel);
+            const after_miss = try scanCache(io, cwd, cache_root_rel, &key_hex);
             var lane_hit = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
                 try stdout.print("SKIP-SPAWN  {s}: lane C hit: {s}\n", .{ entry.name, @errorName(err) });
                 skipped_spawn += 1;
                 continue;
             };
             defer lane_hit.deinit(gpa);
-            const stored_after_hit = try countStoredArtifacts(io, cwd, cache_root_rel);
-            if (duplicate_content) {
-                // An earlier fixture in this run has the same bytes, so BOTH
-                // lanes here are hits on its entry and neither may store.
-                if (stored_after_hit != stored_before) {
-                    unexpected += 1;
-                    try stdout.print(
-                        "CACHE-DUP-STORE  {s}: byte-identical to an earlier fixture, yet {d} entries were added\n",
-                        .{ entry.name, stored_after_hit - stored_before },
-                    );
-                }
-            } else if (stored_after_miss == stored_before) {
+            const after_hit = try scanCache(io, cwd, cache_root_rel, &key_hex);
+            if (!after_miss.has_key) {
                 unexpected += 1;
                 try stdout.print(
-                    "CACHE-STORE-FAIL  {s}: the miss lane stored nothing ({d} entries before and after)\n",
-                    .{ entry.name, stored_before },
+                    "CACHE-STORE-FAIL  {s}: no entry for this module after the miss lane ({d} in the root)\n",
+                    .{ entry.name, after_miss.total },
                 );
-            } else if (stored_after_hit != stored_after_miss) {
+            } else if (after_hit.total != after_miss.total) {
                 unexpected += 1;
                 try stdout.print(
                     "CACHE-HIT-MISSED  {s}: the hit lane stored {d} more entries — it recompiled instead of hitting\n",
-                    .{ entry.name, stored_after_hit - stored_after_miss },
+                    .{ entry.name, after_hit.total - after_miss.total },
                 );
             }
-            // Recorded only once both cache lanes have run. A fixture whose
-            // lane could not be launched `continue`s above without creating an
-            // entry, so recording it earlier would make the next identical
-            // fixture's real first store read as a duplicate's forbidden one.
-            if (!duplicate_content) try seen_content.append(gpa, content_hash);
 
             const equal = lane_a.exit == lane_b.exit and std.mem.eql(u8, lane_a.stdout, lane_b.stdout);
             const cache_equal = lane_a.exit == lane_miss.exit and

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -36,6 +36,13 @@
 //! Everything else defaults to `.match` — any divergence is a finding and
 //! the gate exits non-zero.
 //!
+//! Summary vocabulary, shared with `test/realworld/diff_runner.zig`: the last
+//! field of every summary line is `GATING` or `NOT-GATING: <reason>`, and
+//! reason is one of `oracle-absent`, `oracle-unusable`, `corpus-empty` — this
+//! runner compares zwasm against itself, so only the last can appear here. A
+//! lane that checked nothing says so in its own summary, so a zero exit is
+//! never read as a checked run.
+//!
 //! Usage: `zig build test-aot-diff` /
 //!        `zwasm-aot-process-diff <zwasm-cli> <corpus-dir> [corpus-dir...]`
 
@@ -100,6 +107,28 @@ fn runLane(
         },
         .crashed = result.term != .exited,
     };
+}
+
+/// `.cwasm` entries under the cache-lane root. Called per fixture (before the
+/// miss, after the miss, after the hit) rather than once per run: a store that
+/// works for one fixture and fails for the other 63 satisfies a whole-run
+/// "at least one was stored" check, while `cache_equal` stays true because a
+/// never-stored entry simply recompiles to identical bytes.
+fn countStoredArtifacts(io: std.Io, cwd: std.Io.Dir, root_rel: []const u8) !u32 {
+    var n: u32 = 0;
+    var root_dir = try cwd.openDir(io, root_rel, .{ .iterate = true });
+    defer root_dir.close(io);
+    var root_it = root_dir.iterate();
+    while (try root_it.next(io)) |sub| {
+        if (sub.kind != .directory) continue;
+        var sub_dir = try root_dir.openDir(io, sub.name, .{ .iterate = true });
+        defer sub_dir.close(io);
+        var sub_it = sub_dir.iterate();
+        while (try sub_it.next(io)) |e| {
+            if (std.mem.endsWith(u8, e.name, ".cwasm")) n += 1;
+        }
+    }
+    return n;
 }
 
 pub fn main(init: std.process.Init) !void {
@@ -176,8 +205,10 @@ fn run(init: std.process.Init) !u8 {
     var ratchet_flips: u32 = 0; // gate (a known_table entry now matches)
 
     var n_dirs: u32 = 0;
+    var corpus_empty = false;
     while (arg_it.next()) |corpus_dir_arg| {
         n_dirs += 1;
+        const dir_first_total = total;
         const corpus_dir = try gpa.dupe(u8, corpus_dir_arg);
         defer gpa.free(corpus_dir);
 
@@ -269,18 +300,34 @@ fn run(init: std.process.Init) !u8 {
                 &.{ cli, "run", cache_flag, "--dir", p, entry.name }
             else
                 &.{ cli, "run", cache_flag, entry.name };
+            const stored_before = try countStoredArtifacts(io, cwd, cache_root_rel);
             var lane_miss = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
                 try stdout.print("SKIP-SPAWN  {s}: lane C miss: {s}\n", .{ entry.name, @errorName(err) });
                 skipped_spawn += 1;
                 continue;
             };
             defer lane_miss.deinit(gpa);
+            const stored_after_miss = try countStoredArtifacts(io, cwd, cache_root_rel);
             var lane_hit = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
                 try stdout.print("SKIP-SPAWN  {s}: lane C hit: {s}\n", .{ entry.name, @errorName(err) });
                 skipped_spawn += 1;
                 continue;
             };
             defer lane_hit.deinit(gpa);
+            const stored_after_hit = try countStoredArtifacts(io, cwd, cache_root_rel);
+            if (stored_after_miss == stored_before) {
+                unexpected += 1;
+                try stdout.print(
+                    "CACHE-STORE-FAIL  {s}: the miss lane stored nothing ({d} entries before and after)\n",
+                    .{ entry.name, stored_before },
+                );
+            } else if (stored_after_hit != stored_after_miss) {
+                unexpected += 1;
+                try stdout.print(
+                    "CACHE-HIT-MISSED  {s}: the hit lane stored {d} more entries — it recompiled instead of hitting\n",
+                    .{ entry.name, stored_after_hit - stored_after_miss },
+                );
+            }
 
             const equal = lane_a.exit == lane_b.exit and std.mem.eql(u8, lane_a.stdout, lane_b.stdout);
             const cache_equal = lane_a.exit == lane_miss.exit and
@@ -331,12 +378,32 @@ fn run(init: std.process.Init) !u8 {
                 }
             }
 
+            // A lane that did not exit cleanly produced no comparable result:
+            // `runLane` reports its exit as the harness's 255, which a guest
+            // can also return, so two symmetric crashes make `equal` true. A
+            // crash is therefore never a match — it is the outcome the lane
+            // exists to catch.
+            const crashed_lane: ?[]const u8 = if (lane_a.crashed)
+                "A (.wasm)"
+            else if (lane_b.crashed)
+                "B (.cwasm)"
+            else if (lane_miss.crashed)
+                "C (cache miss)"
+            else if (lane_hit.crashed)
+                "C (cache hit)"
+            else
+                null;
+
             switch (expectationFor(entry.name)) {
                 .match => {
-                    if (equal and cache_equal) {
+                    if (equal and cache_equal and crashed_lane == null) {
                         matched += 1;
                     } else {
                         unexpected += 1;
+                        if (crashed_lane) |lane| try stdout.print(
+                            "LANE-CRASHED  {s}: lane {s} did not exit cleanly; its exit code is the harness's, not the guest's\n",
+                            .{ entry.name, lane },
+                        );
                         if (!equal) try stdout.print(
                             "AOT-DIVERGE  {s}: wasm(exit={d}, {d}B stdout) vs cwasm(exit={d}, {d}B stdout{s})\n",
                             .{
@@ -355,7 +422,10 @@ fn run(init: std.process.Init) !u8 {
                     }
                 },
                 .wrong_result => |reason| {
-                    if (equal) {
+                    // The flip test reads every lane the `.match` arm reads —
+                    // a known divergence whose CACHE lane broke, or that now
+                    // "agrees" only because both lanes crashed, is not fixed.
+                    if (equal and cache_equal and crashed_lane == null) {
                         ratchet_flips += 1;
                         try stdout.print(
                             "RATCHET-FLIP  {s}: known divergence ({s}) now MATCHES — remove its known_table entry in this PR\n",
@@ -363,8 +433,9 @@ fn run(init: std.process.Init) !u8 {
                         );
                     } else {
                         expected_diverged += 1;
-                        try stdout.print("EXPECTED-DIVERGE  {s}: {s} (wasm exit={d} / cwasm exit={d})\n", .{
-                            entry.name, reason, lane_a.exit, lane_b.exit,
+                        const crash_note: []const u8 = if (crashed_lane != null) ", a lane CRASHED" else "";
+                        try stdout.print("EXPECTED-DIVERGE  {s}: {s} (wasm exit={d} / cwasm exit={d}{s})\n", .{
+                            entry.name, reason, lane_a.exit, lane_b.exit, crash_note,
                         });
                     }
                 },
@@ -377,6 +448,14 @@ fn run(init: std.process.Init) !u8 {
             }
             try stdout.flush();
         }
+        // Per DIRECTORY, not over their sum. The two corpora are produced by
+        // different means — the realworld `.wasm` are generated on the Mac
+        // host — so one can empty out while the other still reports a full set
+        // of matches, a closed accounting, and a zero exit.
+        if (total == dir_first_total) {
+            try stdout.print("CORPUS-EMPTY  {s}: the directory contributed no .wasm fixture\n", .{corpus_dir});
+            corpus_empty = true;
+        }
     }
 
     if (n_dirs == 0) {
@@ -385,36 +464,25 @@ fn run(init: std.process.Init) !u8 {
         return 2;
     }
 
-    // The cache lanes must have actually STORED entries — a silently-broken
-    // store would still "match" above by recompiling on every run.
-    var stored_artifacts: u32 = 0;
-    {
-        var root_dir = try cwd.openDir(io, cache_root_rel, .{ .iterate = true });
-        defer root_dir.close(io);
-        var root_it = root_dir.iterate();
-        while (try root_it.next(io)) |sub| {
-            if (sub.kind != .directory) continue;
-            var sub_dir = try root_dir.openDir(io, sub.name, .{ .iterate = true });
-            defer sub_dir.close(io);
-            var sub_it = sub_dir.iterate();
-            while (try sub_it.next(io)) |e| {
-                if (std.mem.endsWith(u8, e.name, ".cwasm")) stored_artifacts += 1;
-            }
-        }
-    }
-    if (matched > 0 and stored_artifacts == 0) {
-        unexpected += 1;
-        try stdout.print("CACHE-STORE-FAIL: cache lanes matched but zero .cwasm entries were stored\n", .{});
-    }
-
     try stdout.print(
-        "\naot_process_diff: {d} fixtures — {d} matched, {d} spawn-skip, {d} refused, {d} expected-diverge, {d} unsound-reported, {d} UNEXPECTED, {d} ratchet-flips — GATING\n",
+        "\naot_process_diff: {d} fixtures — {d} matched, {d} spawn-skip, {d} refused, {d} expected-diverge, {d} unsound-reported, {d} UNEXPECTED, {d} ratchet-flips — ",
         .{ total, matched, skipped_spawn, refused_produce, expected_diverged, unsound_reported, unexpected, ratchet_flips },
     );
+    if (corpus_empty or total == 0) {
+        try stdout.print("NOT-GATING: corpus-empty\n", .{});
+    } else if (unsound_reported != 0) {
+        // `.unsound` rows are report-only by design (see the header), so a run
+        // carrying them gates over fewer fixtures than its total suggests. No
+        // expiry mechanism while `known_table` is empty — the summary says how
+        // many fixtures the word GATING does not cover.
+        try stdout.print("GATING ({d} report-only, not gated)\n", .{unsound_reported});
+    } else {
+        try stdout.print("GATING\n", .{});
+    }
     try stdout.flush();
 
-    if (total == 0) {
-        try stdout.print("error: empty corpus\n", .{});
+    if (corpus_empty or total == 0) {
+        try stdout.print("error: a corpus directory contributed no fixture — the run differentiated nothing\n", .{});
         try stdout.flush();
         return 1;
     }

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -204,6 +204,15 @@ fn run(init: std.process.Init) !u8 {
     var unexpected: u32 = 0; // gate
     var ratchet_flips: u32 = 0; // gate (a known_table entry now matches)
 
+    // Content hashes of the fixtures whose cache entry this run has already
+    // created. The cache is keyed by module CONTENT (`src/cli/cache.zig`
+    // `keyHex` = SHA-256 of the bytes), so two byte-identical fixtures — same
+    // name or not, same directory or not — share one entry: the second one's
+    // "miss" lane is a hit and stores nothing, which the store check below
+    // would otherwise read as a broken store.
+    var seen_content: std.ArrayList([32]u8) = .empty;
+    defer seen_content.deinit(gpa);
+
     var n_dirs: u32 = 0;
     var corpus_empty = false;
     while (arg_it.next()) |corpus_dir_arg| {
@@ -300,6 +309,16 @@ fn run(init: std.process.Init) !u8 {
                 &.{ cli, "run", cache_flag, "--dir", p, entry.name }
             else
                 &.{ cli, "run", cache_flag, entry.name };
+            const fixture_bytes = try dir.readFileAlloc(io, entry.name, gpa, .limited(64 << 20));
+            defer gpa.free(fixture_bytes);
+            var content_hash: [32]u8 = undefined;
+            std.crypto.hash.sha2.Sha256.hash(fixture_bytes, &content_hash, .{});
+            var duplicate_content = false;
+            for (seen_content.items) |h| {
+                if (std.mem.eql(u8, &h, &content_hash)) duplicate_content = true;
+            }
+            if (!duplicate_content) try seen_content.append(gpa, content_hash);
+
             const stored_before = try countStoredArtifacts(io, cwd, cache_root_rel);
             var lane_miss = runLane(gpa, io, lane_c_argv, corpus_dir) catch |err| {
                 try stdout.print("SKIP-SPAWN  {s}: lane C miss: {s}\n", .{ entry.name, @errorName(err) });
@@ -315,7 +334,17 @@ fn run(init: std.process.Init) !u8 {
             };
             defer lane_hit.deinit(gpa);
             const stored_after_hit = try countStoredArtifacts(io, cwd, cache_root_rel);
-            if (stored_after_miss == stored_before) {
+            if (duplicate_content) {
+                // An earlier fixture in this run has the same bytes, so BOTH
+                // lanes here are hits on its entry and neither may store.
+                if (stored_after_hit != stored_before) {
+                    unexpected += 1;
+                    try stdout.print(
+                        "CACHE-DUP-STORE  {s}: byte-identical to an earlier fixture, yet {d} entries were added\n",
+                        .{ entry.name, stored_after_hit - stored_before },
+                    );
+                }
+            } else if (stored_after_miss == stored_before) {
                 unexpected += 1;
                 try stdout.print(
                     "CACHE-STORE-FAIL  {s}: the miss lane stored nothing ({d} entries before and after)\n",

--- a/test/realworld/diff_runner.zig
+++ b/test/realworld/diff_runner.zig
@@ -24,7 +24,8 @@
 //!                 categorises (WASI host gap / validator gap /
 //!                 no entry); orthogonal to differential coverage.
 //!   SKIP-WASMTIME-MISSING — wasmtime not on PATH; runner exits
-//!                 0 with a "no diffs run on this host" notice.
+//!                 0, and every summary line it would have printed
+//!                 says NOT-GATING: oracle-absent instead.
 //!                 Hosts with wasmtime installed see the real gate.
 //!
 //! The `--jit` lane (D-283) re-runs the same corpus through the
@@ -49,11 +50,26 @@
 //! silent (ADR-0210) — and stay covered by the manual `--interp-all`
 //! variant.
 //!
+//! Summary vocabulary, shared with `test/aot/aot_process_diff.zig`: the last
+//! field of every summary line is `GATING`, `NOT-GATING: <reason>`, or
+//! `REPORT-ONLY` (the opt-in lanes that gate nothing by design). Reason is one
+//! of `oracle-absent`, `oracle-unusable`, `corpus-empty`. A lane that checked
+//! nothing says so in its own summary, so a zero exit is never read as a
+//! checked run.
+//!
+//! Oracle version: the runner prints the wasmtime it ran against and compares
+//! it to `WASMTIME_VERSION` in `.github/versions.lock` (passed as
+//! `--versions-lock <path>`), so the lane's numbers are attributable to a
+//! named oracle. A mismatch is annotated, not fatal: that lock file is CI's
+//! pin only — `flake.nix` takes `pkgs.wasmtime` unversioned, so the dev shell
+//! floats with nixpkgs and a fatal check would fail every developer host.
+//!
 //! Usage:
 //!   zig build test-realworld-diff         # shared (.auto) lane only
 //!   zig build test-realworld-diff-jit     # + the gating JIT + forced-interp lanes (test-all)
 //!   zig build test-realworld-diff-interp  # forced-interp over the FULL corpus (manual)
 //!   diff_runner_exe <corpus-dir> [--jit|--aot|--wasmer|--interp|--interp-all]
+//!                                [--versions-lock <path>]
 
 const std = @import("std");
 
@@ -173,6 +189,8 @@ pub fn main(init: std.process.Init) !void {
     var jit_lane = false;
     var interp_lane = false;
     var interp_all = false;
+    var versions_lock: ?[]u8 = null;
+    defer if (versions_lock) |v| gpa.free(v);
     while (arg_it.next()) |a| {
         if (std.mem.eql(u8, a, "--aot")) {
             aot_lane = true;
@@ -185,23 +203,51 @@ pub fn main(init: std.process.Init) !void {
         } else if (std.mem.eql(u8, a, "--interp-all")) {
             interp_lane = true;
             interp_all = true;
+        } else if (std.mem.eql(u8, a, "--versions-lock")) {
+            // Duped: the iterator may reuse its buffer across `next` calls.
+            if (arg_it.next()) |v| versions_lock = try gpa.dupe(u8, v);
         }
     }
 
-    const wasmtime_path_opt = try resolveWasmtime(gpa, io);
-    defer if (wasmtime_path_opt) |p| gpa.free(p);
+    const oracle_opt = try resolveWasmtime(gpa, io);
+    defer if (oracle_opt) |o| o.deinit(gpa);
 
-    if (wasmtime_path_opt == null) {
+    if (oracle_opt == null) {
         try stdout.print(
             "SKIP-WASMTIME-MISSING — wasmtime not on PATH (and no nix-store wrapper found). " ++
                 "§9.6 / 6.F differential gate is non-fatal on this host; the gate is real on " ++
-                "hosts with wasmtime installed (the dev shell pins it via flake.nix).\n",
+                "hosts with wasmtime installed (the dev shell provides it via flake.nix).\n",
             .{},
         );
+        // The skip has to reach the summary, not only the log above. Exit 0
+        // with no summary is indistinguishable from a clean run to anything
+        // reading the tail — which is how a wasmtime-less host produced a
+        // green leg that had checked nothing.
+        try stdout.print("\ndiff_runner: the corpus was not walked — NOT-GATING: oracle-absent\n", .{});
+        if (jit_lane) try stdout.print("diff_runner [jit]: 0 fixtures reached this lane — NOT-GATING: oracle-absent\n", .{});
+        if (interp_lane) try stdout.print("diff_runner [interp]: 0 fixtures reached this lane — NOT-GATING: oracle-absent\n", .{});
         try stdout.flush();
         return;
     }
-    const wasmtime_path = wasmtime_path_opt.?;
+    const wasmtime_path = oracle_opt.?.cmd;
+
+    // Which oracle the numbers below belong to. `resolveWasmtime` already ran
+    // `wasmtime --version` to probe reachability; this keeps its answer.
+    const pinned_opt: ?[]u8 = if (versions_lock) |path| try pinnedWasmtimeVersion(gpa, io, path) else null;
+    defer if (pinned_opt) |v| gpa.free(v);
+    const version_mismatch = if (pinned_opt) |pinned| !std.mem.eql(u8, pinned, oracle_opt.?.version) else false;
+    if (pinned_opt) |pinned| {
+        try stdout.print("oracle: wasmtime {s} — .github/versions.lock pins {s}\n", .{ oracle_opt.?.version, pinned });
+    } else {
+        try stdout.print("oracle: wasmtime {s} — no pin given (--versions-lock)\n", .{oracle_opt.?.version});
+    }
+    if (version_mismatch) {
+        try stdout.print(
+            "ORACLE-VERSION-MISMATCH — this run's figures are attributable to wasmtime {s}, not to the pinned {s}\n",
+            .{ oracle_opt.?.version, pinned_opt.? },
+        );
+    }
+    try stdout.flush();
 
     // Second-oracle resolution (only when --wasmer): wasmer is Mac-only in the
     // flake, so it is absent on the x86_64 hosts — the lane then skips with a
@@ -526,11 +572,24 @@ pub fn main(init: std.process.Init) !void {
         }
     }
 
+    // wasmtime resolved but every spawn failed (e.g. a `which` hit that does
+    // not execute). Decided BEFORE the summaries so the tails can say it — the
+    // notice used to be printed after them, so every lane line above claimed
+    // GATING on a host where nothing had run.
+    const oracle_unusable = matched == 0 and skipped_wasmtime_fail == total and total > 0;
+    const shared_reason: ?[]const u8 = if (total == 0)
+        "corpus-empty"
+    else if (oracle_unusable)
+        "oracle-unusable"
+    else
+        null;
+
     try stdout.print(
         "\ndiff_runner: {d}/{d} matched, {d} mismatched, {d} skipped-empty, " ++
-            "{d} skipped-wasmtime-fail, {d} skipped-v2\n",
+            "{d} skipped-wasmtime-fail, {d} skipped-v2",
         .{ matched, total, mismatched, skipped_empty, skipped_wasmtime_fail, skipped_v2 },
     );
+    try printTail(stdout, shared_reason, version_mismatch);
     // AOT lane summary (opt-in, report-only; D-283 widen / D-251 validate).
     if (aot_lane) {
         try stdout.print(
@@ -547,9 +606,13 @@ pub fn main(init: std.process.Init) !void {
     if (jit_lane) {
         try stdout.print(
             "diff_runner [jit]: {d}/{d} matched vs wasmtime, {d} mismatched, {d} skipped (JIT-unsupported / trap), " ++
-                "{d} skipped-empty, {d} unaccounted — GATING (fatal on mismatch, skip, or shortfall)\n",
+                "{d} skipped-empty, {d} unaccounted",
             .{ jit_matched, jit_eligible, jit_mismatched, jit_skipped, jit_skipped_empty, jit_eligible -| (jit_matched + jit_mismatched + jit_skipped + jit_skipped_empty) },
         );
+        // An empty eligible set is a lane that owed no verdict and gave none:
+        // its three gate arms are all vacuously satisfied, which is exactly the
+        // state the word GATING must not be printed for.
+        try printTail(stdout, shared_reason orelse (if (jit_eligible == 0) "oracle-unusable" else null), version_mismatch);
         // ADR-0210 rule 4: print the identity, do not leave it implied. `{d}/{d}`
         // above is against the ELIGIBLE set, so the corpus-level denominator has
         // to be reconciled separately or the ratio reads as full coverage.
@@ -562,9 +625,10 @@ pub fn main(init: std.process.Init) !void {
     if (interp_lane) {
         try stdout.print(
             "diff_runner [interp]: {d}/{d} matched vs wasmtime, {d} mismatched, {d} skipped (interp-unsupported / trap), " ++
-                "{d} skipped-empty, {d} unaccounted — GATING (fatal on mismatch, skip, or shortfall)\n",
+                "{d} skipped-empty, {d} unaccounted",
             .{ interp_matched, interp_eligible, interp_mismatched, interp_skipped, interp_skipped_empty, interp_eligible -| (interp_matched + interp_mismatched + interp_skipped + interp_skipped_empty) },
         );
+        try printTail(stdout, shared_reason orelse (if (interp_eligible == 0) "oracle-unusable" else null), version_mismatch);
         // Same rule-4 print as the JIT lane, one bucket wider: the enumerated
         // slow skips are part of the corpus-level denominator, so a fixture
         // enumerated out is visibly NOT part of the `{d}/{d}` coverage ratio.
@@ -696,12 +760,10 @@ pub fn main(init: std.process.Init) !void {
             std.process.exit(1);
         }
     }
-    // wasmtime resolved via `which` but every spawn failed (e.g. on
-    // windowsmini, where `which wasmtime` finds a stub that doesn't
-    // actually execute). Treat as SKIP-WASMTIME-MISSING so the gate
-    // remains portable; the gate is real on hosts where wasmtime
-    // genuinely runs.
-    if (matched == 0 and skipped_wasmtime_fail == total and total > 0) {
+    // Treated as SKIP-WASMTIME-MISSING so the gate remains portable; the gate
+    // is real on hosts where wasmtime genuinely runs. The summaries above
+    // already carry `NOT-GATING: oracle-unusable`.
+    if (oracle_unusable) {
         try stdout.print(
             "SKIP-WASMTIME-UNUSABLE — wasmtime resolved but every spawn failed " ++
                 "({d} of {d} fixtures); §9.6 / 6.F differential gate is non-fatal on this host.\n",
@@ -954,8 +1016,54 @@ fn interpCompare(
     return .mismatch;
 }
 
+/// The reference oracle: the command to spawn plus the version it reported.
+const Oracle = struct {
+    cmd: []u8,
+    version: []u8,
+
+    fn deinit(self: Oracle, gpa: std.mem.Allocator) void {
+        gpa.free(self.cmd);
+        gpa.free(self.version);
+    }
+};
+
+/// `WASMTIME_VERSION` from a `.github/versions.lock`-shaped file, or null when
+/// the file is unreadable or carries no such key.
+fn pinnedWasmtimeVersion(gpa: std.mem.Allocator, io: std.Io, path: []const u8) !?[]u8 {
+    const cwd = std.Io.Dir.cwd();
+    const text = cwd.readFileAlloc(io, path, gpa, .limited(64 << 10)) catch return null;
+    defer gpa.free(text);
+    var lines = std.mem.splitScalar(u8, text, '\n');
+    const key = "WASMTIME_VERSION=";
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (std.mem.startsWith(u8, trimmed, key)) return try gpa.dupe(u8, trimmed[key.len..]);
+    }
+    return null;
+}
+
+/// `wasmtime 47.0.3 (5554cc1a6 2026-07-31)` → `47.0.3`.
+fn parseWasmtimeVersion(out: []const u8) []const u8 {
+    var it = std.mem.tokenizeAny(u8, out, " \t\r\n");
+    _ = it.next() orelse return "unknown";
+    return it.next() orelse "unknown";
+}
+
+/// The one summary tail both differential runners print. Kept as a function so
+/// the two words and the three reasons cannot drift between call sites.
+fn printTail(out: anytype, reason: ?[]const u8, version_mismatch: bool) !void {
+    if (reason) |r| {
+        try out.print(" — NOT-GATING: {s}\n", .{r});
+    } else if (version_mismatch) {
+        try out.print(" — GATING (oracle-version-mismatch)\n", .{});
+    } else {
+        try out.print(" — GATING\n", .{});
+    }
+}
+
 /// Test whether `wasmtime` is reachable on PATH. Returns the
-/// bare command name (`"wasmtime"`) if reachable, null otherwise.
+/// bare command name (`"wasmtime"`) and its reported version if
+/// reachable, null otherwise.
 ///
 /// We deliberately do NOT return the path from `which` /
 /// `where.exe` because on Windows MSYS / Git-Bash hosts (e.g.
@@ -968,14 +1076,16 @@ fn interpCompare(
 /// Discharges debt D-008 (the previous "wasmtime stub on
 /// windowsmini" framing was wrong; wasmtime IS installed there
 /// — `which`'s MSYS-format path was the actual blocker).
-fn resolveWasmtime(allocator: std.mem.Allocator, io: std.Io) !?[]u8 {
+fn resolveWasmtime(allocator: std.mem.Allocator, io: std.Io) !?Oracle {
     const result = std.process.run(allocator, io, .{
         .argv = &[_][]const u8{ "wasmtime", "--version" },
     }) catch return null;
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
     if (result.term != .exited or result.term.exited != 0) return null;
-    return try allocator.dupe(u8, "wasmtime");
+    const cmd = try allocator.dupe(u8, "wasmtime");
+    errdefer allocator.free(cmd);
+    return .{ .cmd = cmd, .version = try allocator.dupe(u8, parseWasmtimeVersion(result.stdout)) };
 }
 
 /// Test whether `wasmer` is reachable on PATH (the §9.6 A3 second-oracle lane).


### PR DESCRIPTION
Two lanes on the authoritative gate had the same defect: a counter that is
produced, printed, and never read. Fixed together so they say it the same way.

## What changes

- **AOT** (`test/aot/aot_process_diff.zig`): a lane that did not exit cleanly
  is never a match — its exit is the harness's 255, which a guest can also
  return, so two symmetric crashes made `equal` true. The cache-store check
  moves from a whole-run `> 0` to per fixture: the fixture's own entry
  (`<sha256>.cwasm`, the key `src/cli/cache.zig` derives) must exist after the
  miss lane, and the entry count must not grow after the hit lane. An empty
  corpus **directory** is fatal, not only an empty union of them. The
  ratchet-flip test now reads the cache lanes and the crash flag.
- **Realworld** (`test/realworld/diff_runner.zig`): a run that did not walk the
  corpus prints a summary saying so, per lane. `resolveWasmtime` already ran
  `wasmtime --version` and discarded it; it now reports the version, compared
  against `WASMTIME_VERSION` in `.github/versions.lock` (`--versions-lock`).
- **CI**: the wasmtime install drops `continue-on-error`. `conclusion` is what
  `ci-required` reads, so a runner-side notice alone stays invisible to the API.
- Shared vocabulary: every summary line ends with `GATING`, `NOT-GATING:
  <reason>`, or `REPORT-ONLY`; reasons are `oracle-absent`, `oracle-unusable`,
  `corpus-empty`.

## Measured before implementing (x86_64-linux Debug, 67772ed72)

Gating the crash flag and per-fixture store counting turn **0 of 64 fixtures**
red: 256 lane spawns, zero non-clean terminations; every fixture stores exactly
one `.cwasm` on the miss and none on the hit. All 64 fixtures are git-tracked,
so the per-directory gate can only fire on a deletion.

## Re-derived

`PATH` without wasmtime → the run still exits 0, and now every line says
`NOT-GATING: oracle-absent`. A wasmtime differing from the pin → the run prints
`ORACLE-VERSION-MISMATCH` and tails `GATING (oracle-version-mismatch)`; with a
matching pin, neither appears. An extra empty corpus dir → `CORPUS-EMPTY`,
`NOT-GATING: corpus-empty`, exit 1, while the other directory reported 7/7.
A CLI that crashes in every lane → 0 matched, 15 UNEXPECTED, exit 1.

## Not here

`#307` item 6 (the `test-wasi-p1-official` ratchet) is ordered behind `#312` by
its own thread, and `D-598` is marked separately worth doing in the issue.
`#307` stays open carrying both; nothing new was filed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zwasm/zwasm/pull/375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes #213.
Refs #307.
