### PR TITLE
ci(wasi): the official preview1 corpus blocks, with a ratchet

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,7 +81,9 @@ text or code identifiers.
   merge gate. A PR run gets the **core** gate — zig fmt + `test-all` +
   `bench-latency-build` (compile-only, ADR-0209) + the test-discovery guard,
   plus on the Linux leg only `run-rust-host` and the unit tests built
-  ReleaseSafe (#347). The **extended** checks (lint /
+  ReleaseSafe (#347) — and, as a blocking step OUTSIDE `ci_gate.sh`,
+  `test-wasi-p1-official` (ADR-0225; the only leg content the script does not
+  define). The **extended** checks (lint /
   build-option DCE / ReleaseSafe JIT smoke / AOT cross-compile / `zone_check` /
   `spill_aware`) are gated on `ZWASM_CI_EXTENDED`, which `ci.yml` sets only on
   the **push to `main`** — they are up to ~20 cold-cache ReleaseSafe builds and

--- a/.dev/debt.yaml
+++ b/.dev/debt.yaml
@@ -418,22 +418,30 @@ entries:
       first pass of the 2026-08-14 measurement recorded it as flaky for
       exactly this reason.
       ---
-        DISCHARGE: all 8 green on all three OSes, on both lanes (item (1)
-        wires BOTH lanes into `test-all`, the blocking gate).
-        Four edits land together — anything left behind is a doc that outlives
+        DISCHARGE: the corpus green on all three OSes, on both lanes (item
+        (1) wires BOTH lanes into `test-all`, the blocking gate).
+        Five edits land together — anything left behind is a doc that outlives
         its subject, which is how §11.2 came to describe neither reality nor
         intent:
       (1) `build.zig` — `test_all_step.dependOn` both lanes (`ci_gate.sh` needs
           no edit; it already runs `zig build test-all`);
-      (2) `.github/workflows/ci.yml` — delete the advisory step in `gate`;
+      (2) `.github/workflows/ci.yml` — delete the step in `gate`;
       (3) `docs/development.md` — drop the "Not in `test-all`" marker from the
           table row, restore `test-all`'s "all of the above", and delete the
-          paragraph about the advisory placement;
-      (4) this row — deleted, per the ledger's delete-on-discharge rule
+          paragraph about the separate placement;
+      (4) `test/wasi/official_runner.zig` — remove the windows rows from
+          `known_table`; the table itself stays, empty, the way the AOT
+          differential's does, so a future finding has a home;
+      (5) this row — deleted, per the ledger's delete-on-discharge rule
           (D-582 discharged 2026-08-24).
-      Until then the step reports real counts and stays non-blocking — a
-      deliberate, time-boxed advisory in the sense of ADR-0174 ("NOT a silent
-      skip"), not an indefinite workaround.
+      Until then the step is BLOCKING with a ratchet (ADR-0225 supersedes
+      ADR-0208 D3's advisory placement): linux and macOS are at baseline 0 and
+      any failure reds the PR, and the windows rows above are the `known_table`
+      — tolerated, while anything outside it, and any listed name that starts
+      passing, reds the PR too. The table describes CI's windows-2022 runner,
+      not the Windows 11 host: `path_symlink_trailing_slashes` is recorded here
+      and deliberately NOT in the table, because one exact-match table cannot
+      hold both counts.
     first_raised: "2026-08-14"
     last_reviewed: "2026-08-30"
     refs: |-

--- a/.dev/decisions/0208_wasip1_official_corpus.md
+++ b/.dev/decisions/0208_wasip1_official_corpus.md
@@ -3,7 +3,14 @@
 > **Doc-state**: ACTIVE
 
 - **Status**: Accepted (2026-08-18 — maintainer sign-off on PR #183; the
-  official suite is the bar, D1–D3 as written)
+  official suite is the bar). **D3 superseded by ADR-0225 (2026-09-02)**: the
+  step blocks with a per-OS `known_table` instead of carrying
+  `continue-on-error`, and runs on pull requests as well as the merge. D1 and
+  D2 stand. The "Ratchet the 14 failures instead of running advisory" entry
+  under `Alternatives rejected` is superseded with it — its ground, "Nothing in
+  the repo ratchets failures today", was already false when written
+  (`test/aot/aot_process_diff.zig` has carried that mechanism since
+  `4ac56549a`, 2026-07-09).
 - **Date**: 2026-08-14
 - **Front**: B-hardening (D-582 infrastructure, D-583 the behaviour gaps it exposes)
 - **Findings base**: measured conformance run 2026-08-14 at `2e40d4314` on
@@ -120,6 +127,9 @@ The existing three-fixture `test-wasi-p1` step stays. It exercises the
 longer load-bearing as a conformance claim.
 
 ### D3 — Run it as an advisory step in `gate`, with a written exit condition
+
+> **SUPERSEDED by ADR-0225 (2026-09-02).** Kept as written; what shipped is in
+> ADR-0225 D1/D3.
 
 The step runs at the end of the existing `gate` job on all three OSes with
 step-level `continue-on-error: true`. GitHub's contract is that a failing

--- a/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
+++ b/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
@@ -1,6 +1,7 @@
 # 0225 — The official preview1 corpus blocks, with a ratchet; ADR-0208 D3's advisory placement is superseded
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-09-02 — maintainer sign-off on PR #380, taken on
+  the measurements in Context before any of it was written; D1–D3 as written)
 - **Date**: 2026-09-02
 - **Author**: Junji Takakura
 - **Tags**: ci, wasi, gate, ratchet

--- a/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
+++ b/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
@@ -1,0 +1,117 @@
+# 0225 — The official preview1 corpus blocks, with a ratchet; ADR-0208 D3's advisory placement is superseded
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Author**: Junji Takakura
+- **Tags**: ci, wasi, gate, ratchet
+
+## Context
+
+ADR-0208 D3 placed `zig build test-wasi-p1-official` in the `gate` job with
+step-level `continue-on-error: true`, and its `Alternatives rejected` section
+turned down a failure ratchet in favour of that. Both parts have since been
+overtaken, and one of them was already inaccurate when written.
+
+**The premise moved.** D3's reason was "the corpus is 14 red today", so
+blocking would red every PR. Measured on `0a90547e2` (run 33612652144, all
+three legs, both engines): x86_64-linux and aarch64-macos are at the vendored
+total on both lanes, and x86_64-windows fails the #290 family — the same names
+on both engines, already enumerated by name in D-583. Two of the three hosts
+need no tolerance at all, and the third needs a list, not a flag.
+
+**The rejection's factual ground was wrong.** D3 rejected a ratchet partly on
+"Nothing in the repo ratchets failures today". `test/aot/aot_process_diff.zig`
+has carried exactly that mechanism since `4ac56549a` (2026-07-09), five weeks
+before ADR-0208: a `known_table` whose `.wrong_result` rows name a debt row,
+are tolerated, and trip `RATCHET-FLIP` when the fixture starts matching. The
+table was empty, so the *mechanism* was invisible to a survey of active
+ratchets — but the shape was house-shaped and precedented, not new. #375
+re-affirmed and extended that lane.
+
+**`continue-on-error` did more than annotate.** GitHub keeps `outcome:
+failure` on such a step but rewrites `conclusion` to `success`, and
+`conclusion` is what `needs.gate.result` and therefore `ci-required` read.
+That is what hid #310: the runner stopped producing a summary line at all —
+it died mid-corpus — and the leg reported green. The failure mode was not a
+worse number, it was no number.
+
+**Push-only compounds it.** ADR-0208 predates the 2026-08-24 move to
+`if: github.event_name == 'push'`, whose stated reason is that a step which
+cannot block a PR buys no gate signal for the 182 s it costs. Once the step
+blocks, that reason inverts: a blocking check that runs only after the merge
+turns a preview1 regression into a red `main`, which is the situation #312 is
+open about.
+
+## Decision
+
+### D1 — The step blocks, and the tolerance is a named table, not a flag
+
+`continue-on-error` is deleted. `test/wasi/official_runner.zig` grows a
+`known_table` in the shape of the AOT differential's: entries carry a test
+stem and a debt-row id, a listed test that fails is counted apart and
+tolerated, and a listed test that PASSES exits non-zero so its row is removed
+by the PR that fixed it. `builtin.os.tag` selects the table; linux and macOS
+get an empty one, so every test there is `.match` and any failure reds the PR.
+
+The table records **names**, never a count — the count stays derivable from
+the run. That is the same reason the CI comment block carries no number: this
+project has already had a copied count go stale against the debt row it was
+copied from.
+
+No separate presence check is added. The runner's exit code is the presence
+check: a corpus that stops producing a summary line does so by dying, and a
+dead process exits non-zero. What hid #310 was not a missing check, it was
+`continue-on-error` overwriting the one that existed.
+
+### D2 — The table describes CI's windows-2022 runner and no other host
+
+D-583 records `path_symlink_trailing_slashes` failing on a Windows 11 host,
+where the family is eight rather than seven. An exact-match table cannot hold
+both: listing eight reds windows-2022 with a ratchet flip, listing seven reds
+Windows 11 with an unexpected failure. The gate exists to hold CI, so it is
+written for CI's host. An extra failure on a local Windows 11 box is that box
+disagreeing with the runner; it is recorded in D-583 and not enforced.
+
+### D3 — The step runs on pull requests as well as the merge
+
+Reverses the 2026-08-24 push-only placement, on that placement's own
+reasoning. Cost is the measured 182 s (`286a91f89`, 2026-08-25) — 138 s on the
+macOS leg, 44 s across linux and windows — against a macOS gate leg that ran
+23 m 25 s on PR #376.
+
+## Alternatives rejected
+
+- **Keep the advisory placement and add a notifier for a red `main`.** The
+  premise does not hold up. Over the last 100 push runs of `ci.yml` on `main`
+  (2026-08-04 .. 2026-09-02) there were two failures, both in extended-only
+  checks, and both were fixed within hours by the person who merged —
+  `8ea1f797a` about an hour after run 33056826468, with a body that cites the
+  failure ("the merge red main"), and `a27504789` about 2.5 h after run
+  31552046553, whose own title is "run the test-discovery guard on PRs". In
+  both cases the remedy taken was to move the check to where it blocks. This
+  ADR does that for a third one. Whether a notification channel is also worth
+  having is #312's question and is not settled here.
+
+- **Ratchet on a failure COUNT rather than a name set.** A count cannot tell
+  "one fixed, one regressed" from "no change", which is the state the #290
+  cluster will actually pass through. It also reintroduces the copied number
+  D-583 already lost once.
+
+- **Move the step into `test-all` now.** That is D-583's discharge and it is
+  not reached: the Windows names are still red. Folding it in early would put
+  the tolerance table inside the blocking unit test gate, where it is harder
+  to see.
+
+## Consequences
+
+- ADR-0208 **D3 is superseded**; D1 and D2 stand. Its `Alternatives rejected`
+  entry "Ratchet the 14 failures instead of running advisory" no longer
+  describes current practice, and its factual claim about the repo having no
+  failure ratchet was already false at the time.
+- `ci-required` now genuinely covers the preview1 corpus on all three OSes —
+  before, a Windows leg exiting 1 was indistinguishable through the API from a
+  pass.
+- D-583's DISCHARGE clause gains an edit (emptying the table) and loses its
+  "stays non-blocking" sentence.
+- The #290 cluster is now load-bearing: fixing any of those names requires
+  removing its table row in the same PR, which the ratchet enforces.

--- a/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
+++ b/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
@@ -68,10 +68,14 @@ whose test starts passing. A row whose test is no longer THERE is the other
 direction, and it is silent: an upstream bump that removes a listed test and
 adds another keeps the vendored total intact, so nothing else in the runner
 notices, and the row sits tolerating nothing. Each row therefore carries an
-encountered flag, and a row the walk never reached exits non-zero as
-`STALE-ROW`. Duplicate keys are a `@compileError`, since the second copy would
-be unreachable and its flag would never be set either. Found by Devin's review
-on PR #380 and reproduced before fixing — a bogus row passed at exit 0.
+hit COUNT, and any row the walk did not reach exactly once exits non-zero:
+`STALE-ROW` at zero, `DUP-STEM` above one. Duplicate keys within the table are
+a `@compileError`, since the second copy would be unreachable and never
+counted. Both directions came from Devin's review on PR #380 and were
+reproduced before fixing — a bogus row passed at exit 0, and stem uniqueness
+across the three suites was asserted only by a comment:
+`scripts/vendor_wasip1_official.sh` pins per-language COUNTS, not names, so a
+rename that collides two suites' stems keeps the vendored total intact.
 
 ### D2 — The table describes CI's windows-2022 runner and no other host
 

--- a/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
+++ b/.dev/decisions/0225_wasip1_official_blocking_ratchet.md
@@ -63,6 +63,16 @@ check: a corpus that stops producing a summary line does so by dying, and a
 dead process exits non-zero. What hid #310 was not a missing check, it was
 `continue-on-error` overwriting the one that existed.
 
+The table is held to the corpus in both directions. RATCHET-FLIP covers a row
+whose test starts passing. A row whose test is no longer THERE is the other
+direction, and it is silent: an upstream bump that removes a listed test and
+adds another keeps the vendored total intact, so nothing else in the runner
+notices, and the row sits tolerating nothing. Each row therefore carries an
+encountered flag, and a row the walk never reached exits non-zero as
+`STALE-ROW`. Duplicate keys are a `@compileError`, since the second copy would
+be unreachable and its flag would never be set either. Found by Devin's review
+on PR #380 and reproduced before fixing — a bogus row passed at exit 0.
+
 ### D2 — The table describes CI's windows-2022 runner and no other host
 
 D-583 records `path_symlink_trailing_slashes` failing on a Windows 11 host,
@@ -115,3 +125,8 @@ macOS leg, 44 s across linux and windows — against a macOS gate leg that ran
   "stays non-blocking" sentence.
 - The #290 cluster is now load-bearing: fixing any of those names requires
   removing its table row in the same PR, which the ratchet enforces.
+- `test/aot/aot_process_diff.zig`'s `known_table`, which this one is modelled
+  on, has the STALE-ROW hole too — its `expectationFor` is consulted only for
+  fixtures the corpus yields. Not fixed here: that lane's table is empty today,
+  so the hole is latent, and closing it belongs with that lane rather than in a
+  preview1 gate change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,19 @@
 # CI — the host-local gate on the 3 supported OSes, mirroring the local
 # 3-host gate (Mac aarch64 + Linux x86_64 + Windows x86_64). Each matrix leg
 # runs `scripts/ci_gate.sh`, which is where nearly all of the blocking content
-# lives, so it stays the single source of truth for what the maintainer runs
-# per host; the differential oracle is wasmtime, and its install is required.
+# lives and is the single definition of it; the differential oracle is
+# wasmtime, and its install is required.
 #
-# The leg has ONE blocking step outside that script — `test-wasi-p1-official`,
-# whose own block below says why it sits here rather than inside. So a green
-# local `gate_merge.sh` does not predict this leg. That is not new to it:
-# `doc-truth` is blocking through `ci-required` and its
-# `check_wasi03_coverage_claims` / `check_doc_fossils` have no local
-# counterpart at all. `ci-required` is authoritative and the local scripts are
-# pre-flight (ADR-0076 D9) — but do not read the paragraph above as a promise
-# that a local green cannot go red here.
+# What that does NOT mean is that a green local run predicts this leg, and two
+# things break the correspondence. The leg has one blocking step outside the
+# script — `test-wasi-p1-official`, whose own block below says why it sits
+# here. And `gate_merge.sh` does not invoke `ci_gate.sh` at all: it runs
+# `gate_commit.sh` locally and `run_remote_*.sh test-all` on the two remote
+# hosts, so it approximates the leg rather than reproducing it. Workflow-wide
+# the same already holds for `doc-truth`, which blocks through `ci-required`
+# while its `check_wasi03_coverage_claims` / `check_doc_fossils` have no local
+# counterpart. `ci-required` is authoritative; the local scripts are
+# pre-flight (ADR-0076 D9).
 #
 # Triggers: pull_request (any target) + push to `main` + manual dispatch.
 # `main` is the trunk and is ruleset-protected: no direct pushes — every change

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,25 +286,32 @@ jobs:
           ZWASM_CI_EXTENDED: ${{ (github.event_name == 'push' && matrix.extended) && '1' || '0' }}
         run: bash scripts/ci_gate.sh
 
-      # Official wasi-testsuite wasm32-wasip1 corpus (D-582). ADVISORY: the
-      # corpus is not green (D-583), so a blocking placement would red every
-      # PR. No count here on purpose: D-583 carries the live one and
-      # `zig build test-wasi-p1-official` re-derives it. A count copied to a
-      # second file is what went stale — this block said 14 while the row
-      # already said 8. Step-level `continue-on-error`
-      # keeps the step's `outcome` as `failure` (visible in the run) while its
-      # `conclusion` — and therefore the job's, and therefore
-      # `needs.gate.result` that `ci-required` reads — stays `success`.
+      # Official wasi-testsuite wasm32-wasip1 corpus (D-582). BLOCKING, with
+      # the ratchet in `test/wasi/official_runner.zig`: linux and macOS are at
+      # baseline 0 so every test there must pass, and the Windows leg carries a
+      # `known_table` of the #290 family, which tolerates those failures and
+      # trips when one of them starts passing. No count here on purpose —
+      # D-583 carries the live one, `zig build test-wasi-p1-official`
+      # re-derives it, and the table holds NAMES. A count copied to a second
+      # file is what went stale: this block once said 14 while the row already
+      # said 8.
       #
-      # PUSH-ONLY since 2026-08-24. The paragraph above is exactly why: a
-      # failure here could not block a PR and never could, so the 182 s it
-      # cost on every PR bought no gate signal — measured 2026-08-25 on
-      # `286a91f89`, over the four same-base PR runs that still ran it:
-      # 138 s on the macOS leg (spread 7 s) plus 44 s across linux and
-      # windows. It still runs on the merge to `main`, the same window
-      # `ZWASM_CI_EXTENDED` already accepts for its own checks, so the corpus
-      # verdict stays a per-merge number. D-583's remaining failures are
-      # unaffected either way.
+      # `continue-on-error` is gone (was here 2026-08-24..). It rewrote a
+      # failing step's `conclusion` to `success`, and `conclusion` is what
+      # `needs.gate.result` — and therefore `ci-required` — reads. That hid
+      # #310, where the runner stopped producing a summary line at all rather
+      # than producing a worse number. No separate presence check replaces it:
+      # a runner that dies mid-corpus exits non-zero, so the exit code the step
+      # now honours already says "this leg verified nothing".
+      #
+      # Runs on PULL REQUESTS as well as the merge, reversing the 2026-08-24
+      # push-only placement. That placement was correct while the step could
+      # not block: the 182 s bought no gate signal — measured 2026-08-25 on
+      # `286a91f89` over four same-base PR runs, 138 s on the macOS leg (spread
+      # 7 s) plus 44 s across linux and windows. Now that it blocks, running it
+      # only after the merge would mean a preview1 regression is first seen as
+      # a red `main` — the situation #312 is about — so it belongs where it can
+      # stop the PR that causes it.
       #
       # Deliberately a step in THIS job rather than a job of its own: a
       # separate job would repeat the Zig install and rebuild zwasm from a cold
@@ -312,12 +319,10 @@ jobs:
       # a second full build per PR to run two lanes over 72 small binaries.
       # Here it reuses what `ci_gate.sh` just built.
       #
-      # Time-boxed in the ADR-0174 sense, not indefinite: when D-583 goes
-      # green on all three OSes the step moves into `test-all` and this block
-      # is deleted. That row's DISCHARGE clause lists the four edits.
-      - name: test-wasi-p1-official (advisory, D-582)
-        if: github.event_name == 'push'
-        continue-on-error: true
+      # Time-boxed in the ADR-0174 sense, not indefinite: when D-583 goes green
+      # on all three OSes the step moves into `test-all` and this block is
+      # deleted. That row's DISCHARGE clause lists the edits.
+      - name: test-wasi-p1-official (D-582)
         shell: bash
         run: zig build test-wasi-p1-official
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,17 @@
 # CI — the host-local gate on the 3 supported OSes, mirroring the local
 # 3-host gate (Mac aarch64 + Linux x86_64 + Windows x86_64). Each matrix leg
-# runs `scripts/ci_gate.sh` so CI verifies exactly what the maintainer runs
-# per host (single source of truth); the differential oracle is wasmtime, and
-# its install is required.
+# runs `scripts/ci_gate.sh`, which is where nearly all of the blocking content
+# lives, so it stays the single source of truth for what the maintainer runs
+# per host; the differential oracle is wasmtime, and its install is required.
+#
+# The leg has ONE blocking step outside that script — `test-wasi-p1-official`,
+# whose own block below says why it sits here rather than inside. So a green
+# local `gate_merge.sh` does not predict this leg. That is not new to it:
+# `doc-truth` is blocking through `ci-required` and its
+# `check_wasi03_coverage_claims` / `check_doc_fossils` have no local
+# counterpart at all. `ci-required` is authoritative and the local scripts are
+# pre-flight (ADR-0076 D9) — but do not read the paragraph above as a promise
+# that a local green cannot go red here.
 #
 # Triggers: pull_request (any target) + push to `main` + manual dispatch.
 # `main` is the trunk and is ruleset-protected: no direct pushes — every change

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,9 @@ required **`ci-required`** status check. CI runs
 macOS aarch64, Linux x86_64, Windows x86_64. Your PR gets the *core* gate: fmt
 + `test-all` + the rust-host consumer + the test-discovery guard + the
 ReleaseSafe-runner floor guard (ADR-0177) + the unit tests built
-ReleaseSafe (Linux leg only; the mode every release binary is built in). The extended
+ReleaseSafe (Linux leg only; the mode every release binary is built in) — plus
+`test-wasi-p1-official`, which blocks from a step of its own rather than from
+inside the script (ADR-0225). The extended
 static/build checks (lint, the build-option DCE matrix, AOT cross-compile,
 `zone_check`) run on the merge to `main`, not per PR — they are up to ~20
 cold-cache builds and would dominate every PR's wall-clock. All three legs are
@@ -113,11 +115,13 @@ Doc-only PRs (Markdown, `docs/`, `.dev/`, `.claude/`, `LICENSE`) skip the
 heavy 3-OS legs automatically and are gated by the fast `doc-truth` job
 instead.
 
-To run exactly what CI runs, locally, on your own machine:
+To run what CI runs, locally, on your own machine — the script defines the
+leg's content except for the one blocking step beside it:
 
 ```sh
 bash scripts/ci_gate.sh                    # core (fmt + test-all)
 ZWASM_CI_EXTENDED=1 bash scripts/ci_gate.sh  # + lint/DCE/AOT/zone checks (Unix)
+zig build test-wasi-p1-official            # the blocking step outside the script
 ```
 
 ## Cutting a release

--- a/docs/development.md
+++ b/docs/development.md
@@ -88,7 +88,7 @@ box fails one more (D-583), and that is the box disagreeing with the runner,
 not the table being wrong. It is not part of the local `gate_commit.sh` /
 `gate_merge.sh` flow, so run it directly when touching WASI preview1. When
 D-583 discharges, the step joins `test-all` and this paragraph goes away
-(ADR-0208 D2/D3).
+(ADR-0208 D2, ADR-0225).
 
 ## The merge gate — CI is authoritative
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,13 +77,18 @@ fixtures from source (emcc / TinyGo / Rust) is a maintainer task using the Nix
 
 `test-wasi-p1-official` is the one layer `test-all` does not carry. The corpus
 is not green (D-583 carries the live count — no copy of it here, that is what
-went stale last time), so CI runs it as an **advisory step** in the `gate`
-job: the red shows in the run without blocking the merge. Because it cannot
-block either way, it runs **only on the merge to `main`**, like the extended
-checks below — your PR will not show it. It is not part of the local
-`gate_commit.sh` / `gate_merge.sh` flow either, so run it directly when
-touching WASI preview1. When D-583 discharges, the step joins `test-all` and
-the advisory goes away (ADR-0208 D2/D3).
+went stale last time), so CI runs it as its own **blocking** step in the `gate`
+job, on every PR and on the merge. What makes that placement possible is the
+ratchet in `test/wasi/official_runner.zig`: linux and macOS are at baseline 0
+and must stay there, while the Windows leg carries a `known_table` of the
+currently-failing names — those are tolerated, anything else is not, and a
+listed test that starts passing fails the run so its entry gets removed with
+the fix. The table is written for CI's windows-2022 runner; a local Windows 11
+box fails one more (D-583), and that is the box disagreeing with the runner,
+not the table being wrong. It is not part of the local `gate_commit.sh` /
+`gate_merge.sh` flow, so run it directly when touching WASI preview1. When
+D-583 discharges, the step joins `test-all` and this paragraph goes away
+(ADR-0208 D2/D3).
 
 ## The merge gate — CI is authoritative
 

--- a/test/wasi/official_runner.zig
+++ b/test/wasi/official_runner.zig
@@ -144,12 +144,39 @@ const known_table: []const KnownEntry = switch (builtin.os.tag) {
     else => &.{},
 };
 
-fn expectationFor(stem: []const u8) Expectation {
-    for (known_table) |e| {
-        if (std.mem.eql(u8, e.name, stem)) return e.exp;
+comptime {
+    // A duplicated key makes the second row unreachable, and the
+    // never-encountered check below would then never fire for it either.
+    for (known_table, 0..) |a, i| {
+        for (known_table[i + 1 ..]) |b| {
+            if (std.mem.eql(u8, a.name, b.name)) {
+                @compileError("known_table lists '" ++ a.name ++ "' twice");
+            }
+        }
+    }
+}
+
+/// `stem`'s expectation, marking its row ENCOUNTERED on the way — see `Seen`.
+/// The two travel together because a lookup that does not record the visit is
+/// exactly the hole `Seen` exists to close.
+fn lookup(stem: []const u8, seen: *Seen) Expectation {
+    for (known_table, seen) |e, *flag| {
+        if (std.mem.eql(u8, e.name, stem)) {
+            flag.* = true;
+            return e.exp;
+        }
     }
     return .match;
 }
+
+/// One flag per `known_table` row, set when the corpus actually yields that
+/// test. A row nobody encountered is a tolerance for a test that is no longer
+/// there: an upstream bump that REMOVES a listed test and adds another keeps
+/// `vendored_total` intact, so nothing else in this runner would notice, and
+/// the row would sit there tolerating nothing until someone re-read it. The
+/// ratchet exists to stop the table drifting from the corpus; drifting by
+/// deletion is the direction the RATCHET-FLIP check cannot see.
+const Seen = [known_table.len]bool;
 
 const Counts = struct {
     passed: u32 = 0,
@@ -239,6 +266,7 @@ pub fn main(init: std.process.Init) !void {
 
     var total: Counts = .{};
     var suites: u32 = 0;
+    var seen: Seen = @splat(false);
 
     var root_it = root_dir.iterate();
     while (try root_it.next(io)) |entry| {
@@ -267,7 +295,7 @@ pub fn main(init: std.process.Init) !void {
             },
         };
 
-        const suite = try runSuite(gpa, io, out, corpus_root, entry.name, engine, scratch_root);
+        const suite = try runSuite(gpa, io, out, corpus_root, entry.name, engine, scratch_root, &seen);
         total.passed += suite.passed;
         total.failed += suite.failed;
         total.expected_failed += suite.expected_failed;
@@ -337,9 +365,30 @@ pub fn main(init: std.process.Init) !void {
             .{ total.ran(), vendored_total },
         );
     }
+    // A row nobody encountered describes a test the corpus no longer holds, so
+    // the tolerance it grants is dead. Checked after the loop, not inside it:
+    // the rows are spread across the three suites and only the whole walk knows
+    // which were reached.
+    var stale: u32 = 0;
+    for (known_table, seen) |e, was_seen| {
+        if (was_seen) continue;
+        try out.print(
+            "STALE-ROW  known_table lists '{s}' ({s}), which this corpus does not\n" ++
+                "      hold — remove the row, or re-vendor with\n" ++
+                "      scripts/vendor_wasip1_official.sh\n",
+            .{ e.name, switch (e.exp) {
+                .match => "",
+                .known_failure => |row| row,
+            } },
+        );
+        stale += 1;
+    }
+
     try out.flush();
     discardAbsent(cwd.deleteTree(io, scratch_root));
-    if (total.failed != 0 or total.errored != 0 or partial or total.ratchet_flips != 0) {
+    if (total.failed != 0 or total.errored != 0 or partial or
+        total.ratchet_flips != 0 or stale != 0)
+    {
         std.process.exit(1);
     }
 }
@@ -365,6 +414,7 @@ fn runSuite(
     suite_name: []const u8,
     engine: Engine,
     scratch_root: []const u8,
+    seen: *Seen,
 ) !Counts {
     const suite_path = try std.Io.Dir.path.join(gpa, &.{ corpus_root, suite_name });
     defer gpa.free(suite_path);
@@ -413,7 +463,7 @@ fn runSuite(
         if (!std.mem.endsWith(u8, entry.name, ".wasm")) continue;
 
         const stem = entry.name[0 .. entry.name.len - ".wasm".len];
-        const exp = expectationFor(stem);
+        const exp = lookup(stem, seen);
         if (runOne(gpa, io, out, &suite_dir, suite_path, stem, entry.name, engine, scratch_root)) {
             counts.passed += 1;
             if (exp == .known_failure) {

--- a/test/wasi/official_runner.zig
+++ b/test/wasi/official_runner.zig
@@ -12,7 +12,10 @@
 //!
 //! Exit code: 2 on a usage error, 1 on anything below, 0 otherwise.
 //!
-//! - a test failed (`failed`) or could not be run (`errored`);
+//! - a test failed where `known_table` expected it to pass (`failed`), or
+//!   could not be run at all (`errored`);
+//! - a `known_table` entry PASSED — the gap is fixed and the entry has to go
+//!   with the fix (`ratchet_flips`);
 //! - the corpus ROOT is unopenable;
 //! - a suite carries upstream's descriptor but enumerates no tests;
 //! - the root holds no suites at all;
@@ -26,6 +29,11 @@
 //! ADR-0208 D2 requires the total too. The exact PER-LANGUAGE counts stay in
 //! `scripts/vendor_wasip1_official.sh`, which asserts them at regen; only the
 //! single total is repeated here.
+//!
+//! This exit code is the whole presence check the CI step needs: a corpus that
+//! stops producing a summary line does so by dying, and a dead process is a
+//! non-zero exit. What hid #310 was not a missing check but
+//! `continue-on-error` rewriting this code to success.
 //!
 //! ## Upstream manifest subset
 //!
@@ -47,6 +55,7 @@
 //!    JIT, so an unpinned lane silently measures the JIT and calls it preview1
 //!    coverage. `interp` and `jit` diverge by 4 tests today (D-583).
 
+const builtin = @import("builtin");
 const std = @import("std");
 
 const zwasm = @import("zwasm");
@@ -90,10 +99,68 @@ const Expect = struct {
 
 const Engine = enum { interp, jit };
 
+/// What this host is expected to do with a test. Mirrors the AOT differential's
+/// `known_table` (`test/aot/aot_process_diff.zig`), including its ratchet: the
+/// table records NAMES, never a count, so the count stays derivable from the
+/// run and cannot go stale the way a copied number does.
+const Expectation = union(enum) {
+    /// Must pass. A failure is a finding and the run exits non-zero.
+    match,
+    /// Fails on this OS today, tracked by the named debt row. A PASS here is a
+    /// RATCHET FLIP: the entry must be removed in the same PR, and the run
+    /// exits non-zero to force it.
+    known_failure: []const u8,
+};
+
+const KnownEntry = struct { name: []const u8, exp: Expectation };
+
+/// Keys are test stems, unique across all three vendored suites.
+///
+/// Windows carries the #290 symlink / hardlink / readdir family, identical on
+/// both engines and recorded in D-583.
+///
+/// **This table describes CI's windows-2022 runner, deliberately, and no other
+/// Windows host.** D-583 also records `path_symlink_trailing_slashes` failing
+/// on a Windows 11 host, where it makes eight. An exact-match table cannot
+/// describe both counts at once: listing eight reds windows-2022 with a
+/// ratchet flip, listing seven reds Windows 11 with an unexpected failure.
+/// The gate exists to hold CI, so CI's host is the one it is written for —
+/// an extra failure on a local Windows 11 box is that box disagreeing with
+/// the runner, not the ratchet being wrong. Do not add the eighth entry to
+/// make a local run quiet.
+///
+/// linux and macOS are empty — baseline 0, so every test there is `.match`
+/// and any failure is a finding.
+const known_table: []const KnownEntry = switch (builtin.os.tag) {
+    .windows => &.{
+        .{ .name = "fd_readdir", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "nofollow_errors", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "path_exists", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "path_link", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "readlink", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "symlink_create", .exp = .{ .known_failure = "D-583" } },
+        .{ .name = "symlink_filestat", .exp = .{ .known_failure = "D-583" } },
+    },
+    else => &.{},
+};
+
+fn expectationFor(stem: []const u8) Expectation {
+    for (known_table) |e| {
+        if (std.mem.eql(u8, e.name, stem)) return e.exp;
+    }
+    return .match;
+}
+
 const Counts = struct {
     passed: u32 = 0,
-    /// The test ran and gave the wrong answer. These are the D-583 items.
+    /// The test ran and gave the wrong answer where none was expected. This is
+    /// the bucket that gates.
     failed: u32 = 0,
+    /// Gave the wrong answer, and `known_table` says so. Reported, not gated.
+    expected_failed: u32 = 0,
+    /// A `.known_failure` entry that PASSED: the gap is fixed and its table
+    /// entry must go in the same PR. Gates, so the removal cannot be deferred.
+    ratchet_flips: u32 = 0,
     /// The test could not be run at all — unreadable `.wasm`, malformed
     /// manifest, unsupported preopen entry. Counted apart from `failed`
     /// because it means the CORPUS is broken, not the runtime, and reading it
@@ -102,7 +169,7 @@ const Counts = struct {
     errored: u32 = 0,
 
     fn ran(self: Counts) u32 {
-        return self.passed + self.failed + self.errored;
+        return self.passed + self.failed + self.expected_failed + self.errored;
     }
 };
 
@@ -203,6 +270,8 @@ pub fn main(init: std.process.Init) !void {
         const suite = try runSuite(gpa, io, out, corpus_root, entry.name, engine, scratch_root);
         total.passed += suite.passed;
         total.failed += suite.failed;
+        total.expected_failed += suite.expected_failed;
+        total.ratchet_flips += suite.ratchet_flips;
         total.errored += suite.errored;
         suites += 1;
 
@@ -240,8 +309,14 @@ pub fn main(init: std.process.Init) !void {
     // phase hides behind a green step (ADR-0174 context: a windows leg
     // reported OK while every spec category was pass=0).
     try out.print(
-        "\nwasi_p1_official [{t}]: {d} passed, {d} failed, {d} errored, {d} total (over {d} suites)\n",
-        .{ engine, total.passed, total.failed, total.errored, total.ran(), suites },
+        "\nwasi_p1_official [{t}]: {d} passed, {d} failed, {d} known-failed, " ++
+            "{d} errored, {d} ratchet-flips, {d} total (over {d} suites)\n",
+        .{
+            engine,        total.passed,
+            total.failed,  total.expected_failed,
+            total.errored, total.ratchet_flips,
+            total.ran(),   suites,
+        },
     );
     if (total.errored != 0) {
         try out.print(
@@ -264,7 +339,9 @@ pub fn main(init: std.process.Init) !void {
     }
     try out.flush();
     discardAbsent(cwd.deleteTree(io, scratch_root));
-    if (total.failed != 0 or total.errored != 0 or partial) std.process.exit(1);
+    if (total.failed != 0 or total.errored != 0 or partial or total.ratchet_flips != 0) {
+        std.process.exit(1);
+    }
 }
 
 /// Swallow a cleanup error on a path that may legitimately not exist.
@@ -336,17 +413,39 @@ fn runSuite(
         if (!std.mem.endsWith(u8, entry.name, ".wasm")) continue;
 
         const stem = entry.name[0 .. entry.name.len - ".wasm".len];
+        const exp = expectationFor(stem);
         if (runOne(gpa, io, out, &suite_dir, suite_path, stem, entry.name, engine, scratch_root)) {
             counts.passed += 1;
+            if (exp == .known_failure) {
+                try out.print(
+                    "RATCHET-FLIP  {s}: known failure ({s}) now PASSES — remove its\n" ++
+                        "      known_table entry in this PR\n",
+                    .{ stem, exp.known_failure },
+                );
+                counts.ratchet_flips += 1;
+            }
         } else |err| if (isTestVerdict(err)) {
-            try out.print("FAIL   {s}: {t}\n", .{ stem, err });
-            counts.failed += 1;
+            // A corpus problem is never expected, so the table is consulted
+            // only for a test VERDICT — `errored` below stays fatal either way.
+            switch (exp) {
+                .match => {
+                    try out.print("FAIL   {s}: {t}\n", .{ stem, err });
+                    counts.failed += 1;
+                },
+                .known_failure => |row| {
+                    try out.print("KNOWN  {s}: {t} ({s})\n", .{ stem, err, row });
+                    counts.expected_failed += 1;
+                },
+            }
         } else {
             try out.print("ERROR  {s}: {t} (could not run — corpus problem)\n", .{ stem, err });
             counts.errored += 1;
         }
     }
-    try out.print("    {d} passed, {d} failed, {d} errored\n", .{ counts.passed, counts.failed, counts.errored });
+    try out.print(
+        "    {d} passed, {d} failed, {d} known-failed, {d} errored\n",
+        .{ counts.passed, counts.failed, counts.expected_failed, counts.errored },
+    );
     return counts;
 }
 

--- a/test/wasi/official_runner.zig
+++ b/test/wasi/official_runner.zig
@@ -156,27 +156,34 @@ comptime {
     }
 }
 
-/// `stem`'s expectation, marking its row ENCOUNTERED on the way — see `Seen`.
-/// The two travel together because a lookup that does not record the visit is
-/// exactly the hole `Seen` exists to close.
-fn lookup(stem: []const u8, seen: *Seen) Expectation {
-    for (known_table, seen) |e, *flag| {
+/// `stem`'s expectation, counting the visit on the way — see `Hits`. The two
+/// travel together because a lookup that does not record the visit is exactly
+/// the hole `Hits` exists to close.
+fn lookup(stem: []const u8, hits: *Hits) Expectation {
+    for (known_table, hits) |e, *n| {
         if (std.mem.eql(u8, e.name, stem)) {
-            flag.* = true;
+            n.* += 1;
             return e.exp;
         }
     }
     return .match;
 }
 
-/// One flag per `known_table` row, set when the corpus actually yields that
-/// test. A row nobody encountered is a tolerance for a test that is no longer
-/// there: an upstream bump that REMOVES a listed test and adds another keeps
-/// `vendored_total` intact, so nothing else in this runner would notice, and
-/// the row would sit there tolerating nothing until someone re-read it. The
-/// ratchet exists to stop the table drifting from the corpus; drifting by
-/// deletion is the direction the RATCHET-FLIP check cannot see.
-const Seen = [known_table.len]bool;
+/// How many corpus tests each `known_table` row matched over one whole walk.
+/// Exactly one is the only healthy value, and both other answers are the table
+/// drifting from the corpus in a direction RATCHET-FLIP cannot see:
+///
+/// - **zero** — the row tolerates a test that is no longer there. An upstream
+///   bump that REMOVES a listed test and adds another keeps `vendored_total`
+///   intact, so nothing else in this runner would notice, and the row would sit
+///   there until someone re-read it.
+/// - **more than one** — two suites vendor the same stem, so the row speaks for
+///   both and silently tolerates a test nobody chose to list. Today the corpus
+///   has no cross-suite collision, but nothing upstream or in
+///   `scripts/vendor_wasip1_official.sh` promises that: the script asserts
+///   per-language COUNTS, not name uniqueness. A count is cheaper than the
+///   comment that would otherwise assert it.
+const Hits = [known_table.len]u32;
 
 const Counts = struct {
     passed: u32 = 0,
@@ -266,7 +273,7 @@ pub fn main(init: std.process.Init) !void {
 
     var total: Counts = .{};
     var suites: u32 = 0;
-    var seen: Seen = @splat(false);
+    var hits: Hits = @splat(0);
 
     var root_it = root_dir.iterate();
     while (try root_it.next(io)) |entry| {
@@ -295,7 +302,7 @@ pub fn main(init: std.process.Init) !void {
             },
         };
 
-        const suite = try runSuite(gpa, io, out, corpus_root, entry.name, engine, scratch_root, &seen);
+        const suite = try runSuite(gpa, io, out, corpus_root, entry.name, engine, scratch_root, &hits);
         total.passed += suite.passed;
         total.failed += suite.failed;
         total.expected_failed += suite.expected_failed;
@@ -365,29 +372,37 @@ pub fn main(init: std.process.Init) !void {
             .{ total.ran(), vendored_total },
         );
     }
-    // A row nobody encountered describes a test the corpus no longer holds, so
-    // the tolerance it grants is dead. Checked after the loop, not inside it:
-    // the rows are spread across the three suites and only the whole walk knows
-    // which were reached.
-    var stale: u32 = 0;
-    for (known_table, seen) |e, was_seen| {
-        if (was_seen) continue;
-        try out.print(
-            "STALE-ROW  known_table lists '{s}' ({s}), which this corpus does not\n" ++
-                "      hold — remove the row, or re-vendor with\n" ++
-                "      scripts/vendor_wasip1_official.sh\n",
-            .{ e.name, switch (e.exp) {
-                .match => "",
-                .known_failure => |row| row,
-            } },
-        );
-        stale += 1;
+    // Checked after the loop, not inside it: the rows are spread across the
+    // three suites and only the whole walk knows how often each was reached.
+    var drifted: u32 = 0;
+    for (known_table, hits) |e, n| {
+        if (n == 1) continue;
+        const row = switch (e.exp) {
+            .match => "",
+            .known_failure => |r| r,
+        };
+        if (n == 0) {
+            try out.print(
+                "STALE-ROW  known_table lists '{s}' ({s}), which this corpus does not\n" ++
+                    "      hold — remove the row, or re-vendor with\n" ++
+                    "      scripts/vendor_wasip1_official.sh\n",
+                .{ e.name, row },
+            );
+        } else {
+            try out.print(
+                "DUP-STEM   known_table's '{s}' ({s}) matched {d} corpus tests — the\n" ++
+                    "      row speaks for all of them. Key the table by suite, or\n" ++
+                    "      re-vendor with scripts/vendor_wasip1_official.sh\n",
+                .{ e.name, row, n },
+            );
+        }
+        drifted += 1;
     }
 
     try out.flush();
     discardAbsent(cwd.deleteTree(io, scratch_root));
     if (total.failed != 0 or total.errored != 0 or partial or
-        total.ratchet_flips != 0 or stale != 0)
+        total.ratchet_flips != 0 or drifted != 0)
     {
         std.process.exit(1);
     }
@@ -414,7 +429,7 @@ fn runSuite(
     suite_name: []const u8,
     engine: Engine,
     scratch_root: []const u8,
-    seen: *Seen,
+    hits: *Hits,
 ) !Counts {
     const suite_path = try std.Io.Dir.path.join(gpa, &.{ corpus_root, suite_name });
     defer gpa.free(suite_path);
@@ -463,7 +478,7 @@ fn runSuite(
         if (!std.mem.endsWith(u8, entry.name, ".wasm")) continue;
 
         const stem = entry.name[0 .. entry.name.len - ".wasm".len];
-        const exp = lookup(stem, seen);
+        const exp = lookup(stem, hits);
         if (runOne(gpa, io, out, &suite_dir, suite_path, stem, entry.name, engine, scratch_root)) {
             counts.passed += 1;
             if (exp == .known_failure) {


### PR DESCRIPTION
## What

`zig build test-wasi-p1-official` blocks `ci-required` instead of reporting
from under `continue-on-error`, and runs on pull requests as well as on the
merge.

The tolerance is a per-OS `known_table` in `test/wasi/official_runner.zig`,
shaped like the AOT differential's: empty on linux and macOS (baseline 0), the
#290 names on Windows, and a non-zero exit when a listed name starts passing
so its row leaves with the fix. No separate presence check — a corpus that
stops producing a summary line does so by dying, and the exit code says so.

ADR-0225 records the reversal; ADR-0208 D3 is marked superseded, and D-583's
DISCHARGE clause is updated to the terminal state this creates.

## Verified

Deliberately broken on x86_64-linux at `0a90547e2`, one injection at a time,
restored between:

| injected | result |
|---|---|
| a passing test starts failing | exit 1, `1 failed` |
| a `known_table` name passes | exit 1, `RATCHET-FLIP` printed |
| the runner panics mid-corpus (#310's shape) | exit 1, **0 summary lines** |
| a `known_table` name fails | exit 0, `1 known-failed` |

The 3-OS measurement is this PR's own CI — the Windows leg is where the table
is exercised.

## Not closed

`Refs #312.` — this removes one source of a failure that is only visible after
the merge. It adds no notification, so the general case stands.

`Refs #307.` — item 6 only. D-598 (`zwasm --version` publishing the build mode)
remains, so the issue stays open.

### Added after review

Devin found that the table was only held to the corpus in one direction —
a row naming a test the corpus no longer holds passed at exit 0. Reproduced,
then closed: rows carry an encountered flag, an unreached one exits `STALE-ROW`,
and duplicate keys are a `@compileError`.

| injected | result |
|---|---|
| a row naming a test not in the corpus | exit 1, `STALE-ROW` |
| the same name listed twice | does not compile |

The AOT differential's `known_table` has the same hole. Its table is empty
today so it is latent; noted in ADR-0225's consequences rather than fixed here.
