### PR TITLE
capi: decline a cross-module import the bridge thunk cannot carry

### DIFF
--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -24,6 +24,7 @@
 //! zones (`interp/`, `wasi/`, `frontend/`, `ir/`, `util/`) freely.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 const runtime = @import("../runtime/runtime.zig");
 const runtime_instance = @import("../runtime/instance/instance.zig");
@@ -890,9 +891,114 @@ fn crossModuleJitTarget(
     // surface. It is unsupported at `main` too, by the same route, so the
     // guard withholds an acceptance rather than removing one.
     if (hasConcreteHeapType(want_sig) or hasConcreteHeapType(src_sig)) return error.Unsupported;
+    // #390 — the bridge thunk takes no signature, so it can only carry a call
+    // whose arguments and results all travel in registers: an overflow stack
+    // argument is written by the importer relative to ITS stack and read by
+    // the exporter relative to its own frame, with the thunk's frame in
+    // between; a MEMORY-class result loses its hidden buffer pointer. Both are
+    // wrong answers, not rejections. Decline the shape instead — NULL, as
+    // `v2.6.0` returned for every cross-module import — until the bridge is
+    // signature-aware. Mirrors the host-func sibling above, whose
+    // `dispatchPtrFor` declines the signatures ITS bridge does not cover.
+    if (!bridgeCanCarry(want_sig)) return error.Unsupported;
     if (!validator_helpers.funcTypeImportCompatible(want_sig, src_sig, importer_types))
         return error.Unsupported;
     return source_jit.exportedFuncTarget(ta, it.name) orelse error.Unsupported;
+}
+
+/// #390 — the register budget the cross-module bridge can carry on the
+/// running target. Every number is the JIT call-site marshalling rule for the
+/// same target, cited per row; the bridge inherits those rules because it is
+/// a plain CALL between two JIT bodies. `int` covers i32/i64/ref (one GPR
+/// each), `fp` covers f32/f64. v128 is never carried (a hidden pointer under
+/// Win64, an XMM under SysV, unsupported as a JIT entry arg on arm64).
+const BridgeBudget = struct {
+    /// User integer argument registers with a non-MEMORY-class return.
+    int_regs: u32,
+    /// The same when the return is MEMORY-class (results.len > 2): the hidden
+    /// buffer pointer takes one more slot — and the bridge cannot carry the
+    /// MEMORY-class return at all, so that row only documents the ABI.
+    fp_regs: u32,
+    /// Win64 shares ONE position sequence between int and fp args
+    /// (`op_call.zig`: `n_total = n_int + n_v128 + n_fp` against the int
+    /// budget); SysV and AAPCS64 count the two classes separately.
+    shared_positions: bool,
+};
+
+fn bridgeBudgetFor(comptime arch: std.Target.Cpu.Arch, comptime os: std.Target.Os.Tag) BridgeBudget {
+    // `x86_64/op_call.zig` computeCallReturnBufferOff / marshalCallArgs:
+    // SysV — 5 user int regs (RSI..R9; RDI is the runtime), 8 XMM.
+    // Win64 — 3 user positions (RDX/R8/R9; RCX is the runtime), int and fp
+    // sharing them.
+    if (arch == .x86_64) {
+        return if (os == .windows)
+            .{ .int_regs = 3, .fp_regs = 3, .shared_positions = true }
+        else
+            .{ .int_regs = 5, .fp_regs = 8, .shared_positions = false };
+    }
+    // `arm64/emit.zig` multi-arg entry: X1..X7 (X0 is the runtime), V0..V7.
+    if (arch == .aarch64) return .{ .int_regs = 7, .fp_regs = 8, .shared_positions = false };
+    // No JIT on any other target (`shared/thunk.zig` refuses to compile one),
+    // so nothing is carried.
+    return .{ .int_regs = 0, .fp_regs = 0, .shared_positions = false };
+}
+
+fn bridgeCanCarryFor(comptime arch: std.Target.Cpu.Arch, comptime os: std.Target.Os.Tag, sig: zir.FuncType) bool {
+    const budget = bridgeBudgetFor(arch, os);
+    // A MEMORY-class return (results.len > 2) is returned through a hidden
+    // buffer pointer the bridge does not preserve (#390).
+    if (sig.results.len > 2) return false;
+    var n_int: u32 = 0;
+    var n_fp: u32 = 0;
+    for (sig.params) |vt| switch (vt) {
+        .i32, .i64, .ref => n_int += 1,
+        .f32, .f64 => n_fp += 1,
+        .v128 => return false,
+    };
+    if (budget.shared_positions) return n_int + n_fp <= budget.int_regs;
+    return n_int <= budget.int_regs and n_fp <= budget.fp_regs;
+}
+
+/// #390 — can the cross-module bridge carry this signature on the running
+/// target without an overflow stack argument or a MEMORY-class return?
+fn bridgeCanCarry(sig: zir.FuncType) bool {
+    return bridgeCanCarryFor(builtin.target.cpu.arch, builtin.target.os.tag, sig);
+}
+
+test "bridgeCanCarry: the register budget per target, both sides of each boundary (#390)" {
+    const i32s = [_]zir.ValType{.i32} ** 8;
+    const f64s = [_]zir.ValType{.f64} ** 9;
+    const one = [_]zir.ValType{.i32};
+    const three = [_]zir.ValType{.i32} ** 3;
+    const sig = struct {
+        fn of(params: []const zir.ValType, results: []const zir.ValType) zir.FuncType {
+            return .{ .params = params, .results = results };
+        }
+    };
+    // SysV x86_64: 5 int / 8 fp, classes counted separately.
+    try testing.expect(bridgeCanCarryFor(.x86_64, .linux, sig.of(i32s[0..5], &one)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .linux, sig.of(i32s[0..6], &one)));
+    try testing.expect(bridgeCanCarryFor(.x86_64, .linux, sig.of(f64s[0..8], &one)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .linux, sig.of(f64s[0..9], &one)));
+    // Win64: 3 positions shared by int and fp.
+    try testing.expect(bridgeCanCarryFor(.x86_64, .windows, sig.of(i32s[0..3], &one)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .windows, sig.of(i32s[0..4], &one)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .windows, sig.of(&[_]zir.ValType{ .i32, .i32, .f64, .i32 }, &one)));
+    try testing.expect(bridgeCanCarryFor(.x86_64, .windows, sig.of(&[_]zir.ValType{ .i32, .f64, .i32 }, &one)));
+    // arm64: X1..X7 and V0..V7.
+    try testing.expect(bridgeCanCarryFor(.aarch64, .macos, sig.of(i32s[0..7], &one)));
+    try testing.expect(!bridgeCanCarryFor(.aarch64, .macos, sig.of(i32s[0..8], &one)));
+    try testing.expect(bridgeCanCarryFor(.aarch64, .macos, sig.of(f64s[0..8], &one)));
+    try testing.expect(!bridgeCanCarryFor(.aarch64, .macos, sig.of(f64s[0..9], &one)));
+    // MEMORY-class results and v128 are never carried.
+    try testing.expect(bridgeCanCarryFor(.x86_64, .linux, sig.of(&one, &[_]zir.ValType{ .i32, .i32 })));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .linux, sig.of(&one, &three)));
+    try testing.expect(!bridgeCanCarryFor(.aarch64, .macos, sig.of(&one, &three)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .linux, sig.of(&[_]zir.ValType{.v128}, &one)));
+    // The shape the conformance case uses: six ints, one result.
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .linux, sig.of(i32s[0..6], &one)));
+    try testing.expect(!bridgeCanCarryFor(.x86_64, .windows, sig.of(i32s[0..6], &one)));
+    try testing.expect(bridgeCanCarryFor(.aarch64, .macos, sig.of(i32s[0..6], &one)));
 }
 
 /// #387 — does this signature name a type-section INDEX anywhere? Such a type

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -965,6 +965,62 @@ fn bridgeCanCarry(sig: zir.FuncType) bool {
     return bridgeCanCarryFor(builtin.target.cpu.arch, builtin.target.os.tag, sig);
 }
 
+// #390 — the budget above is a COPY of the call site's marshalling rule, and a
+// copy is where a defect hides (the #385 thunk was one). This pins that the
+// two agree on the host target: for every signature the fence looks at, it
+// carries exactly the ones the JIT call site marshals without an overflow
+// region — SysV: buffer offset 0; Win64: exactly the shadow space; arm64:
+// overflow bytes 0. v128 is excluded (the fence declines it unconditionally)
+// and results > 2 are asserted declined regardless of the call site.
+const call_site = switch (builtin.target.cpu.arch) {
+    .x86_64 => struct {
+        const op_call = @import("../engine/codegen/x86_64/op_call.zig");
+        const abi = @import("../engine/codegen/x86_64/abi.zig");
+        fn noOverflow(sig: zir.FuncType) bool {
+            return op_call.computeCallReturnBufferOff(sig) == abi.current.shadow_space_bytes;
+        }
+    },
+    .aarch64 => struct {
+        const op_call = @import("../engine/codegen/arm64/op_call.zig");
+        fn noOverflow(sig: zir.FuncType) bool {
+            return op_call.computeCallOverflowBytes(sig) == 0;
+        }
+    },
+    else => struct {
+        fn noOverflow(sig: zir.FuncType) bool {
+            _ = sig;
+            return false;
+        }
+    },
+};
+
+test "bridgeCanCarry agrees with the JIT call site's own overflow rule on this target (#390)" {
+    var params: [20]zir.ValType = undefined;
+    const one = [_]zir.ValType{.i32};
+    const three = [_]zir.ValType{ .i32, .i32, .i32 };
+    var n_int: usize = 0;
+    while (n_int <= 10) : (n_int += 1) {
+        var n_fp: usize = 0;
+        while (n_fp <= 10) : (n_fp += 1) {
+            // ints first, then fps: the class counts are what both rules read.
+            for (0..n_int) |k| params[k] = .i32;
+            for (0..n_fp) |k| params[n_int + k] = .f64;
+            const sig: zir.FuncType = .{ .params = params[0 .. n_int + n_fp], .results = &one };
+            try testing.expectEqual(call_site.noOverflow(sig), bridgeCanCarry(sig));
+            // A MEMORY-class result is declined whatever the call site says.
+            const mem_sig: zir.FuncType = .{ .params = params[0 .. n_int + n_fp], .results = &three };
+            try testing.expect(!bridgeCanCarry(mem_sig));
+        }
+    }
+    // refs share the integer class in both rules.
+    const refs = [_]zir.ValType{.{ .ref = zir.RefType.abs(.func, true) }} ** 9;
+    var n: usize = 0;
+    while (n <= 9) : (n += 1) {
+        const sig: zir.FuncType = .{ .params = refs[0..n], .results = &one };
+        try testing.expectEqual(call_site.noOverflow(sig), bridgeCanCarry(sig));
+    }
+}
+
 test "bridgeCanCarry: the register budget per target, both sides of each boundary (#390)" {
     const i32s = [_]zir.ValType{.i32} ** 8;
     const f64s = [_]zir.ValType{.f64} ** 9;

--- a/src/engine/codegen/arm64/op_call.zig
+++ b/src/engine/codegen/arm64/op_call.zig
@@ -134,7 +134,7 @@ fn homedCallerSavedSpillReload(ctx: *EmitCtx, dir: SpillDir) Error!void {
 /// `[SP, #N..N + n_results*8 - 1]`. v128 args are excluded
 /// (current callees' v128 args ride V0..V7 in-pool; future
 /// overflow-v128 needs its own 16 B aligned slot accounting).
-fn computeCallOverflowBytes(callee_sig: FuncType) u32 {
+pub fn computeCallOverflowBytes(callee_sig: FuncType) u32 {
     var n_int: u32 = 0;
     var n_fp: u32 = 0;
     for (callee_sig.params) |p| {

--- a/src/engine/codegen/x86_64/op_call.zig
+++ b/src/engine/codegen/x86_64/op_call.zig
@@ -201,7 +201,7 @@ pub fn emitCallIndirectCtx(ctx: *ctx_mod.EmitCtx, ins: *const zir.ZirInstr) Erro
 /// v128 args excluded from SysV path (rare + 16B alignment
 /// complications). For non-MEMORY callees, return value is
 /// unused.
-fn computeCallReturnBufferOff(callee_sig: zir.FuncType) u32 {
+pub fn computeCallReturnBufferOff(callee_sig: zir.FuncType) u32 {
     var n_int: u32 = 0;
     var n_fp: u32 = 0;
     var n_v128: u32 = 0;

--- a/test/c_api_conformance/cross_module_func.c
+++ b/test/c_api_conformance/cross_module_func.c
@@ -329,11 +329,123 @@ cleanup:
     return rc;
 }
 
+/* (module (func (export "sixth") (param i32 i32 i32 i32 i32 i32) (result i32)
+ *         local.get 5))
+ * Six integer parameters: one more than the JIT's SysV user arg registers
+ * (five — arg0 is the runtime pointer), so the sixth travels on the stack. */
+static const uint8_t kSixArgExporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0b, 0x01, 0x60, 0x06, 0x7f, 0x7f, 0x7f,
+    0x7f, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x09, 0x01, 0x05, 0x73, 0x69, 0x78,
+    0x74, 0x68, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x20, 0x05, 0x0b,
+};
+
+/* (module (import "b" "sixth" (func (param i32 i32 i32 i32 i32 i32) (result i32)))
+ *         (func (export "test") (result i32)
+ *           i32.const 1 i32.const 2 i32.const 3 i32.const 4 i32.const 5 i32.const 6
+ *           call 0)) */
+static const uint8_t kSixArgImporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0f, 0x02, 0x60, 0x06, 0x7f, 0x7f, 0x7f,
+    0x7f, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x00, 0x01, 0x7f, 0x02, 0x0b, 0x01, 0x01, 0x62, 0x05, 0x73,
+    0x69, 0x78, 0x74, 0x68, 0x00, 0x00, 0x03, 0x02, 0x01, 0x01, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65,
+    0x73, 0x74, 0x00, 0x01, 0x0a, 0x12, 0x01, 0x10, 0x00, 0x41, 0x01, 0x41, 0x02, 0x41, 0x03, 0x41,
+    0x04, 0x41, 0x05, 0x41, 0x06, 0x10, 0x00, 0x0b,
+};
+
+/* A signature the cross-module bridge cannot carry. The bridge thunk takes no
+ * signature: an argument that overflows the register set is written by the
+ * importer relative to ITS stack, and the exporter reads it relative to its own
+ * frame — with the thunk's frame in between, it reads the wrong slot. The same
+ * holds for a result the ABI returns through a hidden buffer pointer.
+ *
+ * The contract this asserts is "declined or correct, never wrong": a JIT-backed
+ * engine may refuse to build the importer (NULL, as v2.6.0 did for every
+ * cross-module import), but if it does build it, the call must return 6. The
+ * interpreter, which has no bridge, must return 6. When the bridge learns to
+ * carry the shape, the NULL arm simply stops being taken. */
+static int declines_or_carries_six_args(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* importer_module = NULL;
+    wasm_instance_t* importer = NULL;
+    wasm_extern_vec_t importer_exports = { 0, NULL };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_binary = { sizeof(kSixArgExporterWasm), (wasm_byte_t*) kSixArgExporterWasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fprintf(stderr, "[%s] six-arg exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) { fprintf(stderr, "[%s] six-arg exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] six-arg exporter exposed nothing\n", who);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t importer_binary = { sizeof(kSixArgImporterWasm), (wasm_byte_t*) kSixArgImporterWasm };
+    importer_module = wasm_module_new(store, &importer_binary);
+    if (!importer_module) { fprintf(stderr, "[%s] six-arg importer failed to parse\n", who); goto cleanup; }
+    wasm_extern_t* import_externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t imports = { 1, import_externs };
+    wasm_trap_t* itrap = NULL;
+    importer = zwasm_instance_new_ex(store, importer_module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!importer) {
+        if (engine == ZWASM_ENGINE_INTERP) {
+            fprintf(stderr, "[interp] the six-arg importer failed to instantiate\n");
+            goto cleanup;
+        }
+        /* Declined: the shape is withheld rather than carried wrongly. */
+        fprintf(stderr, "[%s] six-arg cross-module import declined (withheld, not carried)\n", who);
+        rc = 0;
+        goto cleanup;
+    }
+    wasm_instance_exports(importer, &importer_exports);
+    if (importer_exports.size < 1 || !importer_exports.data[0]) {
+        fprintf(stderr, "[%s] the six-arg importer is missing its `test` export\n", who);
+        goto cleanup;
+    }
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(importer_exports.data[0]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the six-arg cross-module call trapped\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 6) {
+        fprintf(stderr, "[%s] the bridge carried a six-arg call and got it WRONG: sixth arg read as %d, expected 6\n",
+                who, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (importer_exports.data) wasm_extern_vec_delete(&importer_exports);
+    if (importer) wasm_instance_delete(importer);
+    if (importer_module) wasm_module_delete(importer_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
 int main(void) {
     for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
         if (compose_on(kEngines[i]) != 0) return 1;
         if (outlives_exporter(kEngines[i]) != 0) return 1;
         if (outlives_module_bytes(kEngines[i]) != 0) return 1;
+        if (declines_or_carries_six_args(kEngines[i]) != 0) return 1;
     }
     return 0;
 }


### PR DESCRIPTION
Follow-up to #382, and what a release containing it needs. Not #390's fix.

## What #382 made reachable

The D-225 bridge thunk takes no signature (#390). Two shapes are wrong
through it under every convention: an argument that overflows the register
set — written by the importer relative to ITS stack, read by the exporter at
`[RBP + 16 + …]` / `[X29, #16 + …]` relative to its own frame, with the thunk's
frame in between — and a MEMORY-class result (`results.len > 2`), whose hidden
buffer pointer `emitImportDispatch` and the thunk both overwrite.

Before #382 no embedder could reach the bridge: every cross-module func import
returned NULL. After it, the stock `wasm_instance_new` binds one, and on this
branch's parent the new conformance case measured:

```
[auto] the bridge carried a six-arg call and got it WRONG: sixth arg read as 8, expected 6
```

A silent wrong answer on the default engine — the invariant `instantiateJit`
states ("uncovered shapes never reach the JIT body") was broken by #382 for
this shape, and I missed it there: the host-func sibling in the same function
has a signature-coverage gate (`dispatchPtrFor`) and the cross-module path I
added did not mirror it.

## The change

`crossModuleJitTarget` declines a signature the bridge cannot carry, so the JIT
rejects the module and `.auto` falls through to the interp retry — which fails
on a JIT-backed source, so the composition returns NULL, exactly as `v2.6.0`
did. A withheld acceptance, not a removed one; #390 lifts it.

The budget is the JIT's own call-site marshalling rule per target, one row
each, cited to the code that marshals:

| target | int args | fp args | note |
|---|---|---|---|
| x86_64 SysV | 5 (RSI..R9; RDI = runtime) | 8 XMM | classes counted separately — `x86_64/op_call.zig` |
| x86_64 Win64 | 3 positions (RDX/R8/R9; RCX = runtime) | shared | int and fp share the positions — `op_call.zig` `n_total` |
| arm64 | 7 (X1..X7; X0 = runtime) | 8 (V0..V7) | `arm64/emit.zig` multi-arg entry |

`results.len > 2` and any `v128` argument are declined everywhere. The table
lives in `api/instance.zig` rather than importing the per-arch `abi.zig`
tables into Zone 3; a unit test pins both sides of every boundary for all
three targets from one host, including the six-int shape the conformance case
uses (declined on x86_64, carried on arm64).

## Proof

`cross_module_func.c` gains `declines_or_carries_six_args`, whose contract is
*declined or correct, never wrong*: a JIT-backed engine may refuse to build
the importer (NULL), but if it builds it the call must return 6; the
interpreter must return 6. Red on the parent commit (`8` for `6` on `auto`),
green here (`auto`/`jit` decline, `interp` 6). On the macOS leg arm64's seven
int registers carry the shape, so that leg exercises the value arm — a
regression there would say the arm64 bridge has a problem of its own.

When #390 makes the bridge signature-aware, the NULL arm stops being taken and
the test needs no edit.

## The budget lives twice, and a test says the copies agree

The call site's marshalling rule (`x86_64/op_call.zig`,
`arm64/op_call.zig`) and `bridgeBudgetFor` are two copies of one fact, and a
copy is where a defect hides — the #385 thunk was one. A second unit test
sweeps int × fp counts (0–10 each, plus refs) on the host target and asserts
`bridgeCanCarry(sig)` equals "the call site marshals no overflow region":
`computeCallReturnBufferOff(sig) == shadow_space_bytes` on x86_64 (0 under
SysV, 32 under Win64), `computeCallOverflowBytes(sig) == 0` on arm64, with
MEMORY-class results asserted declined regardless. The two helpers become
`pub` for it; nothing else in Zone 2 changes. Each CI leg checks its own
target's copy.

## Measured from outside, not by this PR

A read-only pass over this branch through the stock C API found the fence
holding on both sides on x86_64-linux — the #390 shapes (7 × i32, a
three-result return) NULL on `jit`/`auto` and correct on `interp`; everything
inside the budget (an fp result, two results in RAX:RDX, exactly 5 × i32 +
8 × f64) correct on all three. The same pass found, by accident, that an
import vector shorter than the module's import count segfaults on every
engine: `instanceNewWithEngine` hands the binder `.data` "indexed by the
module's import count" and never compares `.size`. Pre-existing at `v2.6.0`,
independent of #360, filed as its own issue; not this PR.

Refs #390. Does not touch #386 / #387 / #388.
