### PR TITLE
jit: derive the x86_64 bridge thunk from the active calling convention

### DIFF
--- a/src/engine/codegen/arm64/thunk.zig
+++ b/src/engine/codegen/arm64/thunk.zig
@@ -121,7 +121,10 @@ comptime {
 }
 
 /// Total thunk size in bytes (26 instructions × 4 bytes + 2 quad
-/// literals × 8 bytes = 120). Stable across all callee signatures.
+/// literals × 8 bytes = 120). One shape for every callee — which bounds what
+/// the bridge can carry: a callee whose arguments overflow the registers reads
+/// them at `[X29, #16 + 8*idx]` relative to its own frame, and this thunk's
+/// frame sits in between. Same gap as the x86_64 encoder's; tracked there.
 /// D-144 grew the thunk from 56 → 96 bytes to cover the full
 /// six-register reserved-invariant cohort; #381's entry clear + trap
 /// relay grew it 96 → 120.

--- a/src/engine/codegen/shared/thunk.zig
+++ b/src/engine/codegen/shared/thunk.zig
@@ -35,8 +35,10 @@ const arch_thunk = switch (builtin.target.cpu.arch) {
 };
 
 /// Bridge thunk byte count for the current target architecture.
-/// Stable across all callee signatures — every thunk has the same
-/// shape; only the embedded literals differ.
+/// One shape for every callee — only the embedded literals differ. That is a
+/// bound, not just a convenience: the bridge takes no signature, so it can
+/// only be right for callees whose arguments and results all travel in
+/// registers (see the per-arch modules).
 ///
 /// The per-arch modules own the layout and its byte count; this
 /// facade deliberately does NOT restate either. Both numbers have

--- a/src/engine/codegen/shared/thunk.zig
+++ b/src/engine/codegen/shared/thunk.zig
@@ -68,9 +68,9 @@ pub const thunk_bytes: usize = arch_thunk.thunk_bytes;
 ///                  `usize`, installed in the entry-arg0 register
 ///                  before the CALL so the callee's prologue
 ///                  snapshots it into its own runtime-ptr register.
-///                  X0 on AArch64; on x86_64 the encoder writes RDI
-///                  unconditionally, which is entry-arg0 under SysV
-///                  ONLY — see the x86_64 module's Win64 note.
+///                  X0 on AArch64; on x86_64 whichever register the
+///                  active convention names (`abi.current.entry_arg0_gpr`
+///                  — RDI under SysV, RCX under Win64, #385).
 /// `callee_entry` — the callee's JIT entry point address (the
 ///                  first instruction of the callee function's
 ///                  body in its module's JIT code block).

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -2,7 +2,8 @@
 //! (ADR-0066 + Amendment §A1, D-142
 //! fix (A.3) + D-238/ADR-0185 (a) RBP frame-link).
 //!
-//! Each thunk is a 40-byte native code snippet that wraps a
+//! Each thunk is a fixed-size native code snippet (`thunk_bytes`; the count
+//! lives there, not restated here — it has moved three times) that wraps a
 //! call-and-return around the callee's JIT entry. It does three
 //! things: **(1)** establishes a standard `PUSH RBP; MOV RBP,RSP`
 //! frame so the cross-instance EH unwinder can walk THROUGH the
@@ -155,7 +156,10 @@ comptime {
 /// R15 [2] + SUB RSP,8 [4] + MOV RDI imm64 [10] + MOV RAX imm64 [10]
 /// + #381 entry clear [3+7 = 10] + MOV RAX imm64 [10] + CALL RAX [2] +
 /// ADD RSP,8 [4] + POP R15 [2] + #381 trap relay [10+7+3+2+7 = 29] +
-/// POP RBP [1] + RET [1] = 79). Stable across all callee signatures.
+/// POP RBP [1] + RET [1] = 79). One shape for every callee, which bounds the
+/// bridge as much as it simplifies it: it takes no signature, so it can only
+/// be right for callees whose arguments and results all travel in registers.
+/// See the signature-agnostic note on `emitThunkCc`.
 pub const thunk_bytes: usize = 79;
 
 /// Emit one bridge thunk into `buf[0..thunk_bytes]`. `buf` MUST be
@@ -163,12 +167,30 @@ pub const thunk_bytes: usize = 79;
 /// allocating it inside an RX-mappable arena.
 ///
 /// `callee_rt`    — the callee instance's `*JitRuntime` value
-///                  to install in RDI before the CALL.
+///                  to install in the entry-arg0 register before the CALL
+///                  (RDI under SysV, RCX under Win64 — #385).
 /// `callee_entry` — the callee's JIT entry point.
 pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     emitThunkCc(abi.current_cc, buf, callee_rt, callee_entry);
 }
 
+/// **Signature-agnostic, and the ABI is not.** The bridge receives no callee
+/// signature, so two shapes are wrong through it under either convention, and
+/// both predate this encoder:
+///
+/// - an **overflow stack argument** — the callee reads it at
+///   `[RBP + 16 + …]` relative to ITS frame (`emit.zig`), while the importer
+///   wrote it relative to the importer's RSP; this thunk's own frame sits in
+///   between and shifts it. arm64 is the same shape (`[X29, #16 + …]`).
+/// - a **MEMORY-class return** (results.len > 2) — the hidden result pointer
+///   belongs in entry-arg0 with the runtime moved to arg1, but
+///   `op_call.zig:emitImportDispatch` overwrites entry-arg0 with the runtime
+///   and this encoder overwrites it again.
+///
+/// Fixing either means making bridge emission signature-aware, which changes
+/// D-225's target-resolution contract rather than this encoder's ABI
+/// derivation. Tracked separately.
+///
 /// #385 — the body of `emitThunk`, with the calling convention as a comptime
 /// parameter. Production always passes `abi.current_cc`; the tests pass both,
 /// so the Win64 layout is checked from a SysV host. It has to be checkable

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -343,11 +343,15 @@ test "emitThunkCc: Win64 reserves the 32-byte home area below the CALL (#385)" {
     try testing.expectEqual(win[9], win[45]); // the ADD undoes exactly the SUB
 }
 
+// These three assert the SysV bytes by construction, so they pin the
+// convention explicitly (#385): `emitThunk` follows `abi.current_cc`, and
+// on the Windows leg that is Win64 — where `48 BF` (MOV RDI) and
+// `48 83 EC 08` (SUB RSP,8) are exactly the bytes this PR replaces.
 test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
     var buf: [thunk_bytes]u8 = undefined;
     const callee_rt: usize = 0xDEADBEEF_CAFEBABE;
     const callee_entry: usize = 0x12345678_9ABCDEF0;
-    emitThunk(&buf, callee_rt, callee_entry);
+    emitThunkCc(.sysv, &buf, callee_rt, callee_entry);
 
     try testing.expectEqual(@as(u8, 0x55), buf[0]); // PUSH RBP
     try testing.expectEqualSlices(u8, &.{ 0x48, 0x89, 0xE5 }, buf[1..4]); // MOV RBP,RSP
@@ -401,7 +405,7 @@ test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
 // while the load reads the callee's, at the SAME offset.
 test "emitThunk: the trap relay reads the callee's runtime and writes the caller's (#381)" {
     var buf: [thunk_bytes]u8 = undefined;
-    emitThunk(&buf, 0, 0);
+    emitThunkCc(.sysv, &buf, 0, 0);
     const flag_off: i32 = jit_abi.trap_flag_off;
     const load = inst.encMovR64FromMemDisp32(.r10, .r11, flag_off);
     const store = inst.encStoreR64MemDisp32(.r10, .r15, flag_off);
@@ -426,7 +430,7 @@ test "emitThunk: the trap relay reads the callee's runtime and writes the caller
 
 test "emitThunk: round-trip literals at zero" {
     var buf: [thunk_bytes]u8 = undefined;
-    emitThunk(&buf, 0, 0);
+    emitThunkCc(.sysv, &buf, 0, 0);
     // Frame + opcode bytes unchanged; both imm64 fields all-zero.
     try testing.expectEqual(@as(u8, 0x55), buf[0]);
     try testing.expectEqualSlices(u8, &.{ 0x48, 0x89, 0xE5 }, buf[1..4]);

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -24,13 +24,13 @@
 //! 0x00    55                                  PUSH RBP           ; frame link (saved importer RBP)
 //! 0x01    48 89 E5                            MOV  RBP, RSP      ; [RBP,8] = importer retaddr
 //! 0x04    41 57                               PUSH R15           ; save caller's R15 (= caller_rt)
-//! 0x06    48 83 EC 08                         SUB  RSP, 8        ; alignment pad
-//! 0x0A    48 BF <callee_rt LE 8 bytes>        MOV  RDI, imm64    ; SysV arg0
+//! 0x06    48 83 EC <pad>                      SUB  RSP, pad      ; align (+ Win64 shadow)
+//! 0x0A    48 B{7,9} <callee_rt LE 8 bytes>    MOV  arg0, imm64   ; RDI SysV / RCX Win64
 //! 0x14    45 31 D2                            XOR  R10D, R10D    ; #381 entry clear
-//! 0x17    4C 89 97 <40 LE4>                   MOV  [RDI+40], R10 ; clear callee trap_flag|kind
+//! 0x17    4C 89 {97,91} <40 LE4>              MOV  [arg0+40], R10; clear callee trap_flag|kind
 //! 0x1E    48 B8 <callee_entry LE 8 bytes>     MOV  RAX, imm64
 //! 0x28    FF D0                               CALL RAX           ; SysV CALL (RSP 16-aligned here)
-//! 0x2A    48 83 C4 08                         ADD  RSP, 8        ; undo pad
+//! 0x2A    48 83 C4 <pad>                      ADD  RSP, pad      ; undo pad
 //! 0x2E    41 5F                               POP  R15           ; restore caller's R15
 //! 0x30    49 BB <callee_rt LE 8 bytes>        MOV  R11, imm64    ; #381 trap relay: callee_rt
 //! 0x3A    4D 8B 93 <40 LE4>                   MOV  R10, [R11+40] ; trap_flag|trap_kind pair
@@ -77,21 +77,34 @@
 //! (`op_call.zig:reloadHomedCallerSaved`), so clobbering them here is free.
 //! The return-value registers (RAX/RDX/XMM0/XMM1) are untouched.
 //!
-//! **This encoder is SysV-only, and that is a live Win64 defect (#385).**
-//! `MOV RDI, callee_rt` is entry-arg0 under SysV; under Win64 entry-arg0 is
-//! RCX (`abi.win64.entry_arg0_gpr`), and `op_call.zig:emitImportDispatch`
-//! leaves the IMPORTER's runtime there on the way into this thunk — so on
-//! Windows the callee's prologue snapshots the importer's runtime, not the
-//! exporter's. Two more Cc gaps ride along: RDI is callee-saved AND
-//! allocatable under Win64 (`abi.win64.allocatable_gprs`), so writing it here
-//! destroys a live importer register; and the CALL below reserves no Win64
-//! shadow space, whose home area would land on this thunk's own saved
-//! RBP/R15 and return address. All three predate the #381 relay and are
-//! tracked in #385 rather than widened into it — the relay is unaffected
-//! (it addresses the callee's runtime by immediate, not by arg register),
-//! but a green Windows CI leg on a cross-module trap test is NOT evidence
-//! that the callee ran on its own runtime: the trap reaches the importer
-//! either way, because on Win64 it was the importer's runtime all along.
+//! **Cc-aware since #385.** The encoder used to write `MOV RDI, callee_rt`
+//! unconditionally — entry-arg0 under SysV only. Under Win64 entry-arg0 is RCX
+//! (`abi.win64.entry_arg0_gpr`) and `op_call.zig:emitImportDispatch` leaves the
+//! IMPORTER's runtime there on the way in, so the callee's prologue snapshotted
+//! the importer's runtime and the exporter's body ran against the wrong
+//! instance's globals, memory, tables and WASI host. Two more Cc gaps rode
+//! along: RDI is callee-saved AND allocatable under Win64
+//! (`abi.win64.allocatable_gprs` adds it for that reason), so writing it
+//! destroyed a live importer register; and the CALL reserved no Win64 shadow
+//! space, whose 32-byte home area starts at this thunk's own RSP and covers
+//! its saved R15, saved RBP and return address.
+//!
+//! All three are one root — a SysV-shaped encoder — and all three go away by
+//! deriving from `abi.current`: the runtime pointer lands in
+//! `entry_arg0_gpr`, RDI is never touched under Win64, and the frame pad is
+//! `shadow_space_bytes + 8` rather than a bare 8. The byte COUNT is identical
+//! under both conventions (the register change keeps every encoding the same
+//! length and the pad is an imm8 either way), so `thunk_bytes` is Cc-agnostic
+//! and the layout below reads for both.
+//!
+//! `emitThunkCc` takes the convention as a comptime parameter so the Win64
+//! layout is testable from a SysV host. It has to be: nothing in the tree
+//! exercised this path on Windows, and the cross-module tests that traverse it
+//! pass there for the wrong reason — `i32.const 42` never touches a runtime,
+//! and a trap raised on the importer's runtime is exactly where the caller
+//! looks. The test that finally told the two apart routes a guest `proc_exit`
+//! through the exporter and reads the WASI host it reached
+//! (`test/c_api_conformance/wasi_exit_code.c`).
 //!
 //! SysV AMD64 §3.2.1 invariant: RBX, RBP, R12..R15 are callee-saved.
 //! v2's JIT prologue (per ADR-0026 Cc-pivot) overwrites R15 with the
@@ -101,23 +114,36 @@
 //! bridge thunk pays the save/restore cost on the caller's behalf.
 //! Same discipline pattern as arm64 X19; see ADR-0066 §A1.
 //!
-//! Stack-alignment note (D-238 changed this): SysV requires
+//! Stack-alignment note (D-238 changed this): both conventions require
 //! `RSP % 16 == 0` at the point of CALL. The importer's CALL into the
 //! thunk leaves entry RSP ≡ 8 mod 16 (pushed return address). The two
 //! pushes (`PUSH RBP` → ≡0, `PUSH R15` → ≡8) would leave `CALL RAX`
-//! misaligned, so the explicit `SUB RSP, 8` pad restores ≡0 before the
-//! CALL (and `ADD RSP, 8` undoes it after). The OLD 27-byte single-push
+//! misaligned, so the explicit `SUB RSP, pad` restores ≡0 before the
+//! CALL (and `ADD RSP, pad` undoes it after). The OLD 27-byte single-push
 //! thunk aligned by luck (one push: ≡8 → ≡0); adding the RBP frame-link
 //! needs the pad. Load-bearing for SSE/AVX in the callee.
+//!
+//! #385 — `pad` is `shadow_space_bytes + 8`: 8 under SysV, 40 under Win64,
+//! where the low 32 bytes are the home area the callee may spill its four
+//! register args into (Microsoft x64 §"Stack allocation"). Without it that
+//! home area starts at this thunk's RSP and covers its saved R15, saved RBP
+//! and return address. The alignment holds for both because
+//! `shadow_space_bytes` is a multiple of 16 — asserted at comptime below.
 //!
 //! Zone 2 (`src/engine/codegen/x86_64/`) — must NOT import
 //! `src/engine/codegen/arm64/` per ROADMAP §A3.
 
 const std = @import("std");
 const inst = @import("inst.zig");
+const abi = @import("abi.zig");
 const jit_abi = @import("../shared/jit_abi.zig");
 
 comptime {
+    // #385 — the frame pad below is `shadow_space_bytes + 8`, which lands the
+    // CALL on a 16-byte boundary only while the shadow itself is a multiple
+    // of 16. Both conventions satisfy it today (0 and 32).
+    if (abi.sysv.shadow_space_bytes % 16 != 0 or abi.win64.shadow_space_bytes % 16 != 0)
+        @compileError("bridge thunk frame pad assumes a 16-multiple shadow space");
     // The relay below copies `trap_flag` and `trap_kind` as one 8-byte pair.
     if (jit_abi.trap_kind_off != jit_abi.trap_flag_off + 4)
         @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; they are no longer adjacent");
@@ -140,7 +166,28 @@ pub const thunk_bytes: usize = 79;
 ///                  to install in RDI before the CALL.
 /// `callee_entry` — the callee's JIT entry point.
 pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
+    emitThunkCc(abi.current_cc, buf, callee_rt, callee_entry);
+}
+
+/// #385 — the body of `emitThunk`, with the calling convention as a comptime
+/// parameter. Production always passes `abi.current_cc`; the tests pass both,
+/// so the Win64 layout is checked from a SysV host. It has to be checkable
+/// that way — the Windows leg is the only instrument that runs this code, and
+/// the cross-module tests that traverse it pass there even when the callee
+/// receives the wrong runtime.
+pub fn emitThunkCc(comptime cc: abi.Cc, buf: []u8, callee_rt: usize, callee_entry: usize) void {
     std.debug.assert(buf.len == thunk_bytes);
+    const tables = switch (cc) {
+        .sysv => abi.sysv,
+        .win64 => abi.win64,
+    };
+    // The register the callee's prologue snapshots its runtime pointer from
+    // (`emit.zig`'s `MOV R15, <entry_arg0>`): RDI under SysV, RCX under Win64.
+    const entry_arg0 = tables.entry_arg0_gpr;
+    // Alignment pad + the Win64 home area the callee may spill its register
+    // args into. Never touches RDI under Win64, where it is callee-saved and
+    // in the allocatable pool.
+    const frame_pad: i8 = @intCast(tables.shadow_space_bytes + 8);
     // PUSH RBP — establish the frame link so the cross-instance EH
     // unwinder can walk through the thunk (D-238 / ADR-0185 a).
     @memcpy(buf[0..1], inst.encPushR(.rbp).slice());
@@ -148,24 +195,25 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
     @memcpy(buf[1..4], inst.encMovRR(.q, .rbp, .rsp).slice());
     // PUSH R15 — save caller's R15 = caller_rt (D-142 cohort save).
     @memcpy(buf[4..6], inst.encPushR(.r15).slice());
-    // SUB RSP, 8 — alignment pad (two pushes left RSP ≡ 8; restore ≡ 0
-    // so the CALL below is SysV 16-aligned).
-    @memcpy(buf[6..10], inst.encSubRSpImm8(8).slice());
+    // SUB RSP, pad — alignment (two pushes left RSP ≡ 8; restore ≡ 0 so the
+    // CALL below is 16-aligned) plus the Win64 shadow space (#385).
+    @memcpy(buf[6..10], inst.encSubRSpImm8(frame_pad).slice());
     const flag_off: i32 = jit_abi.trap_flag_off;
-    // MOV RDI, callee_rt — SysV arg0 (= *JitRuntime).
-    @memcpy(buf[10..20], inst.encMovImm64Q(.rdi, callee_rt).slice());
-    // #381 entry clear — zero the callee's trap_flag|trap_kind pair while RDI
-    // still holds callee_rt, so the relay below reads THIS call's outcome and
-    // not a trap the exporter kept from an earlier one.
+    // MOV <entry_arg0>, callee_rt — the callee's `*JitRuntime` in the register
+    // its prologue reads (#385; RDI under SysV, RCX under Win64).
+    @memcpy(buf[10..20], inst.encMovImm64Q(entry_arg0, callee_rt).slice());
+    // #381 entry clear — zero the callee's trap_flag|trap_kind pair while the
+    // entry-arg0 register still holds callee_rt, so the relay below reads THIS
+    // call's outcome and not a trap the exporter kept from an earlier one.
     @memcpy(buf[20..23], inst.encXorRR(.d, .r10, .r10).slice());
-    @memcpy(buf[23..30], inst.encStoreR64MemDisp32(.r10, .rdi, flag_off).slice());
+    @memcpy(buf[23..30], inst.encStoreR64MemDisp32(.r10, entry_arg0, flag_off).slice());
     // MOV RAX, callee_entry.
     @memcpy(buf[30..40], inst.encMovImm64Q(.rax, callee_entry).slice());
     // CALL RAX — SysV CALL (not JMP); pushes post-CALL RIP so the
     // callee's RET returns here.
     @memcpy(buf[40..42], inst.encCallReg(.rax).slice());
-    // ADD RSP, 8 — undo the alignment pad.
-    @memcpy(buf[42..46], inst.encAddRSpImm8(8).slice());
+    // ADD RSP, pad — undo the alignment + shadow allocation.
+    @memcpy(buf[42..46], inst.encAddRSpImm8(frame_pad).slice());
     // POP R15 — RESTORE caller's R15. Everything below relays onto it, so it
     // must come after this and not before.
     @memcpy(buf[46..48], inst.encPopR(.r15).slice());
@@ -205,6 +253,73 @@ pub fn emitThunk(buf: []u8, callee_rt: usize, callee_entry: usize) void {
 // ============================================================
 
 const testing = std.testing;
+
+// #385 — the Win64 layout, checked from whatever host runs the tests. Nothing
+// in the tree exercised this encoder on Windows, and the cross-module tests
+// that traverse it pass there even when the callee receives the importer's
+// runtime (`i32.const 42` touches no runtime; a trap raised on the importer's
+// runtime is where the caller looks). So the encoding is pinned here rather
+// than left to the one CI leg that runs it.
+test "emitThunkCc: the Win64 layout differs in exactly the Cc-dependent slots (#385)" {
+    var sysv: [thunk_bytes]u8 = undefined;
+    var win: [thunk_bytes]u8 = undefined;
+    const callee_rt: usize = 0xDEADBEEF_CAFEBABE;
+    const callee_entry: usize = 0x12345678_9ABCDEF0;
+    emitThunkCc(.sysv, &sysv, callee_rt, callee_entry);
+    emitThunkCc(.win64, &win, callee_rt, callee_entry);
+
+    // The runtime pointer goes to the register the callee's prologue reads:
+    // MOV RDI (48 BF) vs MOV RCX (48 B9), same length, same literal.
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0xBF }, sysv[10..12]);
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0xB9 }, win[10..12]);
+    try testing.expectEqual(callee_rt, std.mem.readInt(u64, win[12..20], .little));
+
+    // The #381 entry clear stores through that same register: modrm rm=rdi(7)
+    // -> 0x97 vs rm=rcx(1) -> 0x91.
+    try testing.expectEqualSlices(u8, &.{ 0x4C, 0x89, 0x97 }, sysv[23..26]);
+    try testing.expectEqualSlices(u8, &.{ 0x4C, 0x89, 0x91 }, win[23..26]);
+
+    // The frame pad carries the Win64 home area: SUB/ADD RSP, 8 vs 40.
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xEC, 0x08 }, sysv[6..10]);
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xEC, 0x28 }, win[6..10]);
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x08 }, sysv[42..46]);
+    try testing.expectEqualSlices(u8, &.{ 0x48, 0x83, 0xC4, 0x28 }, win[42..46]);
+
+    // Everything else is Cc-invariant, which is why `thunk_bytes` is one number.
+    try testing.expectEqualSlices(u8, sysv[0..6], win[0..6]); // frame + PUSH R15
+    try testing.expectEqualSlices(u8, sysv[20..23], win[20..23]); // XOR R10D,R10D
+    try testing.expectEqualSlices(u8, sysv[26..30], win[26..30]); // the disp32
+    try testing.expectEqualSlices(u8, sysv[30..42], win[30..42]); // MOV RAX + CALL
+    try testing.expectEqualSlices(u8, sysv[46..thunk_bytes], win[46..thunk_bytes]); // POP + relay + RET
+}
+
+// #385 — RDI is callee-saved under Win64 AND in its allocatable pool
+// (`abi.win64.allocatable_gprs` adds RDI/RSI for exactly that reason), so an
+// importer may hold a live value there across the call. The Win64 thunk must
+// not write it. Stated as its own property because the byte-exact test above
+// would still pass if a future edit moved an RDI write somewhere else.
+test "emitThunkCc: the Win64 thunk never writes RDI (#385)" {
+    var win: [thunk_bytes]u8 = undefined;
+    emitThunkCc(.win64, &win, 0xAAAA_BBBB_CCCC_DDDD, 0xEEEE_FFFF_0000_1111);
+    // `MOV RDI, imm64` = REX.W + B8+rdi.low3(7).
+    try testing.expectEqual(@as(?usize, null), std.mem.find(u8, &win, &[_]u8{ 0x48, 0xBF }));
+    // A store through RDI as base: REX.W|R + 0x89 + mod=10 reg=r10 rm=rdi.
+    try testing.expectEqual(@as(?usize, null), std.mem.find(u8, &win, &[_]u8{ 0x4C, 0x89, 0x97 }));
+}
+
+// #385 — the Win64 CALL must leave 32 bytes below it for the callee's home
+// area. Without them the callee's spill of its four register args starts at
+// this thunk's RSP and covers its saved R15, saved RBP and return address.
+test "emitThunkCc: Win64 reserves the 32-byte home area below the CALL (#385)" {
+    var win: [thunk_bytes]u8 = undefined;
+    emitThunkCc(.win64, &win, 0, 0);
+    const pad: i8 = @bitCast(win[9]); // the imm8 of SUB RSP, imm8
+    try testing.expect(pad >= @as(i8, @intCast(abi.win64.shadow_space_bytes)));
+    // …and the pad still lands the CALL on a 16-byte boundary: entry RSP ≡ 8,
+    // two pushes → ≡ 8, minus the pad → ≡ 0.
+    try testing.expectEqual(@as(i32, 0), @mod(8 - @as(i32, pad), 16));
+    try testing.expectEqual(win[9], win[45]); // the ADD undoes exactly the SUB
+}
 
 test "emitThunk: byte-exact layout for known constants (D-238 RBP frame-link)" {
     var buf: [thunk_bytes]u8 = undefined;

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -1,4 +1,4 @@
-// FILE-SIZE-EXEMPT: append-only e2e JIT test aggregator (per ADR-0099 D1).
+// FILE-SIZE-EXEMPT: (cap=2700) append-only e2e JIT test aggregator (per ADR-0099 D1); #385 adds the one cross-module case that can tell the callee's runtime apart, beside the D-225 cases it contrasts with.
 // One self-contained test per behaviour (inline .wasm bytes + wat comment);
 // splitting by concept would scatter the runI32Export harness + duplicate
 // imports for negligible gain (N4 test-dup); growth is by independent test
@@ -1055,6 +1055,62 @@ test "JitInstance.initLinked: cross-module FUNC import dispatches to exporter (D
 // `trap_flag` and the importer runs on past a call that never returned a value.
 // The kind is asserted too: a fix that carries the flag but not the kind would
 // report a trap of kind 0 for an `unreachable`.
+// #385 — does the callee run on its OWN runtime? Every other cross-module test
+// answers `() -> i32` with a constant, which never touches a runtime and so
+// passes whichever one the callee receives. This one makes the two
+// distinguishable: both modules define a mutable global at index 0 with
+// different values, and the exporter returns `global.get 0`. Reading the
+// importer's globals array yields 9; reading its own yields 7.
+//
+// That is the observable of the Win64 defect. `op_call.zig:emitImportDispatch`
+// puts the IMPORTER's runtime in the entry-arg0 register before calling the
+// bridge thunk; if the thunk does not overwrite it with the callee's, the
+// callee's prologue snapshots the importer's runtime and `globals_base` comes
+// from the wrong instance. The thunk wrote RDI unconditionally, which is
+// entry-arg0 under SysV only — so this reads 9 on Windows and 7 elsewhere.
+//
+// No `skip.phaseEnd(.win64)` guard: the Windows leg is the only instrument
+// that executes the Win64 encoding, so this test must run there.
+test "JitInstance.initLinked: the cross-module callee runs on its OWN runtime (#385)" {
+    const gpa = testing.allocator;
+    // (module (global (mut i32) (i32.const 7))
+    //         (func (export "get") (result i32) global.get 0))
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+        0x02, 0x01, 0x00,
+        0x06, 0x06, 0x01, 0x7f, 0x01, 0x41, 0x07, 0x0b, // global0 = (mut i32) 7
+        0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00,
+        0x00,
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x23, 0x00, 0x0b, // global.get 0
+    };
+    // (module (import "b" "get" (func (result i32)))
+    //         (global (mut i32) (i32.const 9))
+    //         (func (export "test") (result i32) call 0))
+    const a_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x02,
+        0x09, 0x01, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74,
+        0x00, 0x00, 0x03, 0x02, 0x01, 0x00,
+        0x06, 0x06, 0x01, 0x7f, 0x01, 0x41, 0x09, 0x0b, // global0 = (mut i32) 9
+        0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74,
+        0x00, 0x01,
+        0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b, // call 0
+    };
+    var b_inst = try JitInstance.init(gpa, &b_bytes);
+    defer b_inst.deinit(gpa);
+    // The exporter answers 7 when called directly — so a 9 below is the
+    // bridge handing it the wrong runtime, not a miscompiled body.
+    try testing.expectEqual(@as(?u64, 7), try b_inst.invoke(gpa, "get", &.{}));
+
+    const target = b_inst.exportedFuncTarget(gpa, "get") orelse return error.TestUnexpectedResult;
+    var a_inst = try JitInstance.initLinked(gpa, &a_bytes, &.{}, &.{target}, &.{}, &.{});
+    defer a_inst.deinit(gpa);
+    // 7 = the exporter's global; 9 would be the importer's, i.e. the callee
+    // running on the runtime the bridge failed to swap in.
+    try testing.expectEqual(@as(?u64, 7), try a_inst.invoke(gpa, "test", &.{}));
+}
+
 test "JitInstance.initLinked: a trap in the cross-module callee reaches the caller (#381)" {
     const gpa = testing.allocator;
     // (module (func (export "get") (result i32) unreachable))

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -454,20 +454,21 @@ const jit_known_fail_x86_64_sysv: []const JitKnownFail = &.{
 
 /// x86_64-windows — measured 2026-09-02 by this lane's own first CI run.
 ///
-/// The same 8 float directives, plus one the SysV leg passes:
-/// `imported-mismatch` is a no-arg `-> i32:3` assert, so it is neither the
-/// float class above nor the Win64 float-register defect. The interpreter
-/// passes it on Windows, and the JIT passes it on Linux; only this
-/// combination fails. Tracked separately from #378 as #379.
-///
-/// This row is why the key is the TARGET and not the arch: keyed on arch
-/// alone, the Windows leg reports a regression on every run.
+/// The same 8 float directives. A ninth row, `imported-mismatch` (a no-arg
+/// `-> i32:3` assert, #379), stood here until #385: its `$imported-throw` is a
+/// func import from the `register`ed "test" module, so the call crosses the
+/// D-225 bridge thunk — which was SysV-only and handed the Win64 callee the
+/// IMPORTER's runtime. The thrown tag then compared against the wrong
+/// instance's identity and the inner `catch $e0` caught what `catch_all`
+/// should have. Measured by this gate's own stale signal: `0 stale` on
+/// main + #384, `1 stale` with the Cc-aware thunk. Keyed on the target and
+/// not the arch for the same reason as before: the Win64 float rows are
+/// theirs alone.
 const jit_known_fail_x86_64_windows: []const JitKnownFail = &.{
     .{ .key = "exception-handling/try_table/throw-catch-param-f32", .count = 2 },
     .{ .key = "exception-handling/try_table/throw-catch-param-f64", .count = 2 },
     .{ .key = "exception-handling/try_table/throw-catch_ref-param-f32", .count = 2 },
     .{ .key = "exception-handling/try_table/throw-catch_ref-param-f64", .count = 2 },
-    .{ .key = "exception-handling/try_table/imported-mismatch", .count = 1 },
 };
 
 /// aarch64 (the macOS leg) — measured 2026-09-02 by this lane's own first CI


### PR DESCRIPTION
Makes the x86_64 cross-module bridge thunk calling-convention-aware. It is what
#382's Windows leg is waiting on.

## The failure this fixes

#382 (`develop/jit-cross-module-import`, rebased onto #384) is red on
`x86_64-windows` on every run since the rebase and green on the other two legs:

| run | pushed | x86_64-windows | x86_64-linux | aarch64-macos |
|---|---|---|---|---|
| 33751478375 | 09-03 11:46Z | **fail** | pass | pass |
| 33755760040 | 09-03 12:32Z | **fail** | pass | pass |

The only `error:` in the Windows log:

```
+- run exe zwasm-conformance-wasi_exit_code failure
[auto] cross-module via imported func: proc_exit(7) reported no status — the
write went to the host the exporting instance captured and the read followed
the called one
```

`proc_exit` writes through the runtime's `wasi_host`. Under Win64 the callee
ran with the IMPORTER's runtime pointer, so the write landed on the wrong host
and the read found nothing. The diagnostic text is `wasi_exit_code.c`'s
pre-written explanation for #352's failure mode — stale wording for this cause
— but the observable is unambiguous: Windows-only, JIT path, wrong runtime.
`[jit]` does not appear in the log because `main` returns at the first failing
expectation; its absence is not the jit row passing.

Why `main` is green: on `main` that row reports "this engine is unmeasured"
because instantiation fails (#360). #382 makes instantiation succeed, the row
becomes an assertion, and it fails. On `main` the SysV-only thunk has no
consumer outside unit tests:

| caller | `func_import_targets` | reaches the thunk |
|---|---|---|
| `JitInstance.init` (`runner.zig`) | `&.{}` | no |
| C API (`api/instance.zig`) | `&.{}` | no — that gap is #360 |
| wasm-3.0 spec runner (`spec_assert_runner_wasm_3_0.zig`) | from `jit_exporters`, filled only by `register`; the corpus has zero | never |
| `src/engine/runner_test.zig` | non-empty | yes |

#382 rebases onto this the way it rebased onto #384 for #381.

## The defect

The encoder wrote `MOV RDI, callee_rt` unconditionally — entry-arg0 under SysV
only. A JIT function's prologue snapshots its runtime pointer from
`abi.current.entry_arg0_gpr` (`emit.zig`), which is RCX under Win64, and the
call site that reaches the thunk has just put the IMPORTER's runtime there:

```
op_call.zig:emitImportDispatch
  MOV RAX, [R15 + host_dispatch_base_off]
  MOV RAX, [RAX + idx*8]          ; the bridge thunk
  MOV <entry_arg0>, R15           ; RCX on Win64 = the importer's runtime
  CALL RAX
```

Two more Cc gaps ride along, one root. RDI is callee-saved AND allocatable
under Win64 (`abi.win64.allocatable_gprs` adds it for exactly that reason), so
writing it destroys a live importer register. And the CALL reserved no Win64
shadow space.

## The change

Derive all three from `abi.current`: the runtime pointer goes to
`entry_arg0_gpr`, RDI is never written under Win64, and the frame pad is
`shadow_space_bytes + 8` instead of a bare 8. Every encoding keeps its length —
`MOV RCX,imm64` and `MOV RDI,imm64` are both 10 bytes, the pad is an imm8
either way — so `thunk_bytes` stays 79 under both conventions. A comptime
check pins the alignment premise (`shadow_space_bytes % 16 == 0`).

`emitThunkCc` takes the convention as a comptime parameter so the Win64
layout is pinned from a SysV host. Three byte tests cover it: the
Cc-dependent slots against the Cc-invariant remainder, that the Win64 thunk
never writes RDI, and that the pad reserves the home area while keeping the
CALL 16-aligned. All three fail against the old body — checked by reverting it
locally.

**The shadow-space reservation is belt-and-braces.** The ABI requires the
caller to provide the 32-byte home area, and this thunk did not; whether a
zwasm-compiled callee currently spills into it was not measured, and no
failure was observed from it. It is landed as the ABI contract, not as a fix
for an observed fault.

## Proof

**On this branch — a unit test that can tell the two runtimes apart.** Every
other cross-module test answers `() -> i32` with a constant, which never
touches a runtime and so passes whichever one the callee receives. The new
`runner_test.zig` case gives both modules a mutable global at index 0 with
different values (exporter 7, importer 9) and has the exporter return
`global.get 0`. Calling through the bridge must read 7; 9 means the callee ran
on the importer's runtime. It carries no `skip.phaseEnd(.win64)` guard, so it
executes on the Windows leg — the only instrument that runs the Win64
encoding.

Red first, as far as a SysV host allows: with the thunk's `MOV entry_arg0,
callee_rt` removed — leaving the register holding what `emitImportDispatch`
put there, i.e. the importer's runtime, which is the Win64 situation — the
test reads `expected 7, found 9`. With it restored, 7. That proves the test
detects the defect; that the Windows leg was red before this change is what
#382's runs above show.

**Downstream — #382's Windows leg.** The integration criterion is
`wasi_exit_code`'s `cross-module via imported func` row going green on
`x86_64-windows` once #382 rebases onto this merge. That is the user's step,
not this PR's.

## What this is not

A prerequisite for cross-module linking, orthogonal to the binding design.
#386 (binds by the import's field name rather than by the extern passed),
#387 (two modules compared in one type space) and #388 (`FuncImportTarget`
cannot express a re-exported import) are about *what* binds to *what*. This is
about which register carries the runtime pointer and who owns the stack around
the call — the ABI half, independent of how those three come out.

**#379 is this defect — measured, not inferred.** The wasm-3.0 JIT lane does
construct `FuncImportTarget`s: `register` directives populate `jit_exporters`
(`spec_assert_runner_wasm_3_0.zig:1210`; the corpus has 30, exception-handling
has 1) and `jitResolveFuncImports` builds `ftargets` from them (:1036).
`try_table.wast`'s `imported-mismatch` module declares
`(func $imported-throw (import "test" "throw"))` — a func import from the
registered module — and calls it inside nested `try_table`s. That call crosses
the bridge thunk; under Win64 the callee ran on the importer's runtime, the
thrown tag compared against the wrong instance's identity, and the inner
`catch $e0` caught what `catch_all` should have — 1 or 2 instead of 3.

The gate's own stale-expectation signal is the measurement:

| Windows leg | thunk | `JIT known-wrong (x86_64-windows)` |
|---|---|---|
| #382 run 33755760040 (main + #384) | SysV-only | `5 enumerated, 0 unexpected, 0 stale` |
| #389 run 33850222345 (this PR) | Cc-aware | `5 enumerated, 0 unexpected, 1 stale` — `imported-mismatch: enumerated 1, observed 0` |

So the `imported-mismatch` row is removed from `jit_known_fail_x86_64_windows`
and its paragraph rewritten to say what it was; the gate fails on a stale row
by design (#376), so this is what turns the Windows leg green, not a scope
widening. Whether this PR also carries `Closes #379` is the user's call — the
observable is gone on every Windows run of this branch, and nothing else in
#379 is left unexplained.

Also in this round: the three `emitThunk` byte tests asserted SysV bytes by
construction and failed on the Windows leg once `emitThunk` followed
`abi.current_cc` (the `48 BF` / `48 83 EC 08` they expected are exactly the
bytes this PR replaces). They now pin `.sysv` explicitly; the Win64 layout has
its own three tests.

Two things the bridge still cannot carry — an overflow stack argument and a
MEMORY-class return — are the same across conventions and predate this PR; the
module doc now says so instead of claiming one shape fits every signature.
Filed separately.

Closes #385.
