### PR TITLE
jit: relay a cross-module callee's trap onto the caller's runtime

### DIFF
--- a/src/engine/codegen/arm64/thunk.zig
+++ b/src/engine/codegen/arm64/thunk.zig
@@ -15,7 +15,7 @@
 //! sig` mismatch (kind=3) because X24 pointed at the callee's
 //! (= imports.0's) typeidx_base instead of the caller's.
 //!
-//! Layout (96 bytes total):
+//! Layout (120 bytes total):
 //!
 //! ```text
 //! offset  encoding                          disassembly
@@ -27,26 +27,53 @@
 //! 0x14    STR X26, [SP, #40]                ; save caller's X26 = funcptr_base
 //! 0x18    STR X27, [SP, #48]                ; save caller's X27 = mem_limit
 //! 0x1C    STR X28, [SP, #56]                ; save caller's X28 = vm_base
-//! 0x20    ADR X16, +48                      ; X16 ← literal pool base
+//! 0x20    ADR X16, +72                      ; X16 ← literal pool base
 //! 0x24    LDR X0,  [X16]                    ; X0  ← callee_rt
-//! 0x28    LDR X16, [X16, #8]                ; X16 ← callee_entry
-//! 0x2C    BLR X16                           ; CALL (LR ← PC+4)
-//! 0x30    LDR X19, [SP, #16]                ; RESTORE caller's X19
-//! 0x34    LDR X24, [SP, #24]                ; RESTORE caller's X24
-//! 0x38    LDR X25, [SP, #32]                ; RESTORE caller's X25
-//! 0x3C    LDR X26, [SP, #40]                ; RESTORE caller's X26
-//! 0x40    LDR X27, [SP, #48]                ; RESTORE caller's X27
-//! 0x44    LDR X28, [SP, #56]                ; RESTORE caller's X28
-//! 0x48    LDP X29, X30, [SP], #80           ; restore FP+LR, pop frame
-//! 0x4C    RET                               ; return to importer
-//! 0x50    .quad callee_rt                   ; literal pool
-//! 0x58    .quad callee_entry
+//! 0x28    STR X0,  [SP, #64]                ; #381: park callee_rt in the frame pad
+//! 0x2C    LDR X16, [X16, #8]                ; X16 ← callee_entry
+//! 0x30    BLR X16                           ; CALL (LR ← PC+4)
+//! 0x34    LDR X19, [SP, #16]                ; RESTORE caller's X19
+//! 0x38    LDR X24, [SP, #24]                ; RESTORE caller's X24
+//! 0x3C    LDR X25, [SP, #32]                ; RESTORE caller's X25
+//! 0x40    LDR X26, [SP, #40]                ; RESTORE caller's X26
+//! 0x44    LDR X27, [SP, #48]                ; RESTORE caller's X27
+//! 0x48    LDR X28, [SP, #56]                ; RESTORE caller's X28
+//! 0x4C    LDR X16, [SP, #64]                ; #381 relay: X16 ← callee_rt
+//! 0x50    LDR X17, [X16, #40]               ; X17 ← callee trap_flag|trap_kind
+//! 0x54    CBZ X17, +2                       ; no trap → skip the store
+//! 0x58    STR X17, [X19, #40]               ; relay onto the CALLER's runtime
+//! 0x5C    LDP X29, X30, [SP], #80           ; restore FP+LR, pop frame
+//! 0x60    RET                               ; return to importer
+//! 0x64    NOP                               ; pad — keeps the pool 8-aligned
+//! 0x68    .quad callee_rt                   ; literal pool
+//! 0x70    .quad callee_entry
 //! ```
 //!
-//! 20 × 4-byte instructions + 16-byte literal pool = 96 bytes total
-//! (the MOV X29,SP consumed the prior alignment-pad slot, so size is
-//! unchanged). `ADR X16, +<offset>` resolves from the ADR's PC
-//! (offset 0x20) to the literal pool base (0x50) — distance = 48 bytes.
+//! 25 × 4-byte instructions + 4-byte pad + 16-byte literal pool = 120 bytes
+//! total. `ADR X16, +<offset>` resolves from the ADR's PC (offset 0x20) to
+//! the literal pool base (0x68) — distance = 72 bytes.
+//!
+//! Trap relay (#381): a JIT trap is a FLAG, not an unwind — the trap stub
+//! writes `[X19 + trap_flag_off]` and returns, and every call site re-reads
+//! that flag afterwards (`arm64/op_call.zig:emitPostCallTrapCheck`,
+//! ADR-0199 / D-468). X19 holds the CALLEE's runtime for the duration of the
+//! call, so a trap raised in the callee landed in a runtime the importer
+//! never reads: the call reported success and the importer ran on past a
+//! call that returned nothing. The four instructions at 0x4C..0x5B copy the
+//! callee's flag onto the caller AFTER X19 has been restored, so the
+//! importer's existing post-call check fires unchanged — no call-site
+//! codegen changes.
+//!
+//! `trap_flag` (u32 @40) and `trap_kind` (u32 @44) are adjacent, so ONE
+//! 8-byte load/store carries both; the kind matters because a relay that
+//! moved only the flag would report every cross-module trap as kind 0. The
+//! adjacency is asserted at comptime below.
+//!
+//! `callee_rt` is parked at `[SP, #64]` (the frame's existing pad, see the
+//! frame layout below) rather than re-derived from the literal pool: X16 is
+//! corruptible across the call (AAPCS64 §6.4.1 IP0) and X0 carries the
+//! return value. X16/X17 are free to clobber after the call; X0..X1 and
+//! V0..V3 (the return-value registers) are untouched.
 //!
 //! AAPCS64 §6.4.1 invariant: X19..X28 are callee-saved. v2's
 //! JIT prologue (per ADR-0017 sub-2d-ii) overwrites the six
@@ -61,7 +88,8 @@
 //!
 //! Frame layout: `[SP+0]=FP, [SP+8]=LR, [SP+16]=X19,
 //! [SP+24]=X24, [SP+32]=X25, [SP+40]=X26, [SP+48]=X27,
-//! [SP+56]=X28, [SP+64..72]=padding`. The 80-byte frame keeps
+//! [SP+56]=X28, [SP+64]=callee_rt (#381 relay), [SP+72]=padding`.
+//! The 80-byte frame keeps
 //! SP 16-byte-aligned per AAPCS64 §6.4.5.1; FP/LR sit at the
 //! bottom matching the standard unwinder frame shape so a
 //! debugger can walk past the thunk.
@@ -71,14 +99,28 @@
 
 const std = @import("std");
 const inst = @import("inst.zig");
+const jit_abi = @import("../shared/jit_abi.zig");
 
-/// Total thunk size in bytes (20 instructions × 4 bytes +
-/// 2 quad literals × 8 bytes = 96; the ADR-0134 D1 MOV X29,SP
-/// consumed the prior alignment pad, so size is unchanged).
-/// Stable across all callee signatures. D-144
-/// grew the thunk from 56 → 96 bytes to cover the full
-/// six-register reserved-invariant cohort.
-pub const thunk_bytes: usize = 96;
+comptime {
+    // The relay below copies `trap_flag` and `trap_kind` as one 8-byte pair,
+    // and `encLdrImm`/`encStrImm` require an 8-aligned byte offset.
+    if (jit_abi.trap_kind_off != jit_abi.trap_flag_off + 4)
+        @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; they are no longer adjacent");
+    if (jit_abi.trap_flag_off % 8 != 0)
+        @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; trap_flag_off is no longer 8-aligned");
+}
+
+/// Total thunk size in bytes (25 instructions × 4 bytes + a 4-byte
+/// pad that re-aligns the pool + 2 quad literals × 8 bytes = 120).
+/// Stable across all callee signatures. D-144 grew the thunk from
+/// 56 → 96 bytes to cover the full six-register reserved-invariant
+/// cohort; #381's trap relay grew it 96 → 120.
+pub const thunk_bytes: usize = 120;
+
+/// #381 — frame slot the thunk parks `callee_rt` in across the call, so the
+/// trap relay can read the callee's runtime after X16/X0 are gone. Uses the
+/// 80-byte frame's existing pad; the frame does not grow.
+const callee_rt_slot: u15 = 64;
 
 /// Emit one bridge thunk into `buf[0..thunk_bytes]`. `buf` MUST
 /// be exactly `thunk_bytes` long; the caller is responsible for
@@ -110,32 +152,45 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     std.mem.writeInt(u32, buf[20..24], inst.encStrImm(26, inst.sp_reg, 40), .little);
     std.mem.writeInt(u32, buf[24..28], inst.encStrImm(27, inst.sp_reg, 48), .little);
     std.mem.writeInt(u32, buf[28..32], inst.encStrImm(28, inst.sp_reg, 56), .little);
-    // ADR X16, +<offset> — literal pool starts at byte 0x50 from thunk
-    // start. ADR instruction is now at byte 0x20 (32). Distance =
-    // 0x50 - 0x20 = 0x30 = 48 bytes (was 52 before the MOV X29,SP insert).
-    std.mem.writeInt(u32, buf[32..36], inst.encAdr(16, 48), .little);
+    // ADR X16, +<offset> — literal pool starts at byte 0x68 from thunk
+    // start. ADR instruction is at byte 0x20 (32). Distance =
+    // 0x68 - 0x20 = 0x48 = 72 bytes (was 48 before the #381 relay).
+    std.mem.writeInt(u32, buf[32..36], inst.encAdr(16, 72), .little);
     // LDR X0, [X16] — X0 ← callee_rt.
     std.mem.writeInt(u32, buf[36..40], inst.encLdrImm(0, 16, 0), .little);
+    // STR X0, [SP, #64] — #381: park callee_rt in the frame's pad slot. X16
+    // is corruptible across the call and X0 returns the callee's result, so
+    // the relay below cannot recover it from either.
+    std.mem.writeInt(u32, buf[40..44], inst.encStrImm(0, inst.sp_reg, callee_rt_slot), .little);
     // LDR X16, [X16, #8] — X16 ← callee_entry.
-    std.mem.writeInt(u32, buf[40..44], inst.encLdrImm(16, 16, 8), .little);
+    std.mem.writeInt(u32, buf[44..48], inst.encLdrImm(16, 16, 8), .little);
     // BLR X16 — CALL.
-    std.mem.writeInt(u32, buf[44..48], inst.encBlr(16), .little);
+    std.mem.writeInt(u32, buf[48..52], inst.encBlr(16), .little);
     // LDR X19..X28 — restore caller's reserved-invariant cohort.
-    std.mem.writeInt(u32, buf[48..52], inst.encLdrImm(19, inst.sp_reg, 16), .little);
-    std.mem.writeInt(u32, buf[52..56], inst.encLdrImm(24, inst.sp_reg, 24), .little);
-    std.mem.writeInt(u32, buf[56..60], inst.encLdrImm(25, inst.sp_reg, 32), .little);
-    std.mem.writeInt(u32, buf[60..64], inst.encLdrImm(26, inst.sp_reg, 40), .little);
-    std.mem.writeInt(u32, buf[64..68], inst.encLdrImm(27, inst.sp_reg, 48), .little);
-    std.mem.writeInt(u32, buf[68..72], inst.encLdrImm(28, inst.sp_reg, 56), .little);
+    std.mem.writeInt(u32, buf[52..56], inst.encLdrImm(19, inst.sp_reg, 16), .little);
+    std.mem.writeInt(u32, buf[56..60], inst.encLdrImm(24, inst.sp_reg, 24), .little);
+    std.mem.writeInt(u32, buf[60..64], inst.encLdrImm(25, inst.sp_reg, 32), .little);
+    std.mem.writeInt(u32, buf[64..68], inst.encLdrImm(26, inst.sp_reg, 40), .little);
+    std.mem.writeInt(u32, buf[68..72], inst.encLdrImm(27, inst.sp_reg, 48), .little);
+    std.mem.writeInt(u32, buf[72..76], inst.encLdrImm(28, inst.sp_reg, 56), .little);
+    // #381 trap relay — X19 now holds caller_rt again, so the store below
+    // lands on the CALLER. Reading and writing the same 8-byte offset carries
+    // trap_flag AND trap_kind. Conditional, so a clean return cannot clear a
+    // flag the caller already holds.
+    const flag_off: u15 = jit_abi.trap_flag_off;
+    std.mem.writeInt(u32, buf[76..80], inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), .little);
+    std.mem.writeInt(u32, buf[80..84], inst.encLdrImm(17, 16, flag_off), .little);
+    std.mem.writeInt(u32, buf[84..88], inst.encCbz(17, 2), .little); // → LDP
+    std.mem.writeInt(u32, buf[88..92], inst.encStrImm(17, 19, flag_off), .little);
     // LDP X29, X30, [SP], #80 — restore FP+LR, pop frame.
-    std.mem.writeInt(u32, buf[72..76], inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), .little);
+    std.mem.writeInt(u32, buf[92..96], inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), .little);
     // RET — return to importer's call site.
-    std.mem.writeInt(u32, buf[76..80], inst.encRet(30), .little);
-    // Literal pool at offset 0x50 (= 80). The 20th instruction (MOV
-    // X29,SP) consumed the prior alignment-pad slot, so the pool stays
-    // 8-aligned at 80 with no pad and `thunk_bytes` stays 96.
-    std.mem.writeInt(u64, buf[80..88], callee_rt, .little);
-    std.mem.writeInt(u64, buf[88..96], callee_entry, .little);
+    std.mem.writeInt(u32, buf[96..100], inst.encRet(30), .little);
+    // NOP — 25 instructions leave the pool 4-aligned; pad it back to 8.
+    std.mem.writeInt(u32, buf[100..104], inst.encNop(), .little);
+    // Literal pool at offset 0x68 (= 104).
+    std.mem.writeInt(u64, buf[104..112], callee_rt, .little);
+    std.mem.writeInt(u64, buf[112..120], callee_entry, .little);
 }
 
 // ============================================================
@@ -162,30 +217,56 @@ test "emitThunk: encoding round-trip via helpers" {
     try testing.expectEqual(inst.encStrImm(26, inst.sp_reg, 40), std.mem.readInt(u32, buf[20..24], .little));
     try testing.expectEqual(inst.encStrImm(27, inst.sp_reg, 48), std.mem.readInt(u32, buf[24..28], .little));
     try testing.expectEqual(inst.encStrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[28..32], .little));
-    try testing.expectEqual(inst.encAdr(16, 48), std.mem.readInt(u32, buf[32..36], .little));
+    try testing.expectEqual(inst.encAdr(16, 72), std.mem.readInt(u32, buf[32..36], .little));
     try testing.expectEqual(inst.encLdrImm(0, 16, 0), std.mem.readInt(u32, buf[36..40], .little));
-    try testing.expectEqual(inst.encLdrImm(16, 16, 8), std.mem.readInt(u32, buf[40..44], .little));
-    try testing.expectEqual(inst.encBlr(16), std.mem.readInt(u32, buf[44..48], .little));
-    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[48..52], .little));
-    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[52..56], .little));
-    try testing.expectEqual(inst.encLdrImm(25, inst.sp_reg, 32), std.mem.readInt(u32, buf[56..60], .little));
-    try testing.expectEqual(inst.encLdrImm(26, inst.sp_reg, 40), std.mem.readInt(u32, buf[60..64], .little));
-    try testing.expectEqual(inst.encLdrImm(27, inst.sp_reg, 48), std.mem.readInt(u32, buf[64..68], .little));
-    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[68..72], .little));
-    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[72..76], .little));
-    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[76..80], .little));
-    try testing.expectEqual(callee_rt, std.mem.readInt(u64, buf[80..88], .little));
-    try testing.expectEqual(callee_entry, std.mem.readInt(u64, buf[88..96], .little));
+    try testing.expectEqual(inst.encStrImm(0, inst.sp_reg, callee_rt_slot), std.mem.readInt(u32, buf[40..44], .little));
+    try testing.expectEqual(inst.encLdrImm(16, 16, 8), std.mem.readInt(u32, buf[44..48], .little));
+    try testing.expectEqual(inst.encBlr(16), std.mem.readInt(u32, buf[48..52], .little));
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
+    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[56..60], .little));
+    try testing.expectEqual(inst.encLdrImm(25, inst.sp_reg, 32), std.mem.readInt(u32, buf[60..64], .little));
+    try testing.expectEqual(inst.encLdrImm(26, inst.sp_reg, 40), std.mem.readInt(u32, buf[64..68], .little));
+    try testing.expectEqual(inst.encLdrImm(27, inst.sp_reg, 48), std.mem.readInt(u32, buf[68..72], .little));
+    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[72..76], .little));
+    // #381 trap relay.
+    try testing.expectEqual(inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), std.mem.readInt(u32, buf[76..80], .little));
+    try testing.expectEqual(inst.encLdrImm(17, 16, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[80..84], .little));
+    try testing.expectEqual(inst.encCbz(17, 2), std.mem.readInt(u32, buf[84..88], .little));
+    try testing.expectEqual(inst.encStrImm(17, 19, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[88..92], .little));
+    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[92..96], .little));
+    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[96..100], .little));
+    try testing.expectEqual(inst.encNop(), std.mem.readInt(u32, buf[100..104], .little));
+    try testing.expectEqual(callee_rt, std.mem.readInt(u64, buf[104..112], .little));
+    try testing.expectEqual(callee_entry, std.mem.readInt(u64, buf[112..120], .little));
+}
+
+// #381 — the relay's meaning, apart from its byte offsets: it reads the
+// CALLEE's runtime (parked in the frame) and writes the CALLER's (X19, already
+// restored), at the same offset, and the CBZ lands on the epilogue rather than
+// inside the store. A reshuffle that keeps the encodings but swaps the two
+// runtimes would still report no trap; this is what catches that.
+test "emitThunk: the trap relay reads the callee's runtime and writes the caller's (#381)" {
+    var buf: [thunk_bytes]u8 = undefined;
+    emitThunk(&buf, 0, 0);
+    const load = std.mem.readInt(u32, buf[80..84], .little);
+    const store = std.mem.readInt(u32, buf[88..92], .little);
+    // Load base = X16 (the parked callee_rt); store base = X19 (caller_rt).
+    try testing.expectEqual(inst.encLdrImm(17, 16, jit_abi.trap_flag_off), load);
+    try testing.expectEqual(inst.encStrImm(17, 19, jit_abi.trap_flag_off), store);
+    // The X19 restore precedes the store — otherwise it would land on the callee.
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
+    // CBZ +2 words from byte 84 = byte 92 = the LDP epilogue.
+    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[84 + 2 * 4 ..][0..4], .little));
 }
 
 test "emitThunk: round-trip literals at zero" {
     var buf: [thunk_bytes]u8 = undefined;
     emitThunk(&buf, 0, 0);
-    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[80..88], .little));
-    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[88..96], .little));
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[104..112], .little));
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[112..120], .little));
     // Instruction prefix unchanged regardless of literals.
     try testing.expectEqual(inst.encStpPreIdx(29, 30, inst.sp_reg, -80), std.mem.readInt(u32, buf[0..4], .little));
-    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[76..80], .little));
+    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[96..100], .little));
 }
 
 test "emitThunk: instruction prefix is constant across two distinct callees" {
@@ -212,8 +293,8 @@ test "emitThunk: saves/restores X19+X24..X28 around BLR" {
     try testing.expectEqual(inst.encStrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[8..12], .little));
     try testing.expectEqual(inst.encStrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[12..16], .little));
     try testing.expectEqual(inst.encStrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[28..32], .little));
-    // Post-BLR restores at offsets 48..72.
-    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[48..52], .little));
-    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[52..56], .little));
-    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[68..72], .little));
+    // Post-BLR restores at offsets 52..76 (shifted +4 by the #381 STR X0).
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
+    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[56..60], .little));
+    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[72..76], .little));
 }

--- a/src/engine/codegen/arm64/thunk.zig
+++ b/src/engine/codegen/arm64/thunk.zig
@@ -30,28 +30,38 @@
 //! 0x20    ADR X16, +72                      ; X16 ← literal pool base
 //! 0x24    LDR X0,  [X16]                    ; X0  ← callee_rt
 //! 0x28    STR X0,  [SP, #64]                ; #381: park callee_rt in the frame pad
-//! 0x2C    LDR X16, [X16, #8]                ; X16 ← callee_entry
-//! 0x30    BLR X16                           ; CALL (LR ← PC+4)
-//! 0x34    LDR X19, [SP, #16]                ; RESTORE caller's X19
-//! 0x38    LDR X24, [SP, #24]                ; RESTORE caller's X24
-//! 0x3C    LDR X25, [SP, #32]                ; RESTORE caller's X25
-//! 0x40    LDR X26, [SP, #40]                ; RESTORE caller's X26
-//! 0x44    LDR X27, [SP, #48]                ; RESTORE caller's X27
-//! 0x48    LDR X28, [SP, #56]                ; RESTORE caller's X28
-//! 0x4C    LDR X16, [SP, #64]                ; #381 relay: X16 ← callee_rt
-//! 0x50    LDR X17, [X16, #40]               ; X17 ← callee trap_flag|trap_kind
-//! 0x54    CBZ X17, +2                       ; no trap → skip the store
-//! 0x58    STR X17, [X19, #40]               ; relay onto the CALLER's runtime
-//! 0x5C    LDP X29, X30, [SP], #80           ; restore FP+LR, pop frame
-//! 0x60    RET                               ; return to importer
-//! 0x64    NOP                               ; pad — keeps the pool 8-aligned
+//! 0x2C    STR XZR, [X0, #40]                ; #381 entry clear: callee trap_flag|kind
+//! 0x30    LDR X16, [X16, #8]                ; X16 ← callee_entry
+//! 0x34    BLR X16                           ; CALL (LR ← PC+4)
+//! 0x38    LDR X19, [SP, #16]                ; RESTORE caller's X19
+//! 0x3C    LDR X24, [SP, #24]                ; RESTORE caller's X24
+//! 0x40    LDR X25, [SP, #32]                ; RESTORE caller's X25
+//! 0x44    LDR X26, [SP, #40]                ; RESTORE caller's X26
+//! 0x48    LDR X27, [SP, #48]                ; RESTORE caller's X27
+//! 0x4C    LDR X28, [SP, #56]                ; RESTORE caller's X28
+//! 0x50    LDR X16, [SP, #64]                ; #381 relay: X16 ← callee_rt
+//! 0x54    LDR X17, [X16, #40]               ; X17 ← callee trap_flag|trap_kind
+//! 0x58    CBZ X17, +2                       ; no trap → skip the store
+//! 0x5C    STR X17, [X19, #40]               ; relay onto the CALLER's runtime
+//! 0x60    LDP X29, X30, [SP], #80           ; restore FP+LR, pop frame
+//! 0x64    RET                               ; return to importer
 //! 0x68    .quad callee_rt                   ; literal pool
 //! 0x70    .quad callee_entry
 //! ```
 //!
-//! 25 × 4-byte instructions + 4-byte pad + 16-byte literal pool = 120 bytes
-//! total. `ADR X16, +<offset>` resolves from the ADR's PC (offset 0x20) to
-//! the literal pool base (0x68) — distance = 72 bytes.
+//! 26 × 4-byte instructions + 16-byte literal pool = 120 bytes total (the
+//! entry-clear STR consumed the alignment pad the relay had needed, so the
+//! size is unchanged). `ADR X16, +<offset>` resolves from the ADR's PC
+//! (offset 0x20) to the literal pool base (0x68) — distance = 72 bytes.
+//!
+//! Entry clear (#381): the thunk IS a JIT entry into another instance's
+//! runtime, and it was the only one that did not clear the trap fields on the
+//! way in — `entry.zig` does it for every host-driven entry, precisely so a
+//! previous run's flag cannot be read as this run's (#336 for the kind). The
+//! callee's `trap_flag`/`trap_kind` therefore stayed set after a cross-module
+//! trap, and once the relay below started READING them a later, successful
+//! call into that same exporter reported the old trap. Clearing on the way in
+//! is what makes the relay's read mean "this call".
 //!
 //! Trap relay (#381): a JIT trap is a FLAG, not an unwind — the trap stub
 //! writes `[X19 + trap_flag_off]` and returns, and every call site re-reads
@@ -110,11 +120,11 @@ comptime {
         @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; trap_flag_off is no longer 8-aligned");
 }
 
-/// Total thunk size in bytes (25 instructions × 4 bytes + a 4-byte
-/// pad that re-aligns the pool + 2 quad literals × 8 bytes = 120).
-/// Stable across all callee signatures. D-144 grew the thunk from
-/// 56 → 96 bytes to cover the full six-register reserved-invariant
-/// cohort; #381's trap relay grew it 96 → 120.
+/// Total thunk size in bytes (26 instructions × 4 bytes + 2 quad
+/// literals × 8 bytes = 120). Stable across all callee signatures.
+/// D-144 grew the thunk from 56 → 96 bytes to cover the full
+/// six-register reserved-invariant cohort; #381's entry clear + trap
+/// relay grew it 96 → 120.
 pub const thunk_bytes: usize = 120;
 
 /// #381 — frame slot the thunk parks `callee_rt` in across the call, so the
@@ -162,33 +172,37 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     // is corruptible across the call and X0 returns the callee's result, so
     // the relay below cannot recover it from either.
     std.mem.writeInt(u32, buf[40..44], inst.encStrImm(0, inst.sp_reg, callee_rt_slot), .little);
+    const flag_off: u15 = jit_abi.trap_flag_off;
+    // STR XZR, [X0, #40] — #381 entry clear: zero the callee's
+    // trap_flag|trap_kind pair while X0 still holds callee_rt, so the relay
+    // below reads THIS call's outcome and not a trap the exporter kept from
+    // an earlier one.
+    std.mem.writeInt(u32, buf[44..48], inst.encStrImm(inst.xzr, 0, flag_off), .little);
     // LDR X16, [X16, #8] — X16 ← callee_entry.
-    std.mem.writeInt(u32, buf[44..48], inst.encLdrImm(16, 16, 8), .little);
+    std.mem.writeInt(u32, buf[48..52], inst.encLdrImm(16, 16, 8), .little);
     // BLR X16 — CALL.
-    std.mem.writeInt(u32, buf[48..52], inst.encBlr(16), .little);
+    std.mem.writeInt(u32, buf[52..56], inst.encBlr(16), .little);
     // LDR X19..X28 — restore caller's reserved-invariant cohort.
-    std.mem.writeInt(u32, buf[52..56], inst.encLdrImm(19, inst.sp_reg, 16), .little);
-    std.mem.writeInt(u32, buf[56..60], inst.encLdrImm(24, inst.sp_reg, 24), .little);
-    std.mem.writeInt(u32, buf[60..64], inst.encLdrImm(25, inst.sp_reg, 32), .little);
-    std.mem.writeInt(u32, buf[64..68], inst.encLdrImm(26, inst.sp_reg, 40), .little);
-    std.mem.writeInt(u32, buf[68..72], inst.encLdrImm(27, inst.sp_reg, 48), .little);
-    std.mem.writeInt(u32, buf[72..76], inst.encLdrImm(28, inst.sp_reg, 56), .little);
+    std.mem.writeInt(u32, buf[56..60], inst.encLdrImm(19, inst.sp_reg, 16), .little);
+    std.mem.writeInt(u32, buf[60..64], inst.encLdrImm(24, inst.sp_reg, 24), .little);
+    std.mem.writeInt(u32, buf[64..68], inst.encLdrImm(25, inst.sp_reg, 32), .little);
+    std.mem.writeInt(u32, buf[68..72], inst.encLdrImm(26, inst.sp_reg, 40), .little);
+    std.mem.writeInt(u32, buf[72..76], inst.encLdrImm(27, inst.sp_reg, 48), .little);
+    std.mem.writeInt(u32, buf[76..80], inst.encLdrImm(28, inst.sp_reg, 56), .little);
     // #381 trap relay — X19 now holds caller_rt again, so the store below
     // lands on the CALLER. Reading and writing the same 8-byte offset carries
     // trap_flag AND trap_kind. Conditional, so a clean return cannot clear a
     // flag the caller already holds.
-    const flag_off: u15 = jit_abi.trap_flag_off;
-    std.mem.writeInt(u32, buf[76..80], inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), .little);
-    std.mem.writeInt(u32, buf[80..84], inst.encLdrImm(17, 16, flag_off), .little);
-    std.mem.writeInt(u32, buf[84..88], inst.encCbz(17, 2), .little); // → LDP
-    std.mem.writeInt(u32, buf[88..92], inst.encStrImm(17, 19, flag_off), .little);
+    std.mem.writeInt(u32, buf[80..84], inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), .little);
+    std.mem.writeInt(u32, buf[84..88], inst.encLdrImm(17, 16, flag_off), .little);
+    std.mem.writeInt(u32, buf[88..92], inst.encCbz(17, 2), .little); // → LDP
+    std.mem.writeInt(u32, buf[92..96], inst.encStrImm(17, 19, flag_off), .little);
     // LDP X29, X30, [SP], #80 — restore FP+LR, pop frame.
-    std.mem.writeInt(u32, buf[92..96], inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), .little);
+    std.mem.writeInt(u32, buf[96..100], inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), .little);
     // RET — return to importer's call site.
-    std.mem.writeInt(u32, buf[96..100], inst.encRet(30), .little);
-    // NOP — 25 instructions leave the pool 4-aligned; pad it back to 8.
-    std.mem.writeInt(u32, buf[100..104], inst.encNop(), .little);
-    // Literal pool at offset 0x68 (= 104).
+    std.mem.writeInt(u32, buf[100..104], inst.encRet(30), .little);
+    // Literal pool at offset 0x68 (= 104). The entry-clear STR consumed the
+    // alignment pad the relay had needed, so the pool stays 8-aligned.
     std.mem.writeInt(u64, buf[104..112], callee_rt, .little);
     std.mem.writeInt(u64, buf[112..120], callee_entry, .little);
 }
@@ -220,22 +234,23 @@ test "emitThunk: encoding round-trip via helpers" {
     try testing.expectEqual(inst.encAdr(16, 72), std.mem.readInt(u32, buf[32..36], .little));
     try testing.expectEqual(inst.encLdrImm(0, 16, 0), std.mem.readInt(u32, buf[36..40], .little));
     try testing.expectEqual(inst.encStrImm(0, inst.sp_reg, callee_rt_slot), std.mem.readInt(u32, buf[40..44], .little));
-    try testing.expectEqual(inst.encLdrImm(16, 16, 8), std.mem.readInt(u32, buf[44..48], .little));
-    try testing.expectEqual(inst.encBlr(16), std.mem.readInt(u32, buf[48..52], .little));
-    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
-    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[56..60], .little));
-    try testing.expectEqual(inst.encLdrImm(25, inst.sp_reg, 32), std.mem.readInt(u32, buf[60..64], .little));
-    try testing.expectEqual(inst.encLdrImm(26, inst.sp_reg, 40), std.mem.readInt(u32, buf[64..68], .little));
-    try testing.expectEqual(inst.encLdrImm(27, inst.sp_reg, 48), std.mem.readInt(u32, buf[68..72], .little));
-    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[72..76], .little));
+    // #381 entry clear.
+    try testing.expectEqual(inst.encStrImm(inst.xzr, 0, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[44..48], .little));
+    try testing.expectEqual(inst.encLdrImm(16, 16, 8), std.mem.readInt(u32, buf[48..52], .little));
+    try testing.expectEqual(inst.encBlr(16), std.mem.readInt(u32, buf[52..56], .little));
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[56..60], .little));
+    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[60..64], .little));
+    try testing.expectEqual(inst.encLdrImm(25, inst.sp_reg, 32), std.mem.readInt(u32, buf[64..68], .little));
+    try testing.expectEqual(inst.encLdrImm(26, inst.sp_reg, 40), std.mem.readInt(u32, buf[68..72], .little));
+    try testing.expectEqual(inst.encLdrImm(27, inst.sp_reg, 48), std.mem.readInt(u32, buf[72..76], .little));
+    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[76..80], .little));
     // #381 trap relay.
-    try testing.expectEqual(inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), std.mem.readInt(u32, buf[76..80], .little));
-    try testing.expectEqual(inst.encLdrImm(17, 16, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[80..84], .little));
-    try testing.expectEqual(inst.encCbz(17, 2), std.mem.readInt(u32, buf[84..88], .little));
-    try testing.expectEqual(inst.encStrImm(17, 19, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[88..92], .little));
-    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[92..96], .little));
-    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[96..100], .little));
-    try testing.expectEqual(inst.encNop(), std.mem.readInt(u32, buf[100..104], .little));
+    try testing.expectEqual(inst.encLdrImm(16, inst.sp_reg, callee_rt_slot), std.mem.readInt(u32, buf[80..84], .little));
+    try testing.expectEqual(inst.encLdrImm(17, 16, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[84..88], .little));
+    try testing.expectEqual(inst.encCbz(17, 2), std.mem.readInt(u32, buf[88..92], .little));
+    try testing.expectEqual(inst.encStrImm(17, 19, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[92..96], .little));
+    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[96..100], .little));
+    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[100..104], .little));
     try testing.expectEqual(callee_rt, std.mem.readInt(u64, buf[104..112], .little));
     try testing.expectEqual(callee_entry, std.mem.readInt(u64, buf[112..120], .little));
 }
@@ -248,15 +263,18 @@ test "emitThunk: encoding round-trip via helpers" {
 test "emitThunk: the trap relay reads the callee's runtime and writes the caller's (#381)" {
     var buf: [thunk_bytes]u8 = undefined;
     emitThunk(&buf, 0, 0);
-    const load = std.mem.readInt(u32, buf[80..84], .little);
-    const store = std.mem.readInt(u32, buf[88..92], .little);
+    const load = std.mem.readInt(u32, buf[84..88], .little);
+    const store = std.mem.readInt(u32, buf[92..96], .little);
     // Load base = X16 (the parked callee_rt); store base = X19 (caller_rt).
     try testing.expectEqual(inst.encLdrImm(17, 16, jit_abi.trap_flag_off), load);
     try testing.expectEqual(inst.encStrImm(17, 19, jit_abi.trap_flag_off), store);
     // The X19 restore precedes the store — otherwise it would land on the callee.
-    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
-    // CBZ +2 words from byte 84 = byte 92 = the LDP epilogue.
-    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[84 + 2 * 4 ..][0..4], .little));
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[56..60], .little));
+    // CBZ +2 words from byte 88 = byte 96 = the LDP epilogue.
+    try testing.expectEqual(inst.encLdpPostIdx(29, 30, inst.sp_reg, 80), std.mem.readInt(u32, buf[88 + 2 * 4 ..][0..4], .little));
+    // The entry clear zeroes the CALLEE's pair (base X0 = callee_rt) before the
+    // call, so the load above cannot see an earlier call's trap.
+    try testing.expectEqual(inst.encStrImm(inst.xzr, 0, jit_abi.trap_flag_off), std.mem.readInt(u32, buf[44..48], .little));
 }
 
 test "emitThunk: round-trip literals at zero" {
@@ -266,7 +284,7 @@ test "emitThunk: round-trip literals at zero" {
     try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[112..120], .little));
     // Instruction prefix unchanged regardless of literals.
     try testing.expectEqual(inst.encStpPreIdx(29, 30, inst.sp_reg, -80), std.mem.readInt(u32, buf[0..4], .little));
-    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[96..100], .little));
+    try testing.expectEqual(inst.encRet(30), std.mem.readInt(u32, buf[100..104], .little));
 }
 
 test "emitThunk: instruction prefix is constant across two distinct callees" {
@@ -293,8 +311,8 @@ test "emitThunk: saves/restores X19+X24..X28 around BLR" {
     try testing.expectEqual(inst.encStrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[8..12], .little));
     try testing.expectEqual(inst.encStrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[12..16], .little));
     try testing.expectEqual(inst.encStrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[28..32], .little));
-    // Post-BLR restores at offsets 52..76 (shifted +4 by the #381 STR X0).
-    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[52..56], .little));
-    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[56..60], .little));
-    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[72..76], .little));
+    // Post-BLR restores at offsets 56..80 (shifted +8 by the two #381 stores).
+    try testing.expectEqual(inst.encLdrImm(19, inst.sp_reg, 16), std.mem.readInt(u32, buf[56..60], .little));
+    try testing.expectEqual(inst.encLdrImm(24, inst.sp_reg, 24), std.mem.readInt(u32, buf[60..64], .little));
+    try testing.expectEqual(inst.encLdrImm(28, inst.sp_reg, 56), std.mem.readInt(u32, buf[76..80], .little));
 }

--- a/src/engine/codegen/shared/thunk.zig
+++ b/src/engine/codegen/shared/thunk.zig
@@ -35,17 +35,27 @@ const arch_thunk = switch (builtin.target.cpu.arch) {
 };
 
 /// Bridge thunk byte count for the current target architecture.
-/// Per ADR-0066 Amendment §A1 (D-142 fix (A)):
-/// - 56 bytes on AArch64 (9 instructions + 4-byte alignment pad
-///   + 16-byte literal pool); call-and-return shape preserving
-///   caller's X19 across the BLR.
-/// - 40 bytes on x86_64 (PUSH RBP + MOV RBP,RSP + PUSH R15 + SUB
-///   RSP,8 + 2× MOV imm64 + CALL RAX + ADD RSP,8 + POP R15 + POP
-///   RBP + RET); call-and-return shape preserving caller's R15
-///   across the CALL + an RBP frame-link for cross-instance EH
-///   unwinding (D-238 / ADR-0185 a).
-/// Stable across all callee signatures — every thunk has the
-/// same shape; only the embedded literals differ.
+/// Stable across all callee signatures — every thunk has the same
+/// shape; only the embedded literals differ.
+///
+/// The per-arch modules own the layout and its byte count; this
+/// facade deliberately does NOT restate either. Both numbers have
+/// moved three times (D-144 grew arm64 56 → 96; D-238 / ADR-0185 a
+/// grew x86_64 27 → 40; #381 grew x86_64 40 → 79) and the copy
+/// here was stale for two of them.
+///
+/// What IS this facade's contract, and holds on both arches:
+/// - **Call-and-return**, not a tail-jump (D-142 fix (A)): the
+///   thunk CALLs the callee and returns to the importer, so it can
+///   restore state around the call.
+/// - The caller's runtime pointer (arm64 X19 / x86_64 R15) and the
+///   rest of the reserved-invariant cohort survive the call.
+/// - The callee's `trap_flag`/`trap_kind` are cleared on the way in
+///   and relayed onto the caller's runtime on the way out (#381), so
+///   a trap raised inside the callee reaches the importer's existing
+///   post-call check.
+/// - An RBP / X29 frame-link makes the thunk frame a chain link for
+///   the cross-instance EH unwinder (D-238 / ADR-0185 a, ADR-0134 D1).
 pub const thunk_bytes: usize = arch_thunk.thunk_bytes;
 
 /// Emit one bridge thunk into `buf[0..thunk_bytes]`. `buf` MUST
@@ -55,9 +65,12 @@ pub const thunk_bytes: usize = arch_thunk.thunk_bytes;
 /// (c)-2.2 thunk-arena lifecycle chunk).
 ///
 /// `callee_rt`    — the callee instance's `*JitRuntime` cast to
-///                  `usize` (the address that will be installed
-///                  in the runtime-ptr register before the
-///                  tail-jump: X0 on AArch64, RDI on x86_64).
+///                  `usize`, installed in the entry-arg0 register
+///                  before the CALL so the callee's prologue
+///                  snapshots it into its own runtime-ptr register.
+///                  X0 on AArch64; on x86_64 the encoder writes RDI
+///                  unconditionally, which is entry-arg0 under SysV
+///                  ONLY — see the x86_64 module's Win64 note.
 /// `callee_entry` — the callee's JIT entry point address (the
 ///                  first instruction of the callee function's
 ///                  body in its module's JIT code block).

--- a/src/engine/codegen/shared/thunk.zig
+++ b/src/engine/codegen/shared/thunk.zig
@@ -190,7 +190,7 @@ const testing = std.testing;
 test "thunk_bytes: matches arch-specific constant" {
     switch (builtin.target.cpu.arch) {
         .aarch64 => try testing.expectEqual(@as(usize, 120), thunk_bytes), // #381: 96→120 (trap relay)
-        .x86_64 => try testing.expectEqual(@as(usize, 69), thunk_bytes), // D-238/ADR-0185 a: 27→40 (RBP frame-link); #381: 40→69 (trap relay)
+        .x86_64 => try testing.expectEqual(@as(usize, 79), thunk_bytes), // D-238/ADR-0185 a: 27→40 (RBP frame-link); #381: 40→79 (entry clear + trap relay)
         else => unreachable,
     }
 }

--- a/src/engine/codegen/shared/thunk.zig
+++ b/src/engine/codegen/shared/thunk.zig
@@ -189,8 +189,8 @@ const testing = std.testing;
 
 test "thunk_bytes: matches arch-specific constant" {
     switch (builtin.target.cpu.arch) {
-        .aarch64 => try testing.expectEqual(@as(usize, 96), thunk_bytes),
-        .x86_64 => try testing.expectEqual(@as(usize, 40), thunk_bytes), // D-238/ADR-0185 a: 27→40 (RBP frame-link)
+        .aarch64 => try testing.expectEqual(@as(usize, 120), thunk_bytes), // #381: 96→120 (trap relay)
+        .x86_64 => try testing.expectEqual(@as(usize, 69), thunk_bytes), // D-238/ADR-0185 a: 27→40 (RBP frame-link); #381: 40→69 (trap relay)
         else => unreachable,
     }
 }

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -77,6 +77,22 @@
 //! (`op_call.zig:reloadHomedCallerSaved`), so clobbering them here is free.
 //! The return-value registers (RAX/RDX/XMM0/XMM1) are untouched.
 //!
+//! **This encoder is SysV-only, and that is a live Win64 defect (#385).**
+//! `MOV RDI, callee_rt` is entry-arg0 under SysV; under Win64 entry-arg0 is
+//! RCX (`abi.win64.entry_arg0_gpr`), and `op_call.zig:emitImportDispatch`
+//! leaves the IMPORTER's runtime there on the way into this thunk — so on
+//! Windows the callee's prologue snapshots the importer's runtime, not the
+//! exporter's. Two more Cc gaps ride along: RDI is callee-saved AND
+//! allocatable under Win64 (`abi.win64.allocatable_gprs`), so writing it here
+//! destroys a live importer register; and the CALL below reserves no Win64
+//! shadow space, whose home area would land on this thunk's own saved
+//! RBP/R15 and return address. All three predate the #381 relay and are
+//! tracked in #385 rather than widened into it — the relay is unaffected
+//! (it addresses the callee's runtime by immediate, not by arg register),
+//! but a green Windows CI leg on a cross-module trap test is NOT evidence
+//! that the callee ran on its own runtime: the trap reaches the importer
+//! either way, because on Win64 it was the importer's runtime all along.
+//!
 //! SysV AMD64 §3.2.1 invariant: RBX, RBP, R12..R15 are callee-saved.
 //! v2's JIT prologue (per ADR-0026 Cc-pivot) overwrites R15 with the
 //! new `*JitRuntime` argument WITHOUT first stack-saving the caller's

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -26,23 +26,34 @@
 //! 0x04    41 57                               PUSH R15           ; save caller's R15 (= caller_rt)
 //! 0x06    48 83 EC 08                         SUB  RSP, 8        ; alignment pad
 //! 0x0A    48 BF <callee_rt LE 8 bytes>        MOV  RDI, imm64    ; SysV arg0
-//! 0x14    48 B8 <callee_entry LE 8 bytes>     MOV  RAX, imm64
-//! 0x1E    FF D0                               CALL RAX           ; SysV CALL (RSP 16-aligned here)
-//! 0x20    48 83 C4 08                         ADD  RSP, 8        ; undo pad
-//! 0x24    41 5F                               POP  R15           ; restore caller's R15
-//! 0x26    49 BB <callee_rt LE 8 bytes>        MOV  R11, imm64    ; #381 trap relay: callee_rt
-//! 0x30    4D 8B 93 <40 LE4>                   MOV  R10, [R11+40] ; trap_flag|trap_kind pair
-//! 0x37    4D 85 D2                            TEST R10, R10
-//! 0x3A    74 07                               JE   +7            ; no trap -> skip
-//! 0x3C    4D 89 97 <40 LE4>                   MOV  [R15+40], R10 ; relay onto the CALLER
-//! 0x43    5D                                  POP  RBP           ; restore importer's RBP
-//! 0x44    C3                                  RET                ; return to importer
+//! 0x14    45 31 D2                            XOR  R10D, R10D    ; #381 entry clear
+//! 0x17    4C 89 97 <40 LE4>                   MOV  [RDI+40], R10 ; clear callee trap_flag|kind
+//! 0x1E    48 B8 <callee_entry LE 8 bytes>     MOV  RAX, imm64
+//! 0x28    FF D0                               CALL RAX           ; SysV CALL (RSP 16-aligned here)
+//! 0x2A    48 83 C4 08                         ADD  RSP, 8        ; undo pad
+//! 0x2E    41 5F                               POP  R15           ; restore caller's R15
+//! 0x30    49 BB <callee_rt LE 8 bytes>        MOV  R11, imm64    ; #381 trap relay: callee_rt
+//! 0x3A    4D 8B 93 <40 LE4>                   MOV  R10, [R11+40] ; trap_flag|trap_kind pair
+//! 0x41    4D 85 D2                            TEST R10, R10
+//! 0x44    74 07                               JE   +7            ; no trap -> skip
+//! 0x46    4D 89 97 <40 LE4>                   MOV  [R15+40], R10 ; relay onto the CALLER
+//! 0x4D    5D                                  POP  RBP           ; restore importer's RBP
+//! 0x4E    C3                                  RET                ; return to importer
 //! ```
 //!
-//! 1 + 3 + 2 + 4 + 10 + 10 + 2 + 4 + 2 + 10 + 7 + 3 + 2 + 7 + 1 + 1 = 69
-//! bytes total. The literals are embedded directly in the MOV imm64
+//! 1 + 3 + 2 + 4 + 10 + 3 + 7 + 10 + 2 + 4 + 2 + 10 + 7 + 3 + 2 + 7 + 1 + 1 =
+//! 79 bytes total. The literals are embedded directly in the MOV imm64
 //! instructions (no separate pool), so the thunk is position-independent:
 //! relocate to any byte-aligned RX page without patching.
+//!
+//! Entry clear (#381): the thunk IS a JIT entry into another instance's
+//! runtime, and it was the only one that did not clear the trap fields on the
+//! way in — `entry.zig` does it for every host-driven entry, precisely so a
+//! previous run's flag cannot be read as this run's (#336 for the kind). The
+//! callee's `trap_flag`/`trap_kind` therefore stayed set after a cross-module
+//! trap, and once the relay below started READING them a later, successful
+//! call into that same exporter reported the old trap. Clearing on the way in
+//! is what makes the relay's read mean "this call".
 //!
 //! Trap relay (#381): a JIT trap is a FLAG, not an unwind — the trap stub
 //! writes `[R15 + trap_flag_off]` and RETs (`op_control.zig:emitTrapExitStub`),
@@ -100,10 +111,10 @@ comptime {
 
 /// Total thunk size in bytes (PUSH RBP [1] + MOV RBP,RSP [3] + PUSH
 /// R15 [2] + SUB RSP,8 [4] + MOV RDI imm64 [10] + MOV RAX imm64 [10]
-/// + CALL RAX [2] + ADD RSP,8 [4] + POP R15 [2] + #381 trap relay
-/// [10+7+3+2+7 = 29] + POP RBP [1] + RET [1] = 69). Stable across all
-/// callee signatures.
-pub const thunk_bytes: usize = 69;
+/// + #381 entry clear [3+7 = 10] + MOV RAX imm64 [10] + CALL RAX [2] +
+/// ADD RSP,8 [4] + POP R15 [2] + #381 trap relay [10+7+3+2+7 = 29] +
+/// POP RBP [1] + RET [1] = 79). Stable across all callee signatures.
+pub const thunk_bytes: usize = 79;
 
 /// Emit one bridge thunk into `buf[0..thunk_bytes]`. `buf` MUST be
 /// exactly `thunk_bytes` long; the caller is responsible for
@@ -124,30 +135,35 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     // SUB RSP, 8 — alignment pad (two pushes left RSP ≡ 8; restore ≡ 0
     // so the CALL below is SysV 16-aligned).
     @memcpy(buf[6..10], inst.encSubRSpImm8(8).slice());
+    const flag_off: i32 = jit_abi.trap_flag_off;
     // MOV RDI, callee_rt — SysV arg0 (= *JitRuntime).
     @memcpy(buf[10..20], inst.encMovImm64Q(.rdi, callee_rt).slice());
+    // #381 entry clear — zero the callee's trap_flag|trap_kind pair while RDI
+    // still holds callee_rt, so the relay below reads THIS call's outcome and
+    // not a trap the exporter kept from an earlier one.
+    @memcpy(buf[20..23], inst.encXorRR(.d, .r10, .r10).slice());
+    @memcpy(buf[23..30], inst.encStoreR64MemDisp32(.r10, .rdi, flag_off).slice());
     // MOV RAX, callee_entry.
-    @memcpy(buf[20..30], inst.encMovImm64Q(.rax, callee_entry).slice());
+    @memcpy(buf[30..40], inst.encMovImm64Q(.rax, callee_entry).slice());
     // CALL RAX — SysV CALL (not JMP); pushes post-CALL RIP so the
     // callee's RET returns here.
-    @memcpy(buf[30..32], inst.encCallReg(.rax).slice());
+    @memcpy(buf[40..42], inst.encCallReg(.rax).slice());
     // ADD RSP, 8 — undo the alignment pad.
-    @memcpy(buf[32..36], inst.encAddRSpImm8(8).slice());
+    @memcpy(buf[42..46], inst.encAddRSpImm8(8).slice());
     // POP R15 — RESTORE caller's R15. Everything below relays onto it, so it
     // must come after this and not before.
-    @memcpy(buf[36..38], inst.encPopR(.r15).slice());
+    @memcpy(buf[46..48], inst.encPopR(.r15).slice());
 
     // #381 trap relay. R11 <- callee_rt (RDI was clobbered by the callee);
     // R10 <- the callee's trap_flag|trap_kind pair; store it onto the caller
     // only when the callee actually trapped, so a clean return cannot clear a
     // flag the caller already holds.
-    const flag_off: i32 = jit_abi.trap_flag_off;
     const relay_load = inst.encMovR64FromMemDisp32(.r10, .r11, flag_off);
     const relay_test = inst.encTestRR(.q, .r10, .r10);
     const relay_store = inst.encStoreR64MemDisp32(.r10, .r15, flag_off);
     // JE skips exactly the store — its own encoded length, not a literal.
     const relay_skip = inst.encJccRel8(.e, @intCast(relay_store.len));
-    var off: usize = 38;
+    var off: usize = 48;
     for ([_]inst.EncodedInsn{
         inst.encMovImm64Q(.r11, callee_rt),
         relay_load,
@@ -192,6 +208,10 @@ test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
         0xEF, 0xBE,
         0xAD, 0xDE,
     }, buf[10..20]);
+    // #381 entry clear — XOR R10D,R10D (REX.RB=45) then MOV [RDI+40], R10
+    // (REX.WR=4C, 89, mod=10 reg=r10(2) rm=rdi(7) = 97).
+    try testing.expectEqualSlices(u8, &.{ 0x45, 0x31, 0xD2 }, buf[20..23]);
+    try testing.expectEqualSlices(u8, &.{ 0x4C, 0x89, 0x97, 0x28, 0x00, 0x00, 0x00 }, buf[23..30]);
     // MOV RAX, callee_entry — REX.W (48) + B8+rax.low3=0=B8 + LE imm64
     try testing.expectEqualSlices(u8, &.{
         0x48, 0xB8,
@@ -199,10 +219,10 @@ test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
         0xBC, 0x9A,
         0x78, 0x56,
         0x34, 0x12,
-    }, buf[20..30]);
-    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]); // CALL RAX
-    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[32..36]); // ADD RSP,8
-    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]); // POP R15
+    }, buf[30..40]);
+    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[40..42]); // CALL RAX
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[42..46]); // ADD RSP,8
+    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[46..48]); // POP R15
     // #381 trap relay — MOV R11, callee_rt (REX.WB=49 + B8+r11.low3=3 = BB).
     try testing.expectEqualSlices(u8, &.{
         0x49, 0xBB,
@@ -210,15 +230,15 @@ test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
         0xFE, 0xCA,
         0xEF, 0xBE,
         0xAD, 0xDE,
-    }, buf[38..48]);
+    }, buf[48..58]);
     // MOV R10, [R11+40] — REX.WRB=4D, 8B, mod=10 reg=r10(2) rm=r11(3) = 93.
-    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x8B, 0x93, 0x28, 0x00, 0x00, 0x00 }, buf[48..55]);
-    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x85, 0xD2 }, buf[55..58]); // TEST R10,R10
-    try testing.expectEqualSlices(u8, &.{ 0x74, 0x07 }, buf[58..60]); // JE +7 (skips the store)
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x8B, 0x93, 0x28, 0x00, 0x00, 0x00 }, buf[58..65]);
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x85, 0xD2 }, buf[65..68]); // TEST R10,R10
+    try testing.expectEqualSlices(u8, &.{ 0x74, 0x07 }, buf[68..70]); // JE +7 (skips the store)
     // MOV [R15+40], R10 — REX.WRB=4D, 89, mod=10 reg=r10(2) rm=r15(7) = 97.
-    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x89, 0x97, 0x28, 0x00, 0x00, 0x00 }, buf[60..67]);
-    try testing.expectEqual(@as(u8, 0x5D), buf[67]); // POP RBP
-    try testing.expectEqual(@as(u8, 0xC3), buf[68]); // RET
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x89, 0x97, 0x28, 0x00, 0x00, 0x00 }, buf[70..77]);
+    try testing.expectEqual(@as(u8, 0x5D), buf[77]); // POP RBP
+    try testing.expectEqual(@as(u8, 0xC3), buf[78]); // RET
 }
 
 // #381 — the relay's two load-bearing properties, stated apart from the
@@ -234,7 +254,15 @@ test "emitThunk: the trap relay reads the callee's runtime and writes the caller
     const store = inst.encStoreR64MemDisp32(.r10, .r15, flag_off);
     const skip = inst.encJccRel8(.e, @intCast(store.len));
     // The relay tail runs from `POP R15` to `POP RBP`, in this exact order.
-    const relay_start = 38 + inst.encMovImm64Q(.r11, 0).len;
+    const relay_start = 48 + inst.encMovImm64Q(.r11, 0).len;
+    // The entry clear zeroes the CALLEE's pair before the call, so the read
+    // above cannot see a trap the exporter kept from an earlier call.
+    try testing.expectEqualSlices(u8, inst.encXorRR(.d, .r10, .r10).slice(), buf[20..23]);
+    try testing.expectEqualSlices(
+        u8,
+        inst.encStoreR64MemDisp32(.r10, .rdi, flag_off).slice(),
+        buf[23..30],
+    );
     try testing.expectEqualSlices(u8, load.slice(), buf[relay_start..][0..load.len]);
     try testing.expectEqualSlices(u8, inst.encTestRR(.q, .r10, .r10).slice(), buf[relay_start + load.len ..][0..3]);
     try testing.expectEqualSlices(u8, skip.slice(), buf[relay_start + load.len + 3 ..][0..skip.len]);
@@ -254,15 +282,15 @@ test "emitThunk: round-trip literals at zero" {
     try testing.expectEqual(@as(u8, 0x48), buf[10]);
     try testing.expectEqual(@as(u8, 0xBF), buf[11]);
     try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[12..20], .little));
-    try testing.expectEqual(@as(u8, 0x48), buf[20]);
-    try testing.expectEqual(@as(u8, 0xB8), buf[21]);
-    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[22..30], .little));
-    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]);
-    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[32..36]);
-    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]);
+    try testing.expectEqual(@as(u8, 0x48), buf[30]);
+    try testing.expectEqual(@as(u8, 0xB8), buf[31]);
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[32..40], .little));
+    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[40..42]);
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[42..46]);
+    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[46..48]);
     // #381 relay: the callee_rt literal is the third imm64 field and zeroes too.
-    try testing.expectEqualSlices(u8, &.{ 0x49, 0xBB }, buf[38..40]);
-    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[40..48], .little));
+    try testing.expectEqualSlices(u8, &.{ 0x49, 0xBB }, buf[48..50]);
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[50..58], .little));
     try testing.expectEqual(@as(u8, 0x5D), buf[thunk_bytes - 2]);
     try testing.expectEqual(@as(u8, 0xC3), buf[thunk_bytes - 1]);
 }
@@ -275,8 +303,9 @@ test "emitThunk: opcode/frame bytes constant across two distinct callees" {
     // Frame + opcode bytes at fixed offsets must match across thunks
     // (ADR-0066 §A1 + ADR-0185 a invariant); only the imm64 literals differ.
     try testing.expectEqualSlices(u8, buf_a[0..12], buf_b[0..12]); // frame + MOV RDI opcode
-    try testing.expectEqualSlices(u8, buf_a[20..22], buf_b[20..22]); // MOV RAX opcode
-    try testing.expectEqualSlices(u8, buf_a[30..40], buf_b[30..40]); // CALL + ADD + POP + POP + RET
+    try testing.expectEqualSlices(u8, buf_a[20..32], buf_b[20..32]); // entry clear + MOV RAX opcode
+    try testing.expectEqualSlices(u8, buf_a[40..48], buf_b[40..48]); // CALL + ADD + POP R15
+    try testing.expectEqualSlices(u8, buf_a[58..79], buf_b[58..79]); // relay + POP RBP + RET
 }
 
 test "emitThunk: D-142 R15 save/restore + D-238 RBP frame around CALL" {
@@ -290,8 +319,8 @@ test "emitThunk: D-142 R15 save/restore + D-238 RBP frame around CALL" {
     try testing.expectEqual(@as(u8, 0x55), buf[0]); // PUSH RBP
     try testing.expectEqualSlices(u8, &.{ 0x48, 0x89, 0xE5 }, buf[1..4]); // MOV RBP,RSP
     try testing.expectEqualSlices(u8, &.{ 0x41, 0x57 }, buf[4..6]); // PUSH R15
-    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]); // CALL RAX
-    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]); // POP R15
+    try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[40..42]); // CALL RAX
+    try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[46..48]); // POP R15
     try testing.expectEqual(@as(u8, 0x5D), buf[thunk_bytes - 2]); // POP RBP
     try testing.expectEqual(@as(u8, 0xC3), buf[thunk_bytes - 1]); // RET
 }

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -30,14 +30,41 @@
 //! 0x1E    FF D0                               CALL RAX           ; SysV CALL (RSP 16-aligned here)
 //! 0x20    48 83 C4 08                         ADD  RSP, 8        ; undo pad
 //! 0x24    41 5F                               POP  R15           ; restore caller's R15
-//! 0x26    5D                                  POP  RBP           ; restore importer's RBP
-//! 0x27    C3                                  RET                ; return to importer
+//! 0x26    49 BB <callee_rt LE 8 bytes>        MOV  R11, imm64    ; #381 trap relay: callee_rt
+//! 0x30    4D 8B 93 <40 LE4>                   MOV  R10, [R11+40] ; trap_flag|trap_kind pair
+//! 0x37    4D 85 D2                            TEST R10, R10
+//! 0x3A    74 07                               JE   +7            ; no trap -> skip
+//! 0x3C    4D 89 97 <40 LE4>                   MOV  [R15+40], R10 ; relay onto the CALLER
+//! 0x43    5D                                  POP  RBP           ; restore importer's RBP
+//! 0x44    C3                                  RET                ; return to importer
 //! ```
 //!
-//! 1 + 3 + 2 + 4 + 10 + 10 + 2 + 4 + 2 + 1 + 1 = 40 bytes total. The
-//! literals are embedded directly in the MOV imm64 instructions (no
-//! separate pool), so the thunk is position-independent: relocate to
-//! any byte-aligned RX page without patching.
+//! 1 + 3 + 2 + 4 + 10 + 10 + 2 + 4 + 2 + 10 + 7 + 3 + 2 + 7 + 1 + 1 = 69
+//! bytes total. The literals are embedded directly in the MOV imm64
+//! instructions (no separate pool), so the thunk is position-independent:
+//! relocate to any byte-aligned RX page without patching.
+//!
+//! Trap relay (#381): a JIT trap is a FLAG, not an unwind — the trap stub
+//! writes `[R15 + trap_flag_off]` and RETs (`op_control.zig:emitTrapExitStub`),
+//! and every call site re-reads that flag afterwards
+//! (`op_control.zig:emitPostCallTrapCheck`, ADR-0199 / D-468). Inside the
+//! thunk R15 is the CALLEE's runtime, so a trap raised in the callee lands in
+//! a runtime the importer never reads: `wasm_func_call` reported success and
+//! the importer ran on past a call that returned nothing. The five
+//! instructions at 0x26..0x42 copy the callee's flag onto the caller AFTER
+//! `POP R15` has restored `caller_rt`, so the importer's existing post-call
+//! check fires unchanged — no call-site codegen changes.
+//!
+//! `trap_flag` (u32 @40) and `trap_kind` (u32 @44) are adjacent, so ONE
+//! 8-byte load/store carries both; the kind matters because a relay that
+//! moved only the flag would report every cross-module trap as kind 0. The
+//! adjacency is asserted at comptime below.
+//!
+//! R10/R11 are volatile in BOTH SysV and Win64 and are not in the
+//! reserved-invariant set (`abi.zig:reserved_invariant_gprs` = {R15}), and the
+//! call site reloads its homed caller-saved registers AFTER the call returns
+//! (`op_call.zig:reloadHomedCallerSaved`), so clobbering them here is free.
+//! The return-value registers (RAX/RDX/XMM0/XMM1) are untouched.
 //!
 //! SysV AMD64 §3.2.1 invariant: RBX, RBP, R12..R15 are callee-saved.
 //! v2's JIT prologue (per ADR-0026 Cc-pivot) overwrites R15 with the
@@ -61,12 +88,22 @@
 
 const std = @import("std");
 const inst = @import("inst.zig");
+const jit_abi = @import("../shared/jit_abi.zig");
+
+comptime {
+    // The relay below copies `trap_flag` and `trap_kind` as one 8-byte pair.
+    if (jit_abi.trap_kind_off != jit_abi.trap_flag_off + 4)
+        @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; they are no longer adjacent");
+    if (jit_abi.trap_flag_off % 8 != 0)
+        @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; trap_flag_off is no longer 8-aligned");
+}
 
 /// Total thunk size in bytes (PUSH RBP [1] + MOV RBP,RSP [3] + PUSH
 /// R15 [2] + SUB RSP,8 [4] + MOV RDI imm64 [10] + MOV RAX imm64 [10]
-/// + CALL RAX [2] + ADD RSP,8 [4] + POP R15 [2] + POP RBP [1] + RET
-/// [1] = 40). Stable across all callee signatures.
-pub const thunk_bytes: usize = 40;
+/// + CALL RAX [2] + ADD RSP,8 [4] + POP R15 [2] + #381 trap relay
+/// [10+7+3+2+7 = 29] + POP RBP [1] + RET [1] = 69). Stable across all
+/// callee signatures.
+pub const thunk_bytes: usize = 69;
 
 /// Emit one bridge thunk into `buf[0..thunk_bytes]`. `buf` MUST be
 /// exactly `thunk_bytes` long; the caller is responsible for
@@ -96,12 +133,39 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     @memcpy(buf[30..32], inst.encCallReg(.rax).slice());
     // ADD RSP, 8 — undo the alignment pad.
     @memcpy(buf[32..36], inst.encAddRSpImm8(8).slice());
-    // POP R15 — RESTORE caller's R15.
+    // POP R15 — RESTORE caller's R15. Everything below relays onto it, so it
+    // must come after this and not before.
     @memcpy(buf[36..38], inst.encPopR(.r15).slice());
+
+    // #381 trap relay. R11 <- callee_rt (RDI was clobbered by the callee);
+    // R10 <- the callee's trap_flag|trap_kind pair; store it onto the caller
+    // only when the callee actually trapped, so a clean return cannot clear a
+    // flag the caller already holds.
+    const flag_off: i32 = jit_abi.trap_flag_off;
+    const relay_load = inst.encMovR64FromMemDisp32(.r10, .r11, flag_off);
+    const relay_test = inst.encTestRR(.q, .r10, .r10);
+    const relay_store = inst.encStoreR64MemDisp32(.r10, .r15, flag_off);
+    // JE skips exactly the store — its own encoded length, not a literal.
+    const relay_skip = inst.encJccRel8(.e, @intCast(relay_store.len));
+    var off: usize = 38;
+    for ([_]inst.EncodedInsn{
+        inst.encMovImm64Q(.r11, callee_rt),
+        relay_load,
+        relay_test,
+        relay_skip,
+        relay_store,
+    }) |e| {
+        @memcpy(buf[off..][0..e.len], e.slice());
+        off += e.len;
+    }
+
     // POP RBP — RESTORE importer's RBP.
-    @memcpy(buf[38..39], inst.encPopR(.rbp).slice());
+    @memcpy(buf[off..][0..1], inst.encPopR(.rbp).slice());
+    off += 1;
     // RET — return to importer's call site.
-    @memcpy(buf[39..40], inst.encRet().slice());
+    @memcpy(buf[off..][0..1], inst.encRet().slice());
+    off += 1;
+    std.debug.assert(off == thunk_bytes);
 }
 
 // ============================================================
@@ -139,8 +203,44 @@ test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
     try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]); // CALL RAX
     try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[32..36]); // ADD RSP,8
     try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]); // POP R15
-    try testing.expectEqual(@as(u8, 0x5D), buf[38]); // POP RBP
-    try testing.expectEqual(@as(u8, 0xC3), buf[39]); // RET
+    // #381 trap relay — MOV R11, callee_rt (REX.WB=49 + B8+r11.low3=3 = BB).
+    try testing.expectEqualSlices(u8, &.{
+        0x49, 0xBB,
+        0xBE, 0xBA,
+        0xFE, 0xCA,
+        0xEF, 0xBE,
+        0xAD, 0xDE,
+    }, buf[38..48]);
+    // MOV R10, [R11+40] — REX.WRB=4D, 8B, mod=10 reg=r10(2) rm=r11(3) = 93.
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x8B, 0x93, 0x28, 0x00, 0x00, 0x00 }, buf[48..55]);
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x85, 0xD2 }, buf[55..58]); // TEST R10,R10
+    try testing.expectEqualSlices(u8, &.{ 0x74, 0x07 }, buf[58..60]); // JE +7 (skips the store)
+    // MOV [R15+40], R10 — REX.WRB=4D, 89, mod=10 reg=r10(2) rm=r15(7) = 97.
+    try testing.expectEqualSlices(u8, &.{ 0x4D, 0x89, 0x97, 0x28, 0x00, 0x00, 0x00 }, buf[60..67]);
+    try testing.expectEqual(@as(u8, 0x5D), buf[67]); // POP RBP
+    try testing.expectEqual(@as(u8, 0xC3), buf[68]); // RET
+}
+
+// #381 — the relay's two load-bearing properties, stated apart from the
+// byte-exact layout so a future reshuffle that keeps the bytes but loses the
+// meaning still fails: the JE skips EXACTLY the store (a wrong displacement
+// lands mid-instruction), and the store targets the CALLER's runtime register
+// while the load reads the callee's, at the SAME offset.
+test "emitThunk: the trap relay reads the callee's runtime and writes the caller's (#381)" {
+    var buf: [thunk_bytes]u8 = undefined;
+    emitThunk(&buf, 0, 0);
+    const flag_off: i32 = jit_abi.trap_flag_off;
+    const load = inst.encMovR64FromMemDisp32(.r10, .r11, flag_off);
+    const store = inst.encStoreR64MemDisp32(.r10, .r15, flag_off);
+    const skip = inst.encJccRel8(.e, @intCast(store.len));
+    // The relay tail runs from `POP R15` to `POP RBP`, in this exact order.
+    const relay_start = 38 + inst.encMovImm64Q(.r11, 0).len;
+    try testing.expectEqualSlices(u8, load.slice(), buf[relay_start..][0..load.len]);
+    try testing.expectEqualSlices(u8, inst.encTestRR(.q, .r10, .r10).slice(), buf[relay_start + load.len ..][0..3]);
+    try testing.expectEqualSlices(u8, skip.slice(), buf[relay_start + load.len + 3 ..][0..skip.len]);
+    try testing.expectEqualSlices(u8, store.slice(), buf[relay_start + load.len + 3 + skip.len ..][0..store.len]);
+    // The branch lands on POP RBP, not inside the store.
+    try testing.expectEqual(@as(usize, thunk_bytes - 2), relay_start + load.len + 3 + skip.len + store.len);
 }
 
 test "emitThunk: round-trip literals at zero" {
@@ -160,8 +260,11 @@ test "emitThunk: round-trip literals at zero" {
     try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]);
     try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, buf[32..36]);
     try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]);
-    try testing.expectEqual(@as(u8, 0x5D), buf[38]);
-    try testing.expectEqual(@as(u8, 0xC3), buf[39]);
+    // #381 relay: the callee_rt literal is the third imm64 field and zeroes too.
+    try testing.expectEqualSlices(u8, &.{ 0x49, 0xBB }, buf[38..40]);
+    try testing.expectEqual(@as(u64, 0), std.mem.readInt(u64, buf[40..48], .little));
+    try testing.expectEqual(@as(u8, 0x5D), buf[thunk_bytes - 2]);
+    try testing.expectEqual(@as(u8, 0xC3), buf[thunk_bytes - 1]);
 }
 
 test "emitThunk: opcode/frame bytes constant across two distinct callees" {
@@ -189,6 +292,6 @@ test "emitThunk: D-142 R15 save/restore + D-238 RBP frame around CALL" {
     try testing.expectEqualSlices(u8, &.{ 0x41, 0x57 }, buf[4..6]); // PUSH R15
     try testing.expectEqualSlices(u8, &.{ 0xFF, 0xD0 }, buf[30..32]); // CALL RAX
     try testing.expectEqualSlices(u8, &.{ 0x41, 0x5F }, buf[36..38]); // POP R15
-    try testing.expectEqual(@as(u8, 0x5D), buf[38]); // POP RBP
-    try testing.expectEqual(@as(u8, 0xC3), buf[39]); // RET
+    try testing.expectEqual(@as(u8, 0x5D), buf[thunk_bytes - 2]); // POP RBP
+    try testing.expectEqual(@as(u8, 0xC3), buf[thunk_bytes - 1]); // RET
 }

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -1080,6 +1080,100 @@ test "JitInstance.initLinked: a trap in the cross-module callee reaches the call
     try testing.expectEqual(@as(u32, 5), a_inst.owned.rt.trap_kind); // unreachable_
 }
 
+// #381 — a trap left on the exporter's runtime must not be read as the
+// OUTCOME of a later call into it. The thunk is a JIT entry into another
+// instance's runtime and, unlike every host-driven entry (`entry.zig`), it did
+// not clear the trap fields on the way in; nothing read them, so nothing
+// noticed. Once the relay started reading them, the first cross-module trap
+// made every subsequent call into that exporter report the same trap — a
+// successful call reported as a failure, and (per #336's reason for clearing
+// the kind) a later generic trap inheriting this one's kind.
+test "JitInstance.initLinked: an exporter's earlier trap does not leak into a later call (#381)" {
+    const gpa = testing.allocator;
+    // (module (func (export "boom") (result i32) unreachable)
+    //         (func (export "ok") (result i32) i32.const 42))
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+        0x03, 0x02, 0x00, 0x00, 0x07, 0x0d, 0x02, 0x04,
+        0x62, 0x6f, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x6f,
+        0x6b, 0x00, 0x01, 0x0a, 0x0a, 0x02, 0x03, 0x00,
+        0x00, 0x0b, 0x04, 0x00, 0x41, 0x2a, 0x0b,
+    };
+    // (module (import "b" "boom" (func (result i32)))
+    //         (import "b" "ok" (func (result i32)))
+    //         (func (export "callBoom") (result i32) call 0)
+    //         (func (export "callOk") (result i32) call 1))
+    const a_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x02,
+        0x11, 0x02, 0x01, 0x62, 0x04, 0x62, 0x6f, 0x6f,
+        0x6d, 0x00, 0x00, 0x01, 0x62, 0x02, 0x6f, 0x6b,
+        0x00, 0x00, 0x03, 0x03, 0x02, 0x00, 0x00, 0x07,
+        0x15, 0x02, 0x08, 0x63, 0x61, 0x6c, 0x6c, 0x42,
+        0x6f, 0x6f, 0x6d, 0x00, 0x02, 0x06, 0x63, 0x61,
+        0x6c, 0x6c, 0x4f, 0x6b, 0x00, 0x03, 0x0a, 0x0b,
+        0x02, 0x04, 0x00, 0x10, 0x00, 0x0b, 0x04, 0x00,
+        0x10, 0x01, 0x0b,
+    };
+    var b_inst = try JitInstance.init(gpa, &b_bytes);
+    defer b_inst.deinit(gpa);
+    const t_boom = b_inst.exportedFuncTarget(gpa, "boom") orelse return error.TestUnexpectedResult;
+    const t_ok = b_inst.exportedFuncTarget(gpa, "ok") orelse return error.TestUnexpectedResult;
+    var a_inst = try JitInstance.initLinked(gpa, &a_bytes, &.{}, &.{ t_boom, t_ok }, &.{}, &.{});
+    defer a_inst.deinit(gpa);
+
+    try testing.expectEqual(@as(?u64, 42), try a_inst.invoke(gpa, "callOk", &.{}));
+    try testing.expectError(entry.Error.Trap, a_inst.invoke(gpa, "callBoom", &.{}));
+    try testing.expectEqual(@as(u32, 5), a_inst.owned.rt.trap_kind); // unreachable_
+    // The SAME exporter, a different export, after the trap.
+    try testing.expectEqual(@as(?u64, 42), try a_inst.invoke(gpa, "callOk", &.{}));
+    // …and the entry clear is why: the exporter's pair reads as "no trap"
+    // once a clean call has entered it. The kind half is asserted too — a
+    // clear that moved only the flag would leave 5 here for the next generic
+    // trap (which raises the flag without writing a kind) to inherit.
+    try testing.expectEqual(@as(u32, 0), b_inst.owned.rt.trap_flag);
+    try testing.expectEqual(@as(u32, 0), b_inst.owned.rt.trap_kind);
+}
+
+// #381 — `return_call` across the bridge. `op_tail_call.zig` notes there is no
+// post-call check at a tail-call site and cannot be, and relies on the
+// grand-caller's check instead; that grand-caller reads its OWN runtime, so
+// the relay is what makes both shapes work. Measured red before the relay:
+// both returned 0 rather than trapping.
+test "JitInstance.initLinked: a cross-module return_call propagates the callee's trap (#381)" {
+    const gpa = testing.allocator;
+    // (module (func (export "boom") (result i32) unreachable))
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+        0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x62,
+        0x6f, 0x6f, 0x6d, 0x00, 0x00, 0x0a, 0x05, 0x01,
+        0x03, 0x00, 0x00, 0x0b,
+    };
+    // (module (import "b" "boom" (func (result i32)))
+    //         (func (export "t") (result i32) return_call 0)  ;; reached from the host entry
+    //         (func (export "g") (result i32) call 1))        ;; reached via a grand-caller
+    const a_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x02,
+        0x0a, 0x01, 0x01, 0x62, 0x04, 0x62, 0x6f, 0x6f,
+        0x6d, 0x00, 0x00, 0x03, 0x03, 0x02, 0x00, 0x00,
+        0x07, 0x09, 0x02, 0x01, 0x74, 0x00, 0x01, 0x01,
+        0x67, 0x00, 0x02, 0x0a, 0x0b, 0x02, 0x04, 0x00,
+        0x12, 0x00, 0x0b, 0x04, 0x00, 0x10, 0x01, 0x0b,
+    };
+    var b_inst = try JitInstance.init(gpa, &b_bytes);
+    defer b_inst.deinit(gpa);
+    const t = b_inst.exportedFuncTarget(gpa, "boom") orelse return error.TestUnexpectedResult;
+    var a_inst = try JitInstance.initLinked(gpa, &a_bytes, &.{}, &.{t}, &.{}, &.{});
+    defer a_inst.deinit(gpa);
+    try testing.expectError(entry.Error.Trap, a_inst.invoke(gpa, "t", &.{}));
+    try testing.expectEqual(@as(u32, 5), a_inst.owned.rt.trap_kind);
+    try testing.expectError(entry.Error.Trap, a_inst.invoke(gpa, "g", &.{}));
+    try testing.expectEqual(@as(u32, 5), a_inst.owned.rt.trap_kind);
+}
+
 test "JitInstance: cross-module TAG identity resolves to the exporter's id (ADR-0134 D3)" {
     const gpa = testing.allocator;
     // Exporter "test" — the real try_table.0 module: defines $e0, exports

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -1048,6 +1048,38 @@ test "JitInstance.initLinked: cross-module FUNC import dispatches to exporter (D
     try testing.expectEqual(@as(?u64, 42), try a_inst.invoke(gpa, "test", &.{}));
 }
 
+// #381 — the same public `initLinked` path, but the EXPORTER traps. A JIT trap
+// is a flag on the runtime the trap stub sees, and the bridge thunk runs the
+// callee with the callee's runtime pointer installed, so without propagation
+// the caller's post-call check (ADR-0199 / D-468) reads its own untouched
+// `trap_flag` and the importer runs on past a call that never returned a value.
+// The kind is asserted too: a fix that carries the flag but not the kind would
+// report a trap of kind 0 for an `unreachable`.
+test "JitInstance.initLinked: a trap in the cross-module callee reaches the caller (#381)" {
+    const gpa = testing.allocator;
+    // (module (func (export "get") (result i32) unreachable))
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x67,
+        0x65, 0x74, 0x00, 0x00, 0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
+    };
+    // (module (import "b" "get" (func $get (result i32)))
+    //         (func (export "test") (result i32) call $get))
+    const a_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x02, 0x09, 0x01, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74,
+        0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65,
+        0x73, 0x74, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+    };
+    var b_inst = try JitInstance.init(gpa, &b_bytes);
+    defer b_inst.deinit(gpa);
+    const target = b_inst.exportedFuncTarget(gpa, "get") orelse return error.TestUnexpectedResult;
+    var a_inst = try JitInstance.initLinked(gpa, &a_bytes, &.{}, &.{target}, &.{}, &.{});
+    defer a_inst.deinit(gpa);
+    try testing.expectError(entry.Error.Trap, a_inst.invoke(gpa, "test", &.{}));
+    try testing.expectEqual(@as(u32, 5), a_inst.owned.rt.trap_kind); // unreachable_
+}
+
 test "JitInstance: cross-module TAG identity resolves to the exporter's id (ADR-0134 D3)" {
     const gpa = testing.allocator;
     // Exporter "test" — the real try_table.0 module: defines $e0, exports


### PR DESCRIPTION
The D-225 bridge thunk swaps the runtime pointer for the callee and restores
the caller's on return. A JIT trap is a **flag**, not an unwind — the trap stub
writes `[runtime_ptr + trap_flag_off]` and returns, and each call site re-reads
that flag afterwards (`emitPostCallTrapCheck`, ADR-0199 / D-468). Inside the
thunk that pointer is the callee's, so a trap raised in an imported instance
landed where the importer never looks: the call reported success and the
importer continued past a call that returned nothing.

Measured before this change, two JIT instances composed through `initLinked`:

```
exporter: (module (func (export "get") (result i32) unreachable))
importer: (module (import "b" "get" (func $get (result i32)))
                  (func (export "test") (result i32) (call $get)))
```

`invoke("test")` returned `0` — the trap stub's cleared EAX — instead of
trapping. `interp` traps correctly.

The thunk now copies the callee's `trap_flag`/`trap_kind` onto the caller once
the caller's runtime pointer is restored, so the importer's existing post-call
check fires with no call-site codegen change. `trap_flag` (u32 @40) and
`trap_kind` (u32 @44) are adjacent, so one 8-byte load/store carries both; a
`comptime` check in each thunk fails the build if that stops being true. The
kind is asserted in the test because a relay that carried only the flag would
report every cross-module trap as kind 0.

Registers: the relay uses R10/R11 (x86_64 — volatile under both SysV and
Win64, outside `reserved_invariant_gprs`, and the call site reloads its homed
caller-saved registers after the call returns) and X16/X17 (arm64). The
return-value registers are untouched. arm64 parks `callee_rt` in the 80-byte
frame's existing pad slot rather than re-deriving it, because X16 is
corruptible across the call and X0 carries the result — the frame does not
grow.

`thunk_bytes`: x86_64 40 → 69, arm64 96 → 120. `allocArena` sizes from that
constant, so the arena follows; arm64 slots stay 4-aligned (120 % 4 == 0). The
module-doc layout tables and the byte-exact layout tests move with it, and each
arch gains a test asserting the relay's *meaning* — that it reads the callee's
runtime and writes the caller's, and that the skip branch lands on the epilogue
rather than inside the store.

The thunk also now **clears** the callee's `trap_flag`/`trap_kind` on the way
in. It is a JIT entry into another instance's runtime and was the only entry
that did not — `entry.zig` does it for every host-driven one, precisely so a
previous run's flag cannot be read as this run's (#336 for the kind). Nothing
read those fields before, so nothing noticed; the relay reads them. Measured:
after one cross-module trap the exporter kept `trap_flag = 1` and every later
call into it reported that trap, so a `callOk` returning 42 before the trap
returned `error.Trap` after it. Caught by Devin's review on this PR.

`return_call` across the bridge is covered by the same relay, measured in both
shapes — reached directly from the host entry, and reached through a
same-module grand-caller. `op_tail_call.zig` is right that a tail-call site has
no post-call check and cannot; what makes it work is that the relay writes onto
the runtime the tail-calling frame shares with its grand-caller. Without the
relay both shapes returned 0 instead of trapping; both are pinned.

**Windows is unaffected by this change, and its green leg proves less than it
looks.** The x86_64 thunk installs `callee_rt` in RDI, which is entry-arg0
under SysV only; under Win64 entry-arg0 is RCX and the import call site leaves
the IMPORTER's runtime there, so the exporter's body has always run against the
importer's state. The trap therefore reached the caller on Windows before this
PR too — via the wrong runtime — and the relay, which addresses the callee by
immediate, changes nothing there. Filed as #385 (pre-existing, different
root, and the tests that would catch it need distinguishable runtimes). A note
at the top of `x86_64/thunk.zig` points there, so a green Windows leg is not
read as evidence. Caught by Devin's review on this PR.

Closes #381. Unblocks #382, which is red on exactly this: with both applied,
`test-all` is green and `wasi_exit_code.c`'s `cross-module via imported func`
rows assert in full on `auto` and `jit` for the first time — the assertions
#354 left waiting.
