### PR TITLE
capi: fail instantiation on an import vector shorter than the import count

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1367,6 +1367,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/trap_kind_per_call.c", .name = "trap_kind_per_call" }, // #336 the kind describes the call just made
         .{ .src = "test/c_api_conformance/gc_heap_cap_trap.c", .name = "gc_heap_cap_trap" }, // #361 GC heap cap is OUT_OF_MEMORY
         .{ .src = "test/c_api_conformance/cross_module_func.c", .name = "cross_module_func" }, // #360 cross-module func import on every engine
+        .{ .src = "test/c_api_conformance/instance_new_short_imports.c", .name = "instance_new_short_imports" }, // #392 a short import vector is NULL, not a read past it
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -601,7 +601,7 @@ fn lookupSourceExportType(
 fn buildBindings(
     arena_alloc: std.mem.Allocator,
     bytes: []const u8,
-    imports_array: ?[*]const ?*const Extern,
+    imports_array: ?[]const ?*const Extern,
     store: *Store,
 ) !?[]const runtime_instance_import.ImportBinding {
     var module = try parser.parse(arena_alloc, bytes);
@@ -638,7 +638,9 @@ fn buildBindings(
             } };
             continue;
         }
-        const ext_ptr = if (imports_array) |arr| arr[idx] else null;
+        // #392 — an entry the vector does not have is a missing import, not
+        // a read past the vector.
+        const ext_ptr = if (imports_array) |arr| (if (idx < arr.len) arr[idx] else null) else null;
         const ext = ext_ptr orelse return error.UnknownImportModule;
         const want_kind: ExternKind = switch (it.kind) {
             .func => .func,
@@ -815,9 +817,14 @@ pub fn instanceNewWithEngine(
     // wasm.h: `imports` is `const wasm_extern_vec_t*` ({size,data}), NOT a
     // bare extern array. Recast to the vec; hand buildBindings its `.data`
     // (indexed by the module's import count). Null vec/data → no imports.
-    const imports_array: ?[*]const ?*const Extern = if (imports) |p| iblk: {
+    // #392 — carry the vector's `.size` with its `.data`: the binder indexes
+    // this by the module's import count, and a vector shorter than that must
+    // fail instantiation (NULL) rather than be read past its end.
+    const imports_array: ?[]const ?*const Extern = if (imports) |p| iblk: {
         const v: *const ExternVec = @ptrCast(@alignCast(p));
-        break :iblk if (v.data) |d| @ptrCast(d) else null;
+        const d = v.data orelse break :iblk null;
+        const arr: [*]const ?*const Extern = @ptrCast(d);
+        break :iblk arr[0..v.size];
     } else null;
 
     // D-275: thread `trap_out` so a start-function trap surfaces per the
@@ -1145,7 +1152,7 @@ fn collectFromExterns(
     ta: std.mem.Allocator,
     type_section_body: []const u8,
     items: []const sections.Import,
-    arr: [*]const ?*const Extern,
+    arr: []const ?*const Extern,
 ) error{ Unsupported, OutOfMemory }!JitFuncImports {
     var types = sections.decodeTypes(ta, type_section_body) catch return error.Unsupported;
     defer types.deinit();
@@ -1157,6 +1164,7 @@ fn collectFromExterns(
     for (items, 0..) |it, i| {
         const func_idx: u32 = @intCast(i);
         if (jit_dispatch.lookup(it.module, it.name) != null) continue; // WASI → setup plants it
+        if (i >= arr.len) return error.Unsupported; // #392 — short vector
         const ext = arr[i] orelse return error.Unsupported;
         if (ext.kind != .func) return error.Unsupported;
         if (ext.instance) |source_inst| {
@@ -1362,11 +1370,11 @@ pub const BindingsBuilder = struct {
     /// path reads the `Extern`s directly (`collectFromExterns`): `build` is
     /// the interp binder, and it cannot describe an import whose source
     /// instance is JIT-backed. Null for the native-facade builder.
-    imports: ?[*]const ?*const Extern = null,
+    imports: ?[]const ?*const Extern = null,
 };
 
 const BuildBindingsCApi = struct {
-    imports_array: ?[*]const ?*const Extern,
+    imports_array: ?[]const ?*const Extern,
 
     fn buildImpl(ctx: *anyopaque, arena_alloc: std.mem.Allocator, bytes: []const u8, store: *Store) anyerror!?[]const runtime_instance_import.ImportBinding {
         const self: *BuildBindingsCApi = @ptrCast(@alignCast(ctx));

--- a/test/c_api_conformance/instance_new_short_imports.c
+++ b/test/c_api_conformance/instance_new_short_imports.c
@@ -1,0 +1,109 @@
+/* zwasm v2 — C-API conformance: an import vector shorter than the module's
+ * import count must make instantiation fail, not read past the vector.
+ *
+ * `wasm_instance_new` takes a `wasm_extern_vec_t` ({size, data}). The binder
+ * indexed `.data` by the module's import count and never looked at `.size`,
+ * so a short vector read whatever lay beyond it and dereferenced it — a
+ * segfault on every engine (#392). Under wasm-c-api a short vector is an
+ * embedder error; the library's answer to it is NULL, not a crash.
+ *
+ * A 2-import module is handed a 1-entry vector, on all three engines; the
+ * exporter's single export fills the one entry so the only thing wrong is the
+ * length. Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (func (export "get") (result i32) (i32.const 42))) */
+static const uint8_t kExporterWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x03,
+    0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04,
+    0x00, 0x41, 0x2a, 0x0b,
+};
+
+/* (module (import "b" "get" (func (result i32)))
+ *         (import "b" "get2" (func (result i32)))
+ *         (func (export "test") (result i32) call 0)) */
+static const uint8_t kTwoImportWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, 0x02,
+    0x12, 0x02, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, 0x01, 0x62, 0x04, 0x67, 0x65, 0x74,
+    0x32, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00,
+    0x02, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+};
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+static int short_vector_is_null(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter_module = NULL;
+    wasm_instance_t* exporter = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* importer_module = NULL;
+    wasm_instance_t* importer = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_binary = { sizeof(kExporterWasm), (wasm_byte_t*) kExporterWasm };
+    exporter_module = wasm_module_new(store, &exporter_binary);
+    if (!exporter_module) { fprintf(stderr, "[%s] exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    wasm_trap_t* etrap = NULL;
+    exporter = zwasm_instance_new_ex(store, exporter_module, &no_imports, &etrap, engine);
+    if (etrap) wasm_trap_delete(etrap);
+    if (!exporter) { fprintf(stderr, "[%s] exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter, &exporter_exports);
+    if (exporter_exports.size < 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] exporter exposed nothing\n", who);
+        goto cleanup;
+    }
+
+    wasm_byte_vec_t importer_binary = { sizeof(kTwoImportWasm), (wasm_byte_t*) kTwoImportWasm };
+    importer_module = wasm_module_new(store, &importer_binary);
+    if (!importer_module) { fprintf(stderr, "[%s] two-import module failed to parse\n", who); goto cleanup; }
+
+    /* One valid entry for a module that declares two imports. What lies past
+     * the entry on the stack is deliberately not a NULL: a NULL would be
+     * caught as a missing import, and the point is that the runtime must not
+     * read there at all. */
+    wasm_extern_t* one_entry[2] = { exporter_exports.data[0], (wasm_extern_t*) (uintptr_t) 0x4141414141414141ull };
+    wasm_extern_vec_t short_vec = { 1, one_entry };
+    wasm_trap_t* itrap = NULL;
+    importer = zwasm_instance_new_ex(store, importer_module, &short_vec, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (importer) {
+        fprintf(stderr, "[%s] a 1-entry vector instantiated a 2-import module\n", who);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (importer) wasm_instance_delete(importer);
+    if (importer_module) wasm_module_delete(importer_module);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter) wasm_instance_delete(exporter);
+    if (exporter_module) wasm_module_delete(exporter_module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (short_vector_is_null(kEngines[i]) != 0) return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
`wasm_instance_new(store, module, imports, trap)` takes a `wasm_extern_vec_t`
(`{size, data}`). `instanceNewWithEngine` recast it to a bare many-pointer and
handed the binder `.data` alone — the comment beside it said "indexed by the
module's import count", and that was the whole problem: `.size` was dropped,
so a vector shorter than the module's import section was read past its end
and the pointer found there dereferenced.

Measured on `main` through the stock C API: a 2-import module with a 1-entry
vector segfaults in the first instantiation on every engine (`interp` first,
because it runs first). Pre-existing at `v2.6.0`; independent of #360, which
changed what a *present* extern resolves to, not whether one is present.

## The change

The vector travels as a slice (`?[]const ?*const Extern`) from the recast
through `BuildBindingsCApi` / `BindingsBuilder.imports` to both indexing
sites, so the length is part of the type rather than a separate argument one
site could forget:

- `buildBindings` (interp binder): an index the vector does not have is a
  missing import — `error.UnknownImportModule`, NULL to the embedder, the same
  answer as an explicit NULL entry;
- `collectFromExterns` (JIT resolver): the same index is `Unsupported`, so the
  JIT declines and the interp retry reaches the first branch.

A vector *longer* than the import count is still accepted with the extras
ignored — unchanged, and not this issue's subject.

## Proof

`test/c_api_conformance/instance_new_short_imports.c`: a 2-import module, a
1-entry vector whose one entry is valid, on all three engines — instantiation
must return NULL. The slot past the vector's end holds a non-NULL sentinel on
purpose: a NULL there would be caught as a missing import and the test would
pass without proving the runtime stopped reading. Red on the parent
(`process terminated with signal SEGV`), green here.

Under wasm-c-api a short vector is an embedder error; with #353 it would also
carry a reason. This PR gives it the answer a library owes: NULL, not a crash.

Closes #392.
