### PR TITLE
capi: hand the JIT the cross-module func targets D-225 already accepts

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1366,6 +1366,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/version.c", .name = "version" }, // a C host reads the runtime's version
         .{ .src = "test/c_api_conformance/trap_kind_per_call.c", .name = "trap_kind_per_call" }, // #336 the kind describes the call just made
         .{ .src = "test/c_api_conformance/gc_heap_cap_trap.c", .name = "gc_heap_cap_trap" }, // #361 GC heap cap is OUT_OF_MEMORY
+        .{ .src = "test/c_api_conformance/cross_module_func.c", .name = "cross_module_func" }, // #360 cross-module func import on every engine
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -113,8 +113,8 @@ WASM_API_EXTERN wasm_func_t* zwasm_instance_get_func(wasm_instance_t*, uint32_t 
 
 /* Per-instance engine kind for zwasm_instance_new_ex. AUTO — what stock
  * wasm_instance_new passes — compiles the module with the JIT and instantiates
- * the interpreter only for a module the JIT declines (an import outside the
- * JIT's host-func bridge, or a body it cannot compile). JIT forces the native
+ * the interpreter only for a module the JIT declines (an import it cannot
+ * satisfy, or a body it cannot compile). JIT forces the native
  * JIT: a declined module fails instantiation, returning NULL — no silent
  * downgrade. INTERP forces the interpreter, which unlike the other two rejects
  * a module importing wasi_snapshot_preview1 when no WASI host is configured on

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -831,9 +831,38 @@ fn crossModuleJitTarget(
     };
     const want_tidx = it.payload.func_typeidx;
     if (want_tidx >= importer_types.items.len) return error.Unsupported;
-    if (!validator_helpers.funcTypeImportCompatible(importer_types.items[want_tidx], src_sig, importer_types))
+    const want_sig = importer_types.items[want_tidx];
+    // #387 — `funcTypeImportCompatible` resolves both signatures in ONE type
+    // space, and the only one in hand here is the importer's. That is sound
+    // while every type is structural, and unsound the moment a signature names
+    // a type INDEX: `(ref $t)` means what `$t` means in the module it came
+    // from. The interp path has the same gap, but it carries
+    // `source_signature` to the call; a resolved JIT target becomes a bridge
+    // thunk jumping straight into the callee's body, so a wrongly accepted
+    // link there is an ABI mismatch rather than a semantic one. Decline the
+    // shape until the exporter's own `Types` are retained (the facade linker's
+    // `export_src_types` + `canonicalEqualCross` is the model) — the caller
+    // falls back to the interp, which is exactly where main already sent it.
+    if (hasConcreteHeapType(want_sig) or hasConcreteHeapType(src_sig)) return error.Unsupported;
+    if (!validator_helpers.funcTypeImportCompatible(want_sig, src_sig, importer_types))
         return error.Unsupported;
     return source_jit.exportedFuncTarget(ta, it.name) orelse error.Unsupported;
+}
+
+/// #387 — does this signature name a type-section INDEX anywhere? Such a type
+/// is only meaningful in its own module, so a single-type-space comparison
+/// cannot judge it across a module boundary.
+fn hasConcreteHeapType(sig: zir.FuncType) bool {
+    for ([_][]const zir.ValType{ sig.params, sig.results }) |half| {
+        for (half) |vt| switch (vt) {
+            .ref => |r| switch (r.heap_type) {
+                .concrete => return true,
+                .abstract => {},
+            },
+            else => {},
+        };
+    }
+    return false;
 }
 
 /// D-478 / #360 — resolve the JIT path's func imports. Returns

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -841,8 +841,12 @@ fn crossModuleJitTarget(
     // thunk jumping straight into the callee's body, so a wrongly accepted
     // link there is an ABI mismatch rather than a semantic one. Decline the
     // shape until the exporter's own `Types` are retained (the facade linker's
-    // `export_src_types` + `canonicalEqualCross` is the model) — the caller
-    // falls back to the interp, which is exactly where main already sent it.
+    // `export_src_types` + `canonicalEqualCross` is the model). Declining is
+    // NOT a graceful degradation: the `.auto` retry lands in `buildBindings`,
+    // which needs the source's interpreter `Runtime` and a JIT-backed source
+    // has none, so this shape stays unsupported — NULL with no trap, #353's
+    // surface. It is unsupported at `main` too, by the same route, so the
+    // guard withholds an acceptance rather than removing one.
     if (hasConcreteHeapType(want_sig) or hasConcreteHeapType(src_sig)) return error.Unsupported;
     if (!validator_helpers.funcTypeImportCompatible(want_sig, src_sig, importer_types))
         return error.Unsupported;

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -110,6 +110,26 @@ pub const Module = extern struct {
     /// Cached borrowed `wasm_ref_t` view (`wasm_module_as_ref`, ADR-0158;
     /// payload = `@intFromPtr(self)`; freed in `wasm_module_delete`).
     ref_view: ?*handles.Ref = null,
+    /// #360 — JIT-backed instances built from this module. Their
+    /// `RuntimeOwned` aliases `bytes_ptr` (passive data / elem segment
+    /// descriptors point into it, per `setup.zig`'s contract that `wasm_bytes`
+    /// outlives the runtime), so while this is non-zero `wasm_module_delete`
+    /// hands the bytes to `Store.orphaned_module_bytes` instead of freeing
+    /// them.
+    ///
+    /// A borrow ends in exactly one way. A JIT instance is never freed at
+    /// `wasm_instance_delete` — it is PARKED on `Store.jit_zombies`
+    /// (importers may hold its address) — and the store-teardown cascade parks
+    /// too, so every borrower lives until `wasm_store_delete`'s reap, which
+    /// frees all parked runtimes and then all orphaned bytes in one sweep.
+    /// There is therefore no decrement anywhere: this only ever asks "has any
+    /// JIT instance aliased these bytes", and once one has, the bytes' free is
+    /// deferred to the store. Intended, not an oversight.
+    ///
+    /// Plain integer on purpose: a Store is single-threaded by design (the SDK
+    /// drops `Send`/`Sync` on it), so this is store-local and needs no atomic
+    /// and no mutex. Appended to the opaque handle; C never sees the layout.
+    jit_borrowers: u32 = 0,
 };
 
 // Instance + ExportType moved to src/runtime/instance/instance.zig
@@ -298,6 +318,11 @@ pub export fn wasm_store_delete(s: ?*Store) callconv(.c) void {
         alloc.destroy(jit);
     }
     handle.jit_zombies.deinit(alloc);
+    // #360 — only now, with every parked runtime gone, may the module bytes
+    // those runtimes aliased be freed (`Module.jit_borrowers` explains why
+    // nothing frees them earlier).
+    for (handle.orphaned_module_bytes.items) |bytes| alloc.free(bytes);
+    handle.orphaned_module_bytes.deinit(alloc);
     // Free the cross-module instance registry (ADR-0065 §"Cat III").
     // Values are erased `*Instance` pointers (lifetimes managed by
     // the zombie list); keys are caller-owned. Only the hashmap's
@@ -521,10 +546,27 @@ pub export fn wasm_module_validate(s: ?*Store, binary: ?*const ByteVec) callconv
 pub export fn wasm_module_delete(m: ?*Module) callconv(.c) void {
     const handle = m orelse return;
     if (handle.host_info_finalizer) |fin| fin(handle.host_info);
+    handle.host_info_finalizer = null;
     const store = handle.store orelse return;
     const alloc = storeAllocator(store) orelse return;
     if (handle.ref_view) |rv| alloc.destroy(rv); // object-identity as_ref view (ADR-0158)
-    if (handle.bytes_ptr) |p| alloc.free(p[0..handle.bytes_len]);
+    handle.ref_view = null;
+    // #360 — a JIT-backed instance built from this module aliases `bytes_ptr`
+    // (alive or parked; see `Module.jit_borrowers`). wasm-c-api lets the
+    // embedder delete the module first, so the BYTES move to the store's
+    // deferred-free list; the HANDLE is destroyed exactly as before, so a
+    // use-after-delete of it keeps faulting instead of going quiet. This sits
+    // after the `store orelse return` above, so it adds no second leak path to
+    // that existing one.
+    if (handle.bytes_ptr) |p| {
+        const bytes = p[0..handle.bytes_len];
+        if (handle.jit_borrowers > 0) {
+            // EXEMPT-FALLBACK: ADR-0014 — deferral OOM accepts a byte-buffer leak over freeing memory a parked runtime aliases.
+            store.orphaned_module_bytes.append(alloc, bytes) catch {};
+        } else {
+            alloc.free(bytes);
+        }
+    }
     alloc.destroy(handle);
 }
 
@@ -1138,6 +1180,11 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     // D-174 live-instance registry so wasm_store_delete cascades teardown.
     // EXEMPT-FALLBACK: D-174 — append OOM degrades to forward-order-only teardown (matches interp path).
     store.live_instances.append(alloc, @ptrCast(inst)) catch {};
+    // #360 — this runtime aliases the module's bytes for as long as it exists,
+    // parked included (`Module.jit_borrowers`). Taken last, after every
+    // fallible step, so no failure path can leave it held — nothing to
+    // errdefer.
+    @constCast(module).jit_borrowers += 1;
     return inst;
 }
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -68,6 +68,7 @@ const handles = @import("handles.zig");
 const jit_dispatch = @import("../wasi/jit_dispatch.zig"); // D-478 — WASI dispatch lookup
 const jit_host_bridge = @import("jit_host_bridge.zig"); // D-478 — host-func JIT bridge
 const setup_mod = @import("../engine/setup.zig"); // D-478 — HostFuncTarget
+const validator_helpers = @import("../validate/validator_helpers.zig"); // #360 — cross-module func import subtyping
 
 const ByteVec = vec.ByteVec;
 const ValVec = vec.ValVec;
@@ -546,7 +547,7 @@ fn buildBindings(
             // The binding outlives this call — and outlives the instance
             // too, since `wasm_instance_delete` parks the arena holding it
             // on `store.zombies`. May over-mark (this also runs on the
-            // throwaway arena in `collectHostFuncTargets`); over-marking
+            // throwaway arena in `collectFuncImportTargets`); over-marking
             // only defers a free, so nothing compensates for it.
             //
             // ADR-0224 — reserve the retirement slot HERE, at capture, not at
@@ -768,39 +769,89 @@ pub fn instantiateFacade(store: *Store, module: *const Module, trap_out: ?*?*Tra
     return instantiateInternal(store, module, BuildBindingsCApi{ .imports_array = null }, trap_out, limits, engine);
 }
 
-/// D-478 — resolve embedder host-func imports for the JIT path into
-/// `HostFuncTarget`s (func-import order). Returns `error.Unsupported` for any
-/// import the JIT cannot satisfy (caller rejects → `.interp`). An empty slice
-/// means "all imports are WASI / none" — those are planted by setup via
-/// `jit_dispatch`, so the embedder binder is NOT consulted (no regression on
-/// the WASI-only JIT path, which needs no `store.wasi_host` at bind time).
-fn collectHostFuncTargets(
+/// D-478 / #360 — the JIT-satisfiable func imports of one module, both in
+/// func-import order: embedder host callbacks (`wasm_func_new`) and
+/// cross-module targets resolved against a JIT-backed exporter.
+const JitFuncImports = struct {
+    host: []setup_mod.HostFuncTarget = &.{},
+    /// Positional, `num_func_imports` long when non-empty; a zeroed entry is
+    /// an import setup resolves some other way (WASI / embedder host).
+    cross: []setup_mod.FuncImportTarget = &.{},
+};
+
+/// #360 — resolve one cross-module FUNC import against a JIT-backed source
+/// instance into the D-225 `FuncImportTarget` `initLinked` already consumes.
+/// `error.Unsupported` when the source is interp-backed (JIT-compiled code
+/// cannot enter an interpreter runtime), when it exports no such func, or
+/// when its type is not a subtype of the declared import type — the same
+/// §4.5.10 rule `instantiate.checkImportTypeMatches` applies on the interp
+/// path. Matching is BY NAME, as the interp binder's cross-module arm is.
+fn crossModuleJitTarget(
+    ta: std.mem.Allocator,
+    source_inst: *Instance,
+    it: sections.Import,
+    importer_types: *const sections.Types,
+) error{Unsupported}!setup_mod.FuncImportTarget {
+    const jit_ptr = source_inst.jit orelse return error.Unsupported;
+    const source_jit: *runner.JitInstance = @ptrCast(@alignCast(jit_ptr));
+    const src_et = lookupSourceExportType(source_inst, .func, it.name) catch return error.Unsupported;
+    const src_sig = switch (src_et) {
+        .func => |sft| sft.sig,
+        else => return error.Unsupported,
+    };
+    const want_tidx = it.payload.func_typeidx;
+    if (want_tidx >= importer_types.items.len) return error.Unsupported;
+    if (!validator_helpers.funcTypeImportCompatible(importer_types.items[want_tidx], src_sig, importer_types))
+        return error.Unsupported;
+    return source_jit.exportedFuncTarget(ta, it.name) orelse error.Unsupported;
+}
+
+/// D-478 / #360 — resolve the JIT path's func imports. Returns
+/// `error.Unsupported` for any import the JIT cannot satisfy (caller rejects →
+/// `.interp`). Empty slices mean "all imports are WASI / none" — those are
+/// planted by setup via `jit_dispatch`, so no binder is consulted (no
+/// regression on the WASI-only JIT path, which needs no `store.wasi_host` at
+/// bind time).
+///
+/// The C ABI path resolves straight off the import `Extern`s
+/// (`builder.imports`), because `buildBindings` — the interp binder — cannot
+/// describe a JIT-backed source at all: it reaches for that instance's
+/// interpreter `Runtime`, which is null by construction (ADR-0200's XOR). The
+/// native-facade path (`src/zwasm/linker.zig`) carries no extern array and
+/// keeps going through the binder, host funcs only.
+fn collectFuncImportTargets(
     ta: std.mem.Allocator,
     bytes: []const u8,
     builder_state: anytype,
     store: *Store,
-) error{ Unsupported, OutOfMemory }![]setup_mod.HostFuncTarget {
+) error{ Unsupported, OutOfMemory }!JitFuncImports {
     var mod = parser.parse(ta, bytes) catch return error.Unsupported;
-    const imp_section = mod.find(.import) orelse return &.{};
+    const imp_section = mod.find(.import) orelse return .{};
     var imports = sections.decodeImports(ta, imp_section.body) catch return error.Unsupported;
     defer imports.deinit();
 
     // First pass: only func imports are JIT-satisfiable; detect whether any
-    // needs the embedder binder (a non-WASI func import).
-    var needs_host = false;
+    // needs a binding resolved here (a non-WASI func import).
+    var needs_binding = false;
     for (imports.items) |it| {
         if (it.kind != .func) return error.Unsupported;
-        if (jit_dispatch.lookup(it.module, it.name) == null) needs_host = true;
+        if (jit_dispatch.lookup(it.module, it.name) == null) needs_binding = true;
     }
-    if (!needs_host) return &.{};
+    if (!needs_binding) return .{};
 
-    // Resolve embedder bindings only now (a host func needs them). buildBindings
-    // wires each host-func import's `host_call.ctx` to its `*HostFuncPayload`.
     var local_state = builder_state;
     const builder: BindingsBuilder = if (@TypeOf(builder_state) == BindingsBuilder)
         builder_state
     else
         local_state.asBuilder();
+
+    if (builder.imports) |arr| {
+        const type_sec = mod.find(.type) orelse return error.Unsupported;
+        return collectFromExterns(ta, type_sec.body, imports.items, arr);
+    }
+
+    // Native-facade path: buildBindings wires each host-func import's
+    // `host_call.ctx` to its `*HostFuncPayload`.
     const bindings_opt = builder.build(builder.ctx, ta, bytes, store) catch return error.Unsupported;
     const bindings = bindings_opt orelse return error.Unsupported;
 
@@ -816,13 +867,51 @@ fn collectHostFuncTargets(
         const dp = jit_host_bridge.dispatchPtrFor(payload.params, payload.results, func_idx) orelse return error.Unsupported;
         try out.append(ta, .{ .idx = func_idx, .dispatch_ptr = dp, .payload = @intFromPtr(payload) });
     }
-    return out.toOwnedSlice(ta);
+    return .{ .host = try out.toOwnedSlice(ta) };
 }
 
-/// ADR-0200 — build a JIT-backed `Instance` (`runtime == null`, `jit` set).
-/// The smallest increment: a no-import compute module compiled to native code
-/// via `engine/runner.zig::JitInstance`. Host imports + WASI are a later slice
-/// (the `func_import_targets` / `wasi_host` plumbing in the impl map). The
+/// C ABI half of `collectFuncImportTargets`: every import is a func (the
+/// caller checked), so the import index IS the func-import index. A host
+/// callback is a standalone entity (`instance == null`); anything carrying a
+/// source instance is a cross-module import.
+fn collectFromExterns(
+    ta: std.mem.Allocator,
+    type_section_body: []const u8,
+    items: []const sections.Import,
+    arr: [*]const ?*const Extern,
+) error{ Unsupported, OutOfMemory }!JitFuncImports {
+    var types = sections.decodeTypes(ta, type_section_body) catch return error.Unsupported;
+    defer types.deinit();
+
+    var host: std.ArrayList(setup_mod.HostFuncTarget) = .empty;
+    var cross = try ta.alloc(setup_mod.FuncImportTarget, items.len);
+    @memset(cross, .{});
+    var any_cross = false;
+    for (items, 0..) |it, i| {
+        const func_idx: u32 = @intCast(i);
+        if (jit_dispatch.lookup(it.module, it.name) != null) continue; // WASI → setup plants it
+        const ext = arr[i] orelse return error.Unsupported;
+        if (ext.kind != .func) return error.Unsupported;
+        if (ext.instance) |source_inst| {
+            cross[i] = try crossModuleJitTarget(ta, source_inst, it, &types);
+            any_cross = true;
+            continue;
+        }
+        const fh = ext.func orelse return error.Unsupported;
+        const payload = fh.host orelse return error.Unsupported;
+        const dp = jit_host_bridge.dispatchPtrFor(payload.params, payload.results, func_idx) orelse return error.Unsupported;
+        try host.append(ta, .{ .idx = func_idx, .dispatch_ptr = dp, .payload = @intFromPtr(payload) });
+    }
+    return .{
+        .host = try host.toOwnedSlice(ta),
+        .cross = if (any_cross) cross else &.{},
+    };
+}
+
+/// ADR-0200 — build a JIT-backed `Instance` (`runtime == null`, `jit` set)
+/// from a module compiled to native code via `engine/runner.zig::JitInstance`.
+/// Imports are resolved by `collectFuncImportTargets` (WASI / embedder host /
+/// cross-module) and fed to `initLinked`; `wasi_host` is attached below. The
 /// borrowed `wasm_bytes` live in the owning `Module`, which outlives the
 /// instance, and the `JitInstance` is heap-pinned so `exportedFuncTarget`'s
 /// `&owned.rt` stays stable.
@@ -831,22 +920,24 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
     const bytes_ptr = module.bytes_ptr orelse return null;
     const bytes = bytes_ptr[0..module.bytes_len];
 
-    // ADR-0200 / D-451 / D-478 — every import must be JIT-satisfiable AT
+    // ADR-0200 / D-451 / D-478 / #360 — every import must be JIT-satisfiable AT
     // INSTANTIATION (mirrors the interp linker's UnknownImport): a WASI func
-    // (`jit_dispatch.lookup`, planted by setup) OR an embedder host func
-    // (`wasm_func_new`) whose signature the comptime bridge covers. Anything
-    // else — non-func import, cross-module func, uncovered host-func signature,
-    // unsatisfied import — rejects here so the caller's `.interp` path handles
-    // it (no silent wrong answer; uncovered shapes never reach the JIT body).
-    // The resolved host-func targets are arena-scoped: setup copies their
-    // (idx, dispatch_ptr, payload) into the heap-owned `host_payloads`, so the
-    // arena can be reclaimed once `initLinked` returns.
+    // (`jit_dispatch.lookup`, planted by setup), an embedder host func
+    // (`wasm_func_new`) whose signature the comptime bridge covers, OR a func
+    // exported by another JIT-backed instance (D-225's `FuncImportTarget`).
+    // Anything else — non-func import, an interp-backed cross-module source,
+    // uncovered host-func signature, unsatisfied import — rejects here so the
+    // caller's `.interp` path handles it (no silent wrong answer; uncovered
+    // shapes never reach the JIT body). The resolved targets are arena-scoped:
+    // setup copies the host ones' (idx, dispatch_ptr, payload) into the
+    // heap-owned `host_payloads` and emits the cross-module ones into its own
+    // thunk arena, so this arena can be reclaimed once `initLinked` returns.
     var ht_arena = std.heap.ArenaAllocator.init(alloc);
     defer ht_arena.deinit();
-    const host_targets = collectHostFuncTargets(ht_arena.allocator(), bytes, builder_state, store) catch return null;
+    const func_imports = collectFuncImportTargets(ht_arena.allocator(), bytes, builder_state, store) catch return null;
 
     const jit = alloc.create(runner.JitInstance) catch return null;
-    jit.* = runner.JitInstance.initLinked(alloc, bytes, &.{}, &.{}, &.{}, host_targets) catch {
+    jit.* = runner.JitInstance.initLinked(alloc, bytes, &.{}, func_imports.cross, &.{}, func_imports.host) catch {
         alloc.destroy(jit);
         return null;
     };
@@ -995,6 +1086,11 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
 pub const BindingsBuilder = struct {
     ctx: *anyopaque,
     build: *const fn (ctx: *anyopaque, arena_alloc: std.mem.Allocator, bytes: []const u8, store: *Store) anyerror!?[]const runtime_instance_import.ImportBinding,
+    /// #360 — the C ABI import vector, when this builder wraps one. The JIT
+    /// path reads the `Extern`s directly (`collectFromExterns`): `build` is
+    /// the interp binder, and it cannot describe an import whose source
+    /// instance is JIT-backed. Null for the native-facade builder.
+    imports: ?[*]const ?*const Extern = null,
 };
 
 const BuildBindingsCApi = struct {
@@ -1006,7 +1102,7 @@ const BuildBindingsCApi = struct {
     }
 
     pub fn asBuilder(self: *BuildBindingsCApi) BindingsBuilder {
-        return .{ .ctx = self, .build = buildImpl };
+        return .{ .ctx = self, .build = buildImpl, .imports = self.imports_array };
     }
 };
 

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -265,6 +265,15 @@ pub export fn wasm_store_delete(s: ?*Store) callconv(.c) void {
                 alloc.destroy(rt);
             }
         }
+        // #360 — a JIT-backed instance still live here has its JitInstance
+        // parked for the reap below. Before this it was dropped on the floor
+        // (the cascade only ever looked at `inst.runtime`), leaking the code
+        // pages and the runtime on the reverse-order teardown path.
+        if (inst.jit) |jp| {
+            // EXEMPT-FALLBACK: ADR-0014 — park OOM at store-teardown accepts a JitInstance leak over UAF.
+            parkJitAsZombie(alloc, handle, jp) catch {};
+            inst.jit = null;
+        }
         inst.funcs_storage = &.{};
         inst.func_ptrs_storage = &.{};
         alloc.destroy(inst);
@@ -281,6 +290,14 @@ pub export fn wasm_store_delete(s: ?*Store) callconv(.c) void {
         alloc.destroy(z.runtime);
     }
     handle.zombies.deinit(alloc);
+    // #360 — and the JIT-backed zombies: an importer's bridge thunk pointed at
+    // each of these, and every importer is gone with the cascade above.
+    for (handle.jit_zombies.items) |jp| {
+        const jit: *runner.JitInstance = @ptrCast(@alignCast(jp));
+        jit.deinit(alloc);
+        alloc.destroy(jit);
+    }
+    handle.jit_zombies.deinit(alloc);
     // Free the cross-module instance registry (ADR-0065 §"Cat III").
     // Values are erased `*Instance` pointers (lifetimes managed by
     // the zombie list); keys are caller-owned. Only the hashmap's
@@ -319,6 +336,19 @@ fn parkAsZombie(
         .runtime = rt,
         .arena = arena,
     });
+}
+
+/// #360 — the JIT counterpart of `parkAsZombie`. A cross-module func import
+/// bakes the exporter's `&owned.rt` and entry address into the importer's
+/// bridge thunk (D-225), so the exporter's `JitInstance` must outlive every
+/// importer. Parking defers the free to `wasm_store_delete`, by when nothing
+/// can call in. Takes the erased pointer the `Instance.jit` field carries.
+fn parkJitAsZombie(
+    store_alloc: std.mem.Allocator,
+    store: *Store,
+    jit: *anyopaque,
+) std.mem.Allocator.Error!void {
+    try store.jit_zombies.append(store_alloc, jit);
 }
 
 // ============================================================
@@ -1393,12 +1423,14 @@ pub export fn wasm_instance_delete(i: ?*Instance) callconv(.c) void {
     // already-freed handle.
     removeFromLiveInstances(store, handle);
     if (handle.jit) |jp| {
-        // ADR-0200 — JIT-backed instance: free the heap-pinned JitInstance, then
-        // the per-instance arena holding `exports_storage` (its name slices
-        // borrowed jit.compiled.arena, freed just above, and are not read here).
-        const jit: *runner.JitInstance = @ptrCast(@alignCast(jp));
-        jit.deinit(alloc);
-        alloc.destroy(jit);
+        // ADR-0200 / #360 — PARK the heap-pinned JitInstance rather than free it,
+        // the JIT counterpart of the interpreter arm below: an importer's bridge
+        // thunk holds this instance's runtime address and entry point (D-225), so
+        // freeing here would leave it calling into released code. Reaped by
+        // `wasm_store_delete`. The per-instance arena holding `exports_storage`
+        // IS freed — only the c_api handle reads it, and it is going away.
+        // EXEMPT-FALLBACK: ADR-0014 — park OOM accepts a JitInstance leak over UAF of an importer's bridge thunk.
+        parkJitAsZombie(alloc, store, jp) catch {};
         handle.jit = null;
         if (handle.arena) |arena| {
             arena.deinit();

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -82,6 +82,18 @@ pub const Store = struct {
     /// through the importer's lifetime). Walked + freed by
     /// `wasm_store_delete`.
     zombies: std.ArrayList(Zombie) = .empty,
+    /// The JIT-backed counterpart of `zombies` (#360). A cross-module
+    /// func import against a JIT exporter bakes that exporter's runtime
+    /// address and entry point into the importer's bridge thunk (D-225),
+    /// so freeing the exporter's `JitInstance` at `wasm_instance_delete`
+    /// leaves the importer calling into released code — the same hazard
+    /// ADR-0014 §2.1 parks the interpreter runtime for. JIT instances
+    /// therefore park here instead and are freed by `wasm_store_delete`,
+    /// by when no importer can reach them. Stored as `*anyopaque` (an
+    /// `engine/runner.zig::JitInstance` erased) because this Zone-1 file
+    /// MUST NOT import Zone-2 `engine/` — same discipline as
+    /// `Instance.jit`; the Zone-3 store teardown casts back.
+    jit_zombies: std.ArrayList(*anyopaque) = .empty,
     /// Wasm 1.0 §4.5 cross-module instance registry per ADR-0065
     /// (Phase 9 Cat III §9.9-III scope). Spec testsuite uses
     /// `(register "M" $inst)` to bind a previously-instantiated

--- a/src/runtime/store.zig
+++ b/src/runtime/store.zig
@@ -94,6 +94,15 @@ pub const Store = struct {
     /// MUST NOT import Zone-2 `engine/` — same discipline as
     /// `Instance.jit`; the Zone-3 store teardown casts back.
     jit_zombies: std.ArrayList(*anyopaque) = .empty,
+    /// #360 — byte buffers of modules the embedder deleted while a JIT-backed
+    /// instance built from them was alive or parked. `setup.zig`'s passive
+    /// data / elem segment descriptors alias the module's bytes (the
+    /// `wasm_bytes` outlives `RuntimeOwned` contract), so `wasm_module_delete`
+    /// moves the buffer here instead of freeing it — the handle itself is
+    /// destroyed as before, so a use-after-delete of the handle still faults
+    /// rather than going quiet. Freed by `wasm_store_delete` AFTER the
+    /// `jit_zombies` reap, by when no runtime aliases them.
+    orphaned_module_bytes: std.ArrayList([]u8) = .empty,
     /// Wasm 1.0 §4.5 cross-module instance registry per ADR-0065
     /// (Phase 9 Cat III §9.9-III scope). Spec testsuite uses
     /// `(register "M" $inst)` to bind a previously-instantiated

--- a/test/c_api_conformance/cross_module_func.c
+++ b/test/c_api_conformance/cross_module_func.c
@@ -15,7 +15,13 @@
  * `wasm_instance_new` entry point was the one that could not compose.
  *
  * The exporter is instantiated on the same engine as the importer — the case
- * the fix is about is exporter and importer both JIT-backed. Exits 0 on success.
+ * the fix is about is exporter and importer both JIT-backed.
+ *
+ * `outlives_exporter` then deletes the exporter and its export handles before
+ * calling the importer. wasm-c-api transfers no ownership at instantiation, so
+ * an embedder may legitimately do that; the importer's bridge thunk holds the
+ * exporter's runtime address and entry point, so the exporter's JIT state has
+ * to outlive it. Exits 0 on success.
  */
 
 #include <stdio.h>
@@ -129,9 +135,97 @@ cleanup:
     return rc;
 }
 
+/* The embedder deletes the exporter — instance, module and export handles —
+ * and only then calls the importer. Nothing in the wasm-c-api contract keeps
+ * the exporter alive: `wasm_instance_new` borrows the import externs for the
+ * call and transfers no ownership. The interpreter has always survived this
+ * (`wasm_instance_delete` parks the runtime + arena as a store zombie per
+ * ADR-0014 §2.1, exactly so cross-module references stay valid); the JIT arm
+ * freed its JitInstance outright, which was harmless only while no C-API
+ * importer could reference one. Once one can, calling here entered released
+ * code and took a fatal signal. */
+static int outlives_exporter(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* importer_module = NULL;
+    wasm_instance_t* importer = NULL;
+    wasm_extern_vec_t importer_exports = { 0, NULL };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_binary = { sizeof(kExporterWasm), (wasm_byte_t*) kExporterWasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fprintf(stderr, "[%s] exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) { fprintf(stderr, "[%s] exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] exporter exposed nothing\n", who);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t importer_binary = { sizeof(kImporterWasm), (wasm_byte_t*) kImporterWasm };
+    importer_module = wasm_module_new(store, &importer_binary);
+    if (!importer_module) { fprintf(stderr, "[%s] importer failed to parse\n", who); goto cleanup; }
+    wasm_extern_t* import_externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    importer = zwasm_instance_new_ex(store, importer_module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!importer) { fprintf(stderr, "[%s] the importer failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(importer, &importer_exports);
+    if (importer_exports.size < 1 || !importer_exports.data[0]) {
+        fprintf(stderr, "[%s] the importer is missing its `test` export\n", who);
+        goto cleanup;
+    }
+
+    /* The exporter goes away. The importer must not. */
+    wasm_extern_vec_delete(&exporter_exports);
+    exporter_exports.data = NULL;
+    wasm_instance_delete(exporter);
+    exporter = NULL;
+    wasm_module_delete(exporter_module);
+    exporter_module = NULL;
+
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(importer_exports.data[0]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the call trapped after the exporter was deleted\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] after deleting the exporter, expected 42, got kind=%d value=%d\n",
+                who, (int) results[0].kind, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (importer_exports.data) wasm_extern_vec_delete(&importer_exports);
+    if (importer) wasm_instance_delete(importer);
+    if (importer_module) wasm_module_delete(importer_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
         if (compose_on(kEngines[i]) != 0) return 1;
+        if (outlives_exporter(kEngines[i]) != 0) return 1;
     }
     return 0;
 }

--- a/test/c_api_conformance/cross_module_func.c
+++ b/test/c_api_conformance/cross_module_func.c
@@ -1,0 +1,137 @@
+/* zwasm v2 — C-API conformance: a cross-module func import under every engine.
+ *
+ * Two modules composed through the stock wasm-c-api: the exporter's `get`
+ * extern is handed to the importer's `wasm_extern_vec_t`, and the importer's
+ * `test` must return the exporter's 42.
+ *
+ *   (module (func (export "get") (result i32) (i32.const 42)))
+ *   (module (import "b" "get" (func $get (result i32)))
+ *           (func (export "test") (result i32) (call $get)))
+ *
+ * Run on `auto`, `jit` and `interp`. `interp` has always bound this; the
+ * JIT-backed engines could not, because the binder resolved the import through
+ * the source instance's interpreter runtime and a JIT-backed instance has none
+ * (#360). Since ADR-0200 / D-496 `auto` is JIT-first, so the stock
+ * `wasm_instance_new` entry point was the one that could not compose.
+ *
+ * The exporter is instantiated on the same engine as the importer — the case
+ * the fix is about is exporter and importer both JIT-backed. Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (func (export "get") (result i32) (i32.const 42))) */
+static const uint8_t kExporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,                   /* type ()->(i32) */
+    0x03, 0x02, 0x01, 0x00,                                     /* func[0]: type 0 */
+    0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00,       /* export "get" -> 0 */
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b,             /* body: i32.const 42 */
+};
+
+/* (module (import "b" "get" (func (result i32)))
+ *         (func (export "test") (result i32) (call 0))) */
+static const uint8_t kImporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,                   /* type ()->(i32) */
+    0x02, 0x09, 0x01, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, /* import b.get */
+    0x03, 0x02, 0x01, 0x00,                                     /* func[1]: type 0 */
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01, /* export "test" -> 1 */
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,             /* body: call 0 */
+};
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+static int compose_on(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* importer_module = NULL;
+    wasm_instance_t* importer = NULL;
+    wasm_extern_vec_t importer_exports = { 0, NULL };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_binary = { sizeof(kExporterWasm), (wasm_byte_t*) kExporterWasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fprintf(stderr, "[%s] exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) { fprintf(stderr, "[%s] exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] exporter exposed nothing\n", who);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t importer_binary = { sizeof(kImporterWasm), (wasm_byte_t*) kImporterWasm };
+    importer_module = wasm_module_new(store, &importer_binary);
+    if (!importer_module) { fprintf(stderr, "[%s] importer failed to parse\n", who); goto cleanup; }
+    wasm_extern_t* import_externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    importer = zwasm_instance_new_ex(store, importer_module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!importer) {
+        fprintf(stderr, "[%s] the importer failed to instantiate — a cross-module func "
+                        "import did not bind\n", who);
+        goto cleanup;
+    }
+    wasm_instance_exports(importer, &importer_exports);
+    if (importer_exports.size < 1 || !importer_exports.data[0] ||
+        wasm_extern_kind(importer_exports.data[0]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] the importer is missing its `test` export\n", who);
+        goto cleanup;
+    }
+
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(importer_exports.data[0]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the cross-module call trapped\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] expected 42, got kind=%d value=%d\n",
+                who, (int) results[0].kind, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (importer_exports.data) wasm_extern_vec_delete(&importer_exports);
+    if (importer) wasm_instance_delete(importer);
+    if (importer_module) wasm_module_delete(importer_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (compose_on(kEngines[i]) != 0) return 1;
+    }
+    return 0;
+}

--- a/test/c_api_conformance/cross_module_func.c
+++ b/test/c_api_conformance/cross_module_func.c
@@ -26,6 +26,8 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <wasm.h>
 #include <zwasm.h>
@@ -222,10 +224,116 @@ cleanup:
     return rc;
 }
 
+/* (module (memory 1)
+ *         (data "\x2a\x00\x00\x00\x00\x00\x00\x00")            ;; passive
+ *         (func (export "get") (result i32)
+ *           i32.const 0 i32.const 0 i32.const 8 memory.init 0
+ *           i32.const 0 i32.load))
+ * The exporter's answer comes from a PASSIVE data segment, i.e. from bytes
+ * that live in the module's own byte buffer until `memory.init` copies them. */
+static const uint8_t kPassiveDataExporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+    0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00,
+    0x00, 0x0c, 0x01, 0x01, 0x0a, 0x13, 0x01, 0x11, 0x00, 0x41, 0x00, 0x41, 0x00, 0x41, 0x08, 0xfc,
+    0x08, 0x00, 0x00, 0x41, 0x00, 0x28, 0x02, 0x00, 0x0b, 0x0b, 0x0b, 0x01, 0x01, 0x08, 0x2a, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+/* The exporter's result is copied out of a passive data segment — bytes the JIT reads straight from the module's
+ * byte buffer (`setup.zig`: segment descriptors alias `wasm_bytes`). Deleting
+ * the exporter's module used to free that buffer while the parked JIT runtime
+ * still pointed into it; the importer's next call then copied whatever the
+ * allocator had reused it for (measured: -1431655766 for 42 on auto/jit). The
+ * module's bytes now outlive every JIT borrower. */
+static int outlives_module_bytes(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* importer_module = NULL;
+    wasm_instance_t* importer = NULL;
+    wasm_extern_vec_t importer_exports = { 0, NULL };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_binary = { sizeof(kPassiveDataExporterWasm), (wasm_byte_t*) kPassiveDataExporterWasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fprintf(stderr, "[%s] passive-data exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) { fprintf(stderr, "[%s] passive-data exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] passive-data exporter exposed nothing\n", who);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t importer_binary = { sizeof(kImporterWasm), (wasm_byte_t*) kImporterWasm };
+    importer_module = wasm_module_new(store, &importer_binary);
+    if (!importer_module) { fprintf(stderr, "[%s] importer failed to parse\n", who); goto cleanup; }
+    wasm_extern_t* import_externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    importer = zwasm_instance_new_ex(store, importer_module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!importer) { fprintf(stderr, "[%s] the importer failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(importer, &importer_exports);
+    if (importer_exports.size < 1 || !importer_exports.data[0]) {
+        fprintf(stderr, "[%s] the importer is missing its `test` export\n", who);
+        goto cleanup;
+    }
+
+    /* The order wasm-c-api permits and that used to fault: the MODULE goes
+     * first while its instance is still alive; the instance is deleted after
+     * the call; the store last (cleanup below). The segment bytes are the
+     * point — they live in the module's buffer. */
+    wasm_module_delete(exporter_module);
+    exporter_module = NULL;
+    /* Churn the heap so a freed buffer would not still hold its old bytes. */
+    for (int k = 0; k < 64; k++) { void* junk = malloc(4096); if (junk) { memset(junk, 0xEE, 4096); free(junk); } }
+
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(importer_exports.data[0]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the call trapped after the exporter's module was deleted\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] after deleting the exporter's module, memory.init copied %d, expected 42\n",
+                who, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    /* Now the exporter instance, before the store. */
+    wasm_extern_vec_delete(&exporter_exports);
+    exporter_exports.data = NULL;
+    wasm_instance_delete(exporter);
+    exporter = NULL;
+    rc = 0;
+
+cleanup:
+    if (importer_exports.data) wasm_extern_vec_delete(&importer_exports);
+    if (importer) wasm_instance_delete(importer);
+    if (importer_module) wasm_module_delete(importer_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
         if (compose_on(kEngines[i]) != 0) return 1;
         if (outlives_exporter(kEngines[i]) != 0) return 1;
+        if (outlives_module_bytes(kEngines[i]) != 0) return 1;
     }
     return 0;
 }


### PR DESCRIPTION
`instantiateJit` passed `&.{}` for `func_import_targets`, so the C API never
fed the JIT the cross-module machinery D-225 has had since
`JitInstance.initLinked` / `exportedFuncTarget`. Since ADR-0200 / D-496 made
`.auto` JIT-first, the stock `wasm_instance_new` was the entry point that
could not compose two modules.

The C ABI path now resolves its func imports off the import `Extern`s rather
than through `buildBindings` — that binder is the interpreter's, and it cannot
describe a JIT-backed source at all. An extern with no source instance is an
embedder host callback (unchanged); one with a source instance is a
cross-module import, resolved via `exportedFuncTarget` after the same §4.5.10
subtype check `instantiate.checkImportTypeMatches` applies. The native-facade
builder (`src/zwasm/linker.zig`) carries no extern array and keeps its old
route, host funcs only.

`test/c_api_conformance/cross_module_func.c` composes two modules on all three
engines and asserts the exporter's 42 comes back. `wasi_exit_code.c`'s
`cross-module via imported func` rows now assert in full on `auto` and `jit`
rather than reporting the engine as unmeasured — the assertions #354 left
waiting, including the `proc_exit` status following the runtime that actually
ran it.

This waited on #381 (merged as `ba9d94c25`): the binding alone let a trapping
callee return as if it had succeeded, so it could not land first. Rebased onto
that; `test-all` is green on the pair.

Deleting the exporter before calling the importer used to take a fatal signal
on the JIT engines: the importer's bridge thunk holds the exporter's runtime
address and entry point, and `wasm_instance_delete` freed the `JitInstance`
outright — while the interpreter arm beside it parks its runtime as a store
zombie for exactly that reason (ADR-0014 §2.1). JIT instances now park too, on
`Store.jit_zombies`, reaped at `wasm_store_delete`; `outlives_exporter` covers
it on all three engines. The store-teardown cascade parks as well, which also
stops a live JIT instance leaking its code pages on the reverse-order path.
Caught by Devin's review.

A func import whose signature names a **type index** is declined on the JIT
path rather than bound. `funcTypeImportCompatible` resolves both signatures in
one type space and the only one in hand here is the importer's, which is sound
for structural types and unsound for `(ref $t)`. The interp path has the same
gap (#387) but carries `source_signature` to the call; a JIT target is a bridge
thunk jumping straight into the callee, so a wrongly accepted link there is an
ABI mismatch rather than a semantic one. Declining keeps this PR from widening
acceptance past what it can judge. It is not a graceful degradation: the
`.auto` retry lands in `buildBindings`, which needs the source's interpreter
`Runtime`, so the shape stays unsupported — NULL with no trap, #353's surface.
It is unsupported at `main` too, by the same route, so the guard withholds an
acceptance rather than removing one. Lifted by #387.

Parking a JIT instance exposed a second lifetime: `setup.zig`'s passive
data / elem segment descriptors alias the module's bytes (`wasm_bytes` must
outlive `RuntimeOwned`), and `wasm_module_delete` freed them while a parked
runtime still pointed in — the importer's next `memory.init` copied a reused
buffer (-1431655766 for 42 on `auto`/`jit`; the interpreter dupes its segments
and was never exposed). A `jit_borrowers` count on the `Module` now defers the
bytes to `Store.orphaned_module_bytes`, freed after the zombie reap; the handle
is destroyed exactly as before, so a use-after-delete of it keeps faulting.
Nothing decrements — a JIT instance is parked, never freed, until the reap —
and the count is a plain store-local integer (single-threaded Store), both
stated in the field's doc. `outlives_module_bytes` pins the permitted order
that used to fault: delete the module, call, delete the instance, delete the
store. Caught by Devin's review.

`.table` / `.memory` imports from a JIT-backed source stay out of scope, as
#360's own Scope section has it: measured NULL on `auto`/`jit` before and after
this change, and `wasi_exit_code.c`'s `via imported table` rows still report
those engines as unmeasured. `setupRuntimeLinked` takes no table/memory import
argument and the JIT's table and memory index spaces reserve no import slots
(globals do, at `src/engine/setup.zig:580-632`), so supplying one is new
machinery rather than a missing wire.

Closes #360. Unblocks the hold on zwasm/zwasm-rust-sdk#24: the SDK exposes no
engine selection, so its callers cannot reach the `ZWASM_ENGINE_INTERP`
workaround.
