### PR TITLE
test(wasi): reconcile the wasip3 official corpus against the blocks that cover it

### DIFF
--- a/src/api/component_wasi_p3.zig
+++ b/src/api/component_wasi_p3.zig
@@ -1206,6 +1206,26 @@ fn runServiceRequest(built: *wasi_p2.BuiltComponent, rop: HttpReqOp) !void {
     if (rop.expect_body) |eb| try testing.expectEqualStrings(eb, capture.items);
 }
 
+/// The corpus entry a `test "wasip3-official: <name>"` block covers, taken
+/// from the block's own name.
+///
+/// The reconciliation below reads coverage out of `builtin.test_functions`,
+/// i.e. out of the test NAMES. If the name and the argument were two
+/// independent strings, a copy/paste slip could run one binary under another
+/// one's title: the named binary would count as covered, never run, and the
+/// set comparison would still pass. Deriving the argument from the name
+/// leaves one value, so there is nothing for them to disagree about.
+///
+/// `@src().fn_name` inside a test block is `test.<the block's name>`; several
+/// blocks append a parenthesised note, which is not part of the file stem.
+fn officialCorpusName(comptime src: std.builtin.SourceLocation) []const u8 {
+    const marker = "test.wasip3-official: ";
+    const at = std.mem.find(u8, src.fn_name, marker) orelse
+        @compileError("official corpus test must be named `wasip3-official: <corpus stem>`");
+    const rest = src.fn_name[at + marker.len ..];
+    return if (std.mem.find(u8, rest, " (")) |sp| rest[0..sp] else rest;
+}
+
 /// Run one vendored official test end-to-end and assert its manifest.
 fn runOfficialWasip3Test(comptime name: []const u8) !void {
     const alloc = testing.allocator;
@@ -1333,142 +1353,142 @@ fn runOfficialWasip3Test(comptime name: []const u8) !void {
 }
 
 test "wasip3-official: cli-env" {
-    try runOfficialWasip3Test("cli-env");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: cli-exit" {
-    try runOfficialWasip3Test("cli-exit");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: cli-stdio" {
-    try runOfficialWasip3Test("cli-stdio");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: cli-stdio-roundtrip" {
-    try runOfficialWasip3Test("cli-stdio-roundtrip");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: cli-stdout-flush" {
-    try runOfficialWasip3Test("cli-stdout-flush");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: cli-terminal" {
-    try runOfficialWasip3Test("cli-terminal");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: monotonic-clock (async wait-until/wait-for timers)" {
-    try runOfficialWasip3Test("monotonic-clock");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: multi-clock-wait (20 interleaved wait-until subtasks)" {
-    try runOfficialWasip3Test("multi-clock-wait");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: random (incl. cached insecure-seed)" {
-    try runOfficialWasip3Test("random");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: wall-clock" {
-    try runOfficialWasip3Test("wall-clock");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: run-with-err (exit code 1)" {
-    try runOfficialWasip3Test("run-with-err");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 
 test "wasip3-official: filesystem-stat" {
-    try runOfficialWasip3Test("filesystem-stat");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-io (file via-stream data plane)" {
-    try runOfficialWasip3Test("filesystem-io");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-advise" {
-    try runOfficialWasip3Test("filesystem-advise");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-dotdot" {
-    try runOfficialWasip3Test("filesystem-dotdot");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-flags-and-type" {
-    try runOfficialWasip3Test("filesystem-flags-and-type");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-hard-links" {
-    try runOfficialWasip3Test("filesystem-hard-links");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-is-same-object" {
-    try runOfficialWasip3Test("filesystem-is-same-object");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-metadata-hash" {
-    try runOfficialWasip3Test("filesystem-metadata-hash");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-mkdir-rmdir" {
-    try runOfficialWasip3Test("filesystem-mkdir-rmdir");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-open-errors" {
-    try runOfficialWasip3Test("filesystem-open-errors");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-read-directory" {
-    try runOfficialWasip3Test("filesystem-read-directory");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-rename" {
-    try runOfficialWasip3Test("filesystem-rename");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-set-size" {
-    try runOfficialWasip3Test("filesystem-set-size");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: filesystem-unlink-errors" {
-    try runOfficialWasip3Test("filesystem-unlink-errors");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 
 test "wasip3-official: sockets-tcp-properties (TCP option store)" {
-    try runOfficialWasip3Test("sockets-tcp-properties");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-udp-properties (UDP option store)" {
-    try runOfficialWasip3Test("sockets-udp-properties");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-udp-bind (bind + address validation)" {
-    try runOfficialWasip3Test("sockets-udp-bind");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-tcp-bind (REUSEADDR + addrinuse contracts)" {
-    try runOfficialWasip3Test("sockets-tcp-bind");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-tcp-connect (incl. explicit-bind connect)" {
-    try runOfficialWasip3Test("sockets-tcp-connect");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-fields (fields resource, RFC 9110 validation)" {
-    try runOfficialWasip3Test("http-fields");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-request (method/scheme/path/authority validation)" {
-    try runOfficialWasip3Test("http-request");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-response (status code + immutable headers)" {
-    try runOfficialWasip3Test("http-response");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-service (handler export + body capture)" {
-    try runOfficialWasip3Test("http-service");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-service-echo (request body + header reflection)" {
-    try runOfficialWasip3Test("http-service-echo");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-service-uri (scheme/authority set by host)" {
-    try runOfficialWasip3Test("http-service-uri");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: http-client (client.send against the harness echo endpoint)" {
-    try runOfficialWasip3Test("http-client");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 
 test "wasip3-official: http-request-options (timeouts + immutable child)" {
-    try runOfficialWasip3Test("http-request-options");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-udp-connect" {
-    try runOfficialWasip3Test("sockets-udp-connect");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-udp-send" {
-    try runOfficialWasip3Test("sockets-udp-send");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-udp-receive" {
-    try runOfficialWasip3Test("sockets-udp-receive");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-tcp-listen" {
-    try runOfficialWasip3Test("sockets-tcp-listen");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-tcp-send" {
-    try runOfficialWasip3Test("sockets-tcp-send");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-tcp-receive" {
-    try runOfficialWasip3Test("sockets-tcp-receive");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 test "wasip3-official: sockets-echo (join! interleaved data plane)" {
-    try runOfficialWasip3Test("sockets-echo");
+    try runOfficialWasip3Test(comptime officialCorpusName(@src()));
 }
 
 /// The vendored corpus root, relative to the repo root. The 45 test blocks
@@ -1496,9 +1516,10 @@ const wasip3_official_root = "test/component/wasip3_official";
 //
 // CAVEAT: `-Dtest-filter` removes tests from `test_functions`, so a filter
 // that keeps THIS block while dropping the 45 reports them all as uncovered.
-// No build step passes a filter (`test-all` does not), and the failure names
-// itself below.
-test "wasip3-official: the covered set is exactly the vendored corpus" {
+// This block is deliberately NOT named `wasip3-official: …`, so the obvious
+// filter drops this block instead — the harmless direction. No build step
+// passes a filter (`test-all` does not), and the failure names itself below.
+test "wasip3_official corpus: every vendored binary has a block that runs it" {
     const builtin = @import("builtin");
     const alloc = testing.allocator;
 
@@ -1516,7 +1537,6 @@ test "wasip3-official: the covered set is exactly the vendored corpus" {
         var name = t.name[at + marker.len ..];
         // Several blocks append a parenthesised note ("(async wait-until/…)").
         if (std.mem.find(u8, name, " (")) |sp| name = name[0..sp];
-        if (std.mem.eql(u8, name, "the covered set is exactly the vendored corpus")) continue;
         try covered.append(alloc, name);
     }
 

--- a/src/api/component_wasi_p3.zig
+++ b/src/api/component_wasi_p3.zig
@@ -1470,3 +1470,118 @@ test "wasip3-official: sockets-tcp-receive" {
 test "wasip3-official: sockets-echo (join! interleaved data plane)" {
     try runOfficialWasip3Test("sockets-echo");
 }
+
+/// The vendored corpus root, relative to the repo root. The 45 test blocks
+/// above reach it through `runOfficialWasip3Test`, which builds the same
+/// prefix from a comptime name.
+const wasip3_official_root = "test/component/wasip3_official";
+
+// ADR-0210 — the denominator behind "the official wasm32-wasip3 corpus,
+// 45/45 green on all three supported OSes".
+//
+// Every `.wasm` in the corpus does have a `test "wasip3-official: …"` block
+// above, but nothing checked that, and the two sides drift in opposite ways:
+//
+//   corpus -> covered   a newly vendored binary that nobody writes a block
+//                       for is simply never run, and the lane stays green
+//                       over a corpus it no longer covers.
+//   covered -> corpus   a block naming a binary that regen removed fails on
+//                       the file read, which is loud — but only once the
+//                       block still exists to fail, so it is checked here
+//                       too rather than relied on.
+//
+// The covered set is read from `builtin.test_functions` rather than from a
+// second hand-written list: a list would be one more copy of the 45 names,
+// and a copy is the thing this test exists to stop.
+//
+// CAVEAT: `-Dtest-filter` removes tests from `test_functions`, so a filter
+// that keeps THIS block while dropping the 45 reports them all as uncovered.
+// No build step passes a filter (`test-all` does not), and the failure names
+// itself below.
+test "wasip3-official: the covered set is exactly the vendored corpus" {
+    const builtin = @import("builtin");
+    const alloc = testing.allocator;
+
+    var threaded: std.Io.Threaded = .init(alloc, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    // `<module path>.test.wasip3-official: <name>[ (note)]` — the block's own
+    // name carries the corpus entry it covers, so it is the source of truth.
+    const marker = ".test.wasip3-official: ";
+    var covered: std.ArrayList([]const u8) = .empty;
+    defer covered.deinit(alloc);
+    for (builtin.test_functions) |t| {
+        const at = std.mem.find(u8, t.name, marker) orelse continue;
+        var name = t.name[at + marker.len ..];
+        // Several blocks append a parenthesised note ("(async wait-until/…)").
+        if (std.mem.find(u8, name, " (")) |sp| name = name[0..sp];
+        if (std.mem.eql(u8, name, "the covered set is exactly the vendored corpus")) continue;
+        try covered.append(alloc, name);
+    }
+
+    var root = std.Io.Dir.cwd().openDir(io, wasip3_official_root, .{ .iterate = true }) catch |err| {
+        // ADR-0174 — the corpus is committed, so an unopenable root is a path
+        // or checkout failure. It must never read as "0 entries, all green".
+        std.debug.print(
+            "wasip3-official corpus root '{s}' not openable: {t}\n" ++
+                "  the corpus is committed — regen with scripts/vendor_wasip3_official.sh\n",
+            .{ wasip3_official_root, err },
+        );
+        return error.TestUnexpectedResult;
+    };
+    defer root.close(io);
+
+    var vendored: u32 = 0;
+    var uncovered: u32 = 0;
+    var it = root.iterate();
+    while (try it.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.name, ".wasm")) continue;
+        vendored += 1;
+        const stem = entry.name[0 .. entry.name.len - ".wasm".len];
+        var found = false;
+        for (covered.items) |c| {
+            if (std.mem.eql(u8, c, stem)) found = true;
+        }
+        if (!found) {
+            uncovered += 1;
+            std.debug.print(
+                "UNCOVERED  {s}/{s}: vendored, but no `test \"wasip3-official: {s}\"` block runs it\n",
+                .{ wasip3_official_root, entry.name, stem },
+            );
+        }
+    }
+
+    var absent: u32 = 0;
+    for (covered.items) |c| {
+        const rel = try std.fmt.allocPrint(alloc, "{s}.wasm", .{c});
+        defer alloc.free(rel);
+        root.access(io, rel, .{}) catch {
+            absent += 1;
+            std.debug.print(
+                "ABSENT  a test block covers '{s}', but {s}/{s} is not in the corpus\n",
+                .{ c, wasip3_official_root, rel },
+            );
+        };
+    }
+
+    // Always print the count. The claim this lane backs is a NUMBER, and an
+    // OK/NG verdict is how a lane running over a fraction of its corpus reads
+    // as green (ADR-0174). Same vocabulary as `test/wasi/official_runner.zig`
+    // and the wasm-3.0 assert lane.
+    std.debug.print(
+        "wasip3_official: {d} covered, {d} uncovered, {d} absent, {d} vendored\n",
+        .{ covered.items.len, uncovered, absent, vendored },
+    );
+
+    if (vendored == 0) {
+        // Reachable with an openable-but-empty root, where every check above
+        // passes vacuously.
+        std.debug.print("the corpus root holds no .wasm — regen with scripts/vendor_wasip3_official.sh\n", .{});
+        return error.TestUnexpectedResult;
+    }
+    try testing.expectEqual(@as(u32, 0), uncovered);
+    try testing.expectEqual(@as(u32, 0), absent);
+    try testing.expectEqual(@as(usize, vendored), covered.items.len);
+}


### PR DESCRIPTION
`zig build test-wasi-p3` printed `3230/3242` for the whole module, so nothing
re-derived the "45/45" the README names. The lane now says it:

```
wasip3_official: 45 covered, 0 uncovered, 0 absent, 45 vendored
```

## Both directions

The 45 test blocks and the 45 `.wasm` files agree today, but only by hand:

- **corpus → covered** — a newly vendored binary with no block is simply never
  run, and the lane stays green over a corpus it no longer covers. Verified: a
  46th file makes it red and names the block that is missing.
- **covered → corpus** — a block naming a removed binary fails on the file
  read, which is loud, but only while the block survives to fail. Verified:
  removing a `.wasm` makes it red and names it.

The covered set is read from `builtin.test_functions`, not a second
hand-written list. A list would be one more copy of the 45 names, and a copy
drifting is the thing this checks for.

## The name is the only value

Coverage is read out of test names, so a body passing an independent string
could run one binary under another's title — the named binary counted as
covered, never ran, and the comparison still passed. `@src().fn_name` is
comptime-usable inside a test block, so each block's argument is now derived
from its own name. Verified: mistyping a title reports both the uncovered
binary and the absent one.

## Placement

Unchanged. `test-wasi-p3` is already a `test-all` dependency, so this runs in
the core `ci-required` gate on all three OSes.

Closes #214.
