### PR TITLE
jit: liveness's .end asserts its frame base and closes to the frame's result shape

### DIFF
--- a/src/engine/codegen/arm64/emit.zig
+++ b/src/engine/codegen/arm64/emit.zig
@@ -879,7 +879,7 @@ pub fn compile(
     for (func.instrs.items, 0..) |ins, pc| {
         // D-596 — mirror of the x86_64 call; see `shared/liveness_parity.zig`.
         if (parity_on) {
-            liveness_parity.check(func, pc, ins.op, pushed_vregs.items, labels.items, dead_code);
+            liveness_parity.check(func, pc, ins.op, pushed_vregs.items, labels.items);
         }
         // Diagnostic surface: on any error return
         // from the per-op switch below, surface the failing op

--- a/src/engine/codegen/arm64/emit_test_local.zig
+++ b/src/engine/codegen/arm64/emit_test_local.zig
@@ -144,7 +144,7 @@ test "compile: 1 local — prologue includes SUB SP,SP,#16; epilogue ADD SP,SP,#
     try f.instrs.append(testing.allocator, .{ .op = .@"local.set", .payload = 0 });
     try f.instrs.append(testing.allocator, .{ .op = .@"local.get", .payload = 0 });
     try f.instrs.append(testing.allocator, .{ .op = .end });
-    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
@@ -180,7 +180,7 @@ test "compile: 3 locals — frame rounds up to 32 bytes (3*8=24 → align to 32)
     try f.instrs.append(testing.allocator, .{ .op = .@"local.set", .payload = 2 });
     try f.instrs.append(testing.allocator, .{ .op = .@"local.get", .payload = 2 });
     try f.instrs.append(testing.allocator, .{ .op = .end });
-    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
@@ -218,7 +218,7 @@ test "compile: local.tee writes to local but keeps value pushed" {
     try f.instrs.append(testing.allocator, .{ .op = .@"local.tee", .payload = 0 });
     // After tee, vreg0 still on stack. end consumes it.
     try f.instrs.append(testing.allocator, .{ .op = .end });
-    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);

--- a/src/engine/codegen/shared/compile.zig
+++ b/src/engine/codegen/shared/compile.zig
@@ -231,7 +231,7 @@ pub fn compileOne(
     }
 
     trace.passEnter(func_idx, .liveness);
-    const lv = try liveness.compute(allocator, &func, func_sigs, module_types);
+    const lv = try liveness.compute(allocator, &func, func_sigs, module_types, tag_param_counts);
     func.liveness = lv;
     // ZirFunc.deinit does NOT walk into the (optional) liveness
     // slot — that slot is owned by the FuncResult, freed via

--- a/src/engine/codegen/shared/liveness_parity.zig
+++ b/src/engine/codegen/shared/liveness_parity.zig
@@ -12,17 +12,21 @@
 //! D-330, #245 and two of #253's three shapes are depth-neutral and only show
 //! up as a differing vreg id.
 //!
-//! Two places where the models legitimately differ, both reconstructible from
+//! One place where the models legitimately differ, reconstructible from
 //! state the emit already holds:
 //!
-//!   1. Dead code. An unconditional terminator drains liveness's `sim_stack`;
-//!      the emit sets `dead_code` and freezes `pushed_vregs` until the `.end`
-//!      or `.else` that clears it. Skipped via the caller's own flag.
-//!   2. The else arm of an `if (result T…)` with no params. `emitElse`
+//!   1. The else arm of an `if (result T…)` with no params. `emitElse`
 //!      captures the then-arm's top `result_arity` vregs as the merge target
 //!      and leaves them ON `pushed_vregs`; liveness's `.else` truncates to the
 //!      frame's entry depth and drops them. `expected()` deletes them again,
 //!      driven by the emit's own label stack.
+//!
+//! Dead code is not one of them any more. A terminator pops what the op
+//! consumes and then leaves the stack alone on both sides — the emit by
+//! freezing `pushed_vregs` under `dead_code`, liveness by closing ranges
+//! without popping — so the `.end` or `.else` that clears the flag (the
+//! next pc, since the lowerer prunes the dead body) sees one frozen stack
+//! on each side and is compared like any other pc.
 //!
 //! Zone 2 (`engine/`); reads Zone 1 `ir/` downward, which the layering allows.
 
@@ -69,10 +73,8 @@ pub fn check(
     op: zir.ZirOp,
     pushed_vregs: []const u32,
     labels: anytype,
-    dead_code: bool,
 ) void {
     if (!compiled_in) return;
-    if (dead_code) return;
     const lv = func.liveness orelse return;
     if (pc >= lv.stack_depth.len) return;
 

--- a/src/engine/codegen/x86_64/emit.zig
+++ b/src/engine/codegen/x86_64/emit.zig
@@ -910,7 +910,7 @@ pub fn compile(
         // D-596 — liveness's operand-stack simulation must still agree with
         // what this loop does to `pushed_vregs`. Off unless the diagnostic is.
         if (parity_on) {
-            liveness_parity.check(func, pc, ins.op, pushed_vregs.items, labels.items, dead_code);
+            liveness_parity.check(func, pc, ins.op, pushed_vregs.items, labels.items);
         }
         // `end` / `else` always exit the dead region — emit's own
         // bookkeeping (label-stack pop / arm switch) must run.

--- a/src/engine/codegen/x86_64/emit_test_int.zig
+++ b/src/engine/codegen/x86_64/emit_test_int.zig
@@ -133,7 +133,7 @@ test "compile: function with 1 local + (i32.const 42) (local.set 0) (local.get 0
     try f.instrs.append(testing.allocator, .{ .op = .@"local.set", .payload = 0 });
     try f.instrs.append(testing.allocator, .{ .op = .@"local.get", .payload = 0 });
     try f.instrs.append(testing.allocator, .{ .op = .end });
-    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);
@@ -171,7 +171,7 @@ test "compile: local.tee preserves stack — uses top vreg without popping" {
     try f.instrs.append(testing.allocator, .{ .op = .@"i32.const", .payload = 7 });
     try f.instrs.append(testing.allocator, .{ .op = .@"local.tee", .payload = 0 });
     try f.instrs.append(testing.allocator, .{ .op = .end });
-    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try liveness.compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |lv| liveness.deinit(testing.allocator, lv);
     const alloc = try regalloc.compute(testing.allocator, &f);
     defer regalloc.deinit(testing.allocator, alloc);

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -413,14 +413,36 @@ pub fn compute(
                         }
                     }
                 }
+                // Mirror of `emitEndIntra`'s closing step. Whatever the
+                // arms above left, the frame closes to `[..base) ++
+                // results`, the shape the validator hands the enclosing
+                // frame: the top `result_arity` entries move down to
+                // `base`, anything between is dropped. The snapshot is
+                // one side of a comparison (`liveness_parity`), so it
+                // computes that shape rather than assume it. A body that
+                // never produced its results (it ended in a terminator
+                // with nothing on the stack) leaves the frame short; the
+                // emit names each missing result vreg 0, its dead-fall-
+                // through placeholder, and the snapshot carries the same
+                // id. The range extension a later pop of it records on
+                // vreg 0 is conservative.
+                //
+                // Before the first vreg is minted that id names nothing:
+                // the emit's own read of it is out of bounds
+                // (`regalloc.slot`), and pushing it here would move that
+                // read to the next pop. The snapshot stays short there,
+                // and the parity check reports the difference, which is
+                // a true statement about the emit.
+                const frame_base: usize = @as(usize, fr.entry_depth) -| @as(usize, fr.param_arity);
+                const closed_len: usize = frame_base + @as(usize, fr.result_arity);
+                if (sim_len > closed_len) {
+                    const results: usize = fr.result_arity;
+                    std.mem.copyForwards(u32, sim_stack[frame_base..closed_len], sim_stack[sim_len - results .. sim_len]);
+                    sim_len = closed_len;
+                }
+                while (sim_len < closed_len and ranges.items.len != 0) : (sim_len += 1) sim_stack[sim_len] = 0;
                 block_stack_len -= 1;
             }
-            // Mid-function `end` (block/loop/if frame closer) is
-            // transparent at the liveness level — values produced
-            // inside the block stay on the operand stack and flow
-            // naturally to the next consumer. The Wasm validator
-            // already enforces stack-shape consistency at block
-            // boundaries.
             continue;
         }
 
@@ -616,29 +638,38 @@ pub fn compute(
         // the callee's params, marshalled by the emit layer, and
         // control never reaches subsequent ops at this PC).
         // ADR-0113 §A: is_terminator=true, n_successor_edges=0.
-        // "Drain" here means down to the innermost open frame's entry
-        // depth, not to 0 — see the body.
+        // "Drain" here closes ranges; the stack itself stays — see the body.
         if (instr.op == .@"return" or instr.op == .@"unreachable" or
             instr.op == .throw or instr.op == .throw_ref or
             instr.op == .return_call or instr.op == .return_call_indirect or
             instr.op == .return_call_ref)
         {
-            // Drain only to the innermost open frame's entry depth — the
-            // same rule the `br` handler below applies, for the same reason:
-            // control never falls through, but the next reachable code
-            // resumes at that frame's `.end`, so values below it are still
-            // read. The emit does not drain `pushed_vregs` on these ops at
-            // all (it sets `dead_code` and skips the rest of the body), so
-            // draining to 0 here would desync the two models and let the
-            // block-merge `.end` pad over slots it cannot reconstruct.
+            // The emit pops what the op itself consumes by value — the
+            // `throw_ref` exception, the `return_call_indirect` table index,
+            // the `return_call_ref` funcref — and then freezes
+            // `pushed_vregs` (it sets `dead_code`); `return`, `unreachable`
+            // and `return_call` read their operands in place. Mirror that:
+            // pop the same, close every range above the innermost open
+            // frame's entry depth (control never falls through, so this is
+            // their last read), and leave the rest of the stack for that
+            // frame's `.end` to close, exactly as the emit's frozen stack
+            // reaches its `emitEndIntra`.
+            if (instr.op == .throw_ref or instr.op == .return_call_indirect or
+                instr.op == .return_call_ref)
+            {
+                if (sim_len > 0) {
+                    sim_len -= 1;
+                    ranges.items[sim_stack[sim_len]].last_use_pc = pc;
+                }
+            }
             const innermost_entry_term: u32 = if (block_stack_len == 0)
                 0
             else
                 block_stack[block_stack_len - 1].entry_depth;
-            while (sim_len > @as(usize, innermost_entry_term)) {
-                sim_len -= 1;
-                const vreg = sim_stack[sim_len];
-                ranges.items[vreg].last_use_pc = pc;
+            var k: usize = sim_len;
+            while (k > @as(usize, innermost_entry_term)) {
+                k -= 1;
+                ranges.items[sim_stack[k]].last_use_pc = pc;
             }
             continue;
         }
@@ -681,16 +712,19 @@ pub fn compute(
             // across the enclosing block when the target was an outer
             // block, killing that lhs early -> regalloc aliased its reg
             // with the `$exit` fall-through const (got 25, expected 50).
-            // The emit mirrors this: its forward-`br` leaves `pushed_vregs`
-            // intact; only the per-block `.end` truncates.
+            // The emit's forward `br` leaves `pushed_vregs` intact; only the
+            // per-block `.end` truncates. So close the ranges here and leave
+            // the vregs where they are — the innermost frame's `.end` keeps
+            // the top `result_arity` of them as that frame's result, as the
+            // emit does, and the snapshot has to agree with it there.
             const innermost_entry: u32 = if (block_stack_len == 0)
                 0
             else
                 block_stack[block_stack_len - 1].entry_depth;
-            while (sim_len > @as(usize, innermost_entry)) {
-                sim_len -= 1;
-                const vreg = sim_stack[sim_len];
-                ranges.items[vreg].last_use_pc = pc;
+            var k: usize = sim_len;
+            while (k > @as(usize, innermost_entry)) {
+                k -= 1;
+                ranges.items[sim_stack[k]].last_use_pc = pc;
             }
             continue;
         }
@@ -983,7 +1017,10 @@ test "compute: D-093 (d-3) local.tee keeps the input vreg alive across the tee" 
 
 test "compute: br closes all live vregs at branch site (sub-7.5c-iv)" {
     // (i32.const 1) (br) (end) — `br` is now handled, not rejected.
-    // The const's vreg should have last_use_pc == br's pc.
+    // With no frame open the `br` is the function-level return: it
+    // reads the const's vreg in place and the emit keeps it on
+    // `pushed_vregs`, so the function-level `end` reads it once more
+    // and the range closes there (pc 2), not at the `br`.
     var f = try buildFunc(testing.allocator, &.{
         .{ .op = .@"i32.const", .payload = 1 },
         .{ .op = .br },
@@ -994,7 +1031,7 @@ test "compute: br closes all live vregs at branch site (sub-7.5c-iv)" {
     const live = try compute(testing.allocator, &f, &.{}, &.{});
     defer deinit(testing.allocator, live);
     try testing.expectEqual(@as(usize, 1), live.ranges.len);
-    try testing.expectEqual(@as(u32, 1), live.ranges[0].last_use_pc); // br at pc=1
+    try testing.expectEqual(@as(u32, 2), live.ranges[0].last_use_pc);
 }
 
 test "compute: pop on empty stack is tolerant (validator-cleared dead-code path)" {
@@ -1075,4 +1112,80 @@ test "compute: install onto ZirFunc.liveness slot round-trips" {
 
     try testing.expect(f.liveness != null);
     try testing.expectEqual(@as(usize, 1), f.liveness.?.ranges.len);
+}
+
+test "compute: a frame whose body ended in a terminator closes to its result shape" {
+    // loop (result i32) ; local.get 0 ; return ; end ; i32.const 1 ; i32.add ; end
+    // `return` reads vreg 0 in place and the emit freezes its stack, so
+    // the loop's `.end` hands vreg 0 on as the loop's result and the
+    // `i32.add` pops it. Its range must reach the add (pre-fix the
+    // terminator drained it and the range stopped at the `return`).
+    var f = try buildFunc(testing.allocator, &.{
+        .{ .op = .loop, .extra = 1 },
+        .{ .op = .@"local.get", .payload = 0 },
+        .{ .op = .@"return" },
+        .{ .op = .end },
+        .{ .op = .@"i32.const", .payload = 1 },
+        .{ .op = .@"i32.add" },
+        .{ .op = .end },
+    });
+    defer f.deinit(testing.allocator);
+
+    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    defer deinit(testing.allocator, live);
+
+    try testing.expectEqual(@as(usize, 3), live.ranges.len);
+    try testing.expectEqual(@as(u32, 5), live.ranges[0].last_use_pc);
+}
+
+test "compute: the snapshot carries a frame's results past a br-only body" {
+    // `(block (result i32) (loop (result i32) i32.const 5 br 1))` lowers,
+    // with the constant hoisted into a local, to
+    //   block ; i32.const ; local.set 0 ; loop ; local.get 0 ; br 1 ; end ; end ; end
+    // Entering the block's `.end` (pc 7) the emit's stack is `{ 1 }`: the
+    // loop closed to its one result. The snapshot must read the same.
+    dbg.initFromEnv("liveverify");
+    defer dbg.resetForTest();
+    var f = try buildFunc(testing.allocator, &.{
+        .{ .op = .block, .extra = 1 },
+        .{ .op = .@"i32.const", .payload = 5 },
+        .{ .op = .@"local.set", .payload = 0 },
+        .{ .op = .loop, .extra = 1 },
+        .{ .op = .@"local.get", .payload = 0 },
+        .{ .op = .br, .payload = 1 },
+        .{ .op = .end },
+        .{ .op = .end },
+        .{ .op = .end },
+    });
+    defer f.deinit(testing.allocator);
+
+    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    defer deinit(testing.allocator, live);
+
+    try testing.expectEqual(@as(u32, 1), live.stack_depth[7]);
+    try testing.expectEqual(snapshotDigest(&.{1}), live.stack_digest[7]);
+    try testing.expectEqual(@as(u32, 1), live.stack_depth[8]);
+    try testing.expectEqual(snapshotDigest(&.{1}), live.stack_digest[8]);
+}
+
+test "compute: a frame closed before any vreg exists leaves the snapshot short" {
+    // block (result i32) ; unreachable ; end ; end — nothing mints a vreg,
+    // so the emit's placeholder vreg 0 names nothing. Liveness must not
+    // push it (the function-level `end` would then index an empty
+    // `ranges`); the snapshot stays one short of the emit's `{ 0 }`.
+    dbg.initFromEnv("liveverify");
+    defer dbg.resetForTest();
+    var f = try buildFunc(testing.allocator, &.{
+        .{ .op = .block, .extra = 1 },
+        .{ .op = .@"unreachable" },
+        .{ .op = .end },
+        .{ .op = .end },
+    });
+    defer f.deinit(testing.allocator);
+
+    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    defer deinit(testing.allocator, live);
+
+    try testing.expectEqual(@as(usize, 0), live.ranges.len);
+    try testing.expectEqual(@as(u32, 0), live.stack_depth[3]);
 }

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -155,6 +155,30 @@ fn captureBlockMergeVregs(
     fr.merge_captured = true;
 }
 
+/// The signature a call-shaped op pops its arguments against: `call` /
+/// `return_call` index `func_sigs` by func index, the indirect and ref
+/// forms index `module_types` by type index. Shared by the `call` arm and
+/// the tail-call terminators so both pop the same count.
+fn calleeSig(
+    instr: ZirInstr,
+    func_sigs: []const zir.FuncType,
+    module_types: []const zir.FuncType,
+    func_idx: u32,
+) Error!zir.FuncType {
+    if (instr.op == .call or instr.op == .return_call) {
+        if (instr.payload >= func_sigs.len) {
+            std.debug.print("liveness: UnsupportedOp[call-payload-OOB] payload={d} func_sigs.len={d} func_idx={d}\n", .{ instr.payload, func_sigs.len, func_idx });
+            return Error.UnsupportedOp;
+        }
+        return func_sigs[instr.payload];
+    }
+    if (instr.payload >= module_types.len) {
+        std.debug.print("liveness: UnsupportedOp[call_indirect/call_ref-payload-OOB] payload={d} types.len={d} func_idx={d}\n", .{ instr.payload, module_types.len, func_idx });
+        return Error.UnsupportedOp;
+    }
+    return module_types[instr.payload];
+}
+
 fn isControlFlow(op: ZirOp) bool {
     // After sub-7.5c-iv, every Wasm 1.0 control-flow op is
     // handled explicitly in `compute`. The function exists
@@ -184,8 +208,10 @@ fn isControlFlow(op: ZirOp) bool {
 /// `func_sigs` indexes function signatures by func_idx; consulted
 /// by `call N` to determine the pop/push count. `module_types`
 /// indexes type signatures by typeidx; consulted by
-/// `call_indirect type_idx`. Pass empty slices when the function
-/// has no calls (the existing straight-line tests).
+/// `call_indirect type_idx`. `tag_param_counts` indexes a tag's
+/// payload count by tag index; consulted by `throw`, with the emit's
+/// fallback of 0 for an index past the end. Pass empty slices when
+/// the function has no calls or throws (the straight-line tests).
 ///
 /// **Phase 7.5 scope**: extends Phase-5's straight-line MVP +
 /// conversions + sat_trunc (sub-h5) with `call` + `call_indirect`.
@@ -197,6 +223,7 @@ pub fn compute(
     func: *const ZirFunc,
     func_sigs: []const zir.FuncType,
     module_types: []const zir.FuncType,
+    tag_param_counts: []const u32,
 ) Error!Liveness {
     var ranges: std.ArrayList(LiveRange) = .empty;
     errdefer ranges.deinit(allocator);
@@ -644,23 +671,32 @@ pub fn compute(
             instr.op == .return_call or instr.op == .return_call_indirect or
             instr.op == .return_call_ref)
         {
-            // The emit pops what the op itself consumes by value — the
-            // `throw_ref` exception, the `return_call_indirect` table index,
-            // the `return_call_ref` funcref — and then freezes
-            // `pushed_vregs` (it sets `dead_code`); `return`, `unreachable`
-            // and `return_call` read their operands in place. Mirror that:
-            // pop the same, close every range above the innermost open
-            // frame's entry depth (control never falls through, so this is
-            // their last read), and leave the rest of the stack for that
-            // frame's `.end` to close, exactly as the emit's frozen stack
-            // reaches its `emitEndIntra`.
-            if (instr.op == .throw_ref or instr.op == .return_call_indirect or
-                instr.op == .return_call_ref)
-            {
-                if (sim_len > 0) {
+            // The emit pops what the op consumes and then freezes
+            // `pushed_vregs` (it sets `dead_code`): a `throw` pops its tag's
+            // payload, `throw_ref` the exception, the tail calls their
+            // callee's arguments — after the table index (`return_call_
+            // indirect`) or funcref (`return_call_ref`) on top; `return`
+            // and `unreachable` read in place and pop nothing. Mirror the
+            // pops, close every range above the innermost open frame's
+            // entry depth (control never falls through, so this is their
+            // last read), and leave the rest of the stack for that frame's
+            // `.end` to close, exactly as the emit's frozen stack reaches
+            // its `emitEndIntra`. Pops are tolerant like the `call` arm's.
+            var n_pop: usize = 0;
+            if (instr.op == .throw) {
+                n_pop = if (instr.payload < tag_param_counts.len) tag_param_counts[instr.payload] else 0;
+            } else if (instr.op == .throw_ref) {
+                n_pop = 1;
+            } else if (instr.op != .@"return" and instr.op != .@"unreachable") {
+                if (instr.op != .return_call and sim_len > 0) {
                     sim_len -= 1;
                     ranges.items[sim_stack[sim_len]].last_use_pc = pc;
                 }
+                n_pop = (try calleeSig(instr, func_sigs, module_types, func.func_idx)).params.len;
+            }
+            while (n_pop > 0 and sim_len > 0) : (n_pop -= 1) {
+                sim_len -= 1;
+                ranges.items[sim_stack[sim_len]].last_use_pc = pc;
             }
             const innermost_entry_term: u32 = if (block_stack_len == 0)
                 0
@@ -815,21 +851,7 @@ pub fn compute(
         // pops a funcref off the top before the params (like
         // call_indirect pops the table index). NON-terminator.
         if (instr.op == .call or instr.op == .call_indirect or instr.op == .call_ref) {
-            const callee_sig: zir.FuncType = blk: {
-                if (instr.op == .call) {
-                    if (instr.payload >= func_sigs.len) {
-                        std.debug.print("liveness: UnsupportedOp[call-payload-OOB] payload={d} func_sigs.len={d} func_idx={d}\n", .{ instr.payload, func_sigs.len, func.func_idx });
-                        return Error.UnsupportedOp;
-                    }
-                    break :blk func_sigs[instr.payload];
-                } else {
-                    if (instr.payload >= module_types.len) {
-                        std.debug.print("liveness: UnsupportedOp[call_indirect/call_ref-payload-OOB] payload={d} types.len={d} func_idx={d}\n", .{ instr.payload, module_types.len, func.func_idx });
-                        return Error.UnsupportedOp;
-                    }
-                    break :blk module_types[instr.payload];
-                }
-            };
+            const callee_sig = try calleeSig(instr, func_sigs, module_types, func.func_idx);
             // call_indirect's stack at entry is [args..., idx]; call_ref's
             // is [args..., funcref]. Pop that top operand first. Tolerant:
             // dead-code pops are no-ops (validator proved shape).
@@ -959,7 +981,7 @@ test "compute: straight-line i32.const + i32.const + i32.add + drop + end" {
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(usize, 3), live.ranges.len);
@@ -982,7 +1004,7 @@ test "compute: function-level end closes the still-live vreg" {
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(usize, 1), live.ranges.len);
@@ -1000,7 +1022,7 @@ test "compute: D-093 (d-3) local.tee keeps the input vreg alive across the tee" 
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     // local.tee is operand-stack-transparent (matches emit's
@@ -1028,7 +1050,7 @@ test "compute: br closes all live vregs at branch site (sub-7.5c-iv)" {
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
     try testing.expectEqual(@as(usize, 1), live.ranges.len);
     try testing.expectEqual(@as(u32, 2), live.ranges[0].last_use_pc);
@@ -1045,7 +1067,7 @@ test "compute: pop on empty stack is tolerant (validator-cleared dead-code path)
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
     try testing.expectEqual(@as(usize, 0), live.ranges.len);
 }
@@ -1069,7 +1091,7 @@ test "compute: dead code after `br 0` does not underflow" {
 
     // Should compute successfully — no underflow on the dead
     // i32.const after the br.
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
     // Two i32.const pushes → 2 vreg ranges.
     try testing.expectEqual(@as(usize, 2), live.ranges.len);
@@ -1087,7 +1109,7 @@ test "compute: select consumes 3 vregs and produces 1" {
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(usize, 4), live.ranges.len);
@@ -1107,7 +1129,7 @@ test "compute: install onto ZirFunc.liveness slot round-trips" {
     });
     defer f.deinit(testing.allocator);
 
-    f.liveness = try compute(testing.allocator, &f, &.{}, &.{});
+    f.liveness = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer if (f.liveness) |li| deinit(testing.allocator, li);
 
     try testing.expect(f.liveness != null);
@@ -1131,7 +1153,7 @@ test "compute: a frame whose body ended in a terminator closes to its result sha
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(usize, 3), live.ranges.len);
@@ -1159,7 +1181,7 @@ test "compute: the snapshot carries a frame's results past a br-only body" {
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(u32, 1), live.stack_depth[7]);
@@ -1183,9 +1205,61 @@ test "compute: a frame closed before any vreg exists leaves the snapshot short" 
     });
     defer f.deinit(testing.allocator);
 
-    const live = try compute(testing.allocator, &f, &.{}, &.{});
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{});
     defer deinit(testing.allocator, live);
 
     try testing.expectEqual(@as(usize, 0), live.ranges.len);
     try testing.expectEqual(@as(u32, 0), live.stack_depth[3]);
+}
+
+test "compute: a tail call pops its arguments before the stack freezes" {
+    // block (result i32) ; i32.const ; i32.const ; return_call 0 ; end ; i32.eqz ; end
+    // with func 0 taking two i32s. The emit's `marshalCallArgs` pops both
+    // arguments before `dead_code`, so the block closes short and takes the
+    // placeholder: entering `i32.eqz` (pc 5) the stack is `{ 0 }`, not the
+    // second constant.
+    dbg.initFromEnv("liveverify");
+    defer dbg.resetForTest();
+    var f = try buildFunc(testing.allocator, &.{
+        .{ .op = .block, .extra = 1 },
+        .{ .op = .@"i32.const", .payload = 1 },
+        .{ .op = .@"i32.const", .payload = 2 },
+        .{ .op = .return_call, .payload = 0 },
+        .{ .op = .end },
+        .{ .op = .@"i32.eqz" },
+        .{ .op = .end },
+    });
+    defer f.deinit(testing.allocator);
+    const sigs = [_]zir.FuncType{.{ .params = &.{ .i32, .i32 }, .results = &.{.i32} }};
+
+    const live = try compute(testing.allocator, &f, &sigs, &.{}, &.{});
+    defer deinit(testing.allocator, live);
+
+    try testing.expectEqual(@as(u32, 3), live.ranges[1].last_use_pc);
+    try testing.expectEqual(@as(u32, 1), live.stack_depth[5]);
+    try testing.expectEqual(snapshotDigest(&.{0}), live.stack_digest[5]);
+}
+
+test "compute: a throw pops its tag's payload before the stack freezes" {
+    // Same shape with `throw 0` and a one-i32 tag: the emit pops the
+    // payload only, so the first constant survives as the block's result.
+    dbg.initFromEnv("liveverify");
+    defer dbg.resetForTest();
+    var f = try buildFunc(testing.allocator, &.{
+        .{ .op = .block, .extra = 1 },
+        .{ .op = .@"i32.const", .payload = 1 },
+        .{ .op = .@"i32.const", .payload = 2 },
+        .{ .op = .throw, .payload = 0 },
+        .{ .op = .end },
+        .{ .op = .@"i32.eqz" },
+        .{ .op = .end },
+    });
+    defer f.deinit(testing.allocator);
+
+    const live = try compute(testing.allocator, &f, &.{}, &.{}, &.{1});
+    defer deinit(testing.allocator, live);
+
+    try testing.expectEqual(@as(u32, 3), live.ranges[1].last_use_pc);
+    try testing.expectEqual(@as(u32, 1), live.stack_depth[5]);
+    try testing.expectEqual(snapshotDigest(&.{0}), live.stack_digest[5]);
 }

--- a/src/ir/analysis/liveness.zig
+++ b/src/ir/analysis/liveness.zig
@@ -304,8 +304,16 @@ pub fn compute(
                         // vregs captured at `.else`) IS the if's result. Emit
                         // never dropped them from `pushed_vregs`; restore them
                         // here so the post-if consumer pops the canonical vreg.
+                        // A terminator drains only to the innermost open
+                        // frame's entry depth (the `return` / `br` arms
+                        // below), so nothing lowers `sim_len` past this
+                        // frame's base. The pad that once filled that gap
+                        // wrote a vreg it could not reconstruct over an
+                        // enclosing frame's record; the invariant is
+                        // asserted instead
+                        // (`.claude/rules/comment_as_invariant.md`).
+                        std.debug.assert(sim_len >= entry);
                         if (sim_len > entry) sim_len = entry;
-                        while (sim_len < entry) : (sim_len += 1) sim_stack[sim_len] = fr.merge_vregs[0];
                         var i: usize = 0;
                         while (i < arity) : (i += 1) {
                             if (sim_len == max_simulated_stack) return Error.OperandStackUnderflow;
@@ -334,8 +342,9 @@ pub fn compute(
                     const arity: usize = fr.result_arity;
                     const entry: usize = @as(usize, fr.entry_depth) -| @as(usize, fr.param_arity);
                     if (sim_len < entry + arity) {
+                        // Same invariant as the if-merge arm above.
+                        std.debug.assert(sim_len >= entry);
                         if (sim_len > entry) sim_len = entry;
-                        while (sim_len < entry) : (sim_len += 1) sim_stack[sim_len] = fr.param_vregs[0];
                         var i: usize = 0;
                         while (i < arity) : (i += 1) {
                             if (sim_len == max_simulated_stack) return Error.OperandStackUnderflow;
@@ -384,8 +393,9 @@ pub fn compute(
                         // push, which then aliases the block's result
                         // (AssemblyScript `~lib/rt/tlsf.ts` insertBlock's
                         // `slMap[fl] |= 1 << sl` read 1 instead of 0).
+                        // Same invariant as the if-merge arm above.
+                        std.debug.assert(sim_len >= entry);
                         if (sim_len > entry) sim_len = entry;
-                        while (sim_len < entry) : (sim_len += 1) sim_stack[sim_len] = fr.merge_vregs[0];
                         var i: usize = 0;
                         while (i < arity) : (i += 1) {
                             if (sim_len == max_simulated_stack) return Error.OperandStackUnderflow;


### PR DESCRIPTION
One design decision is the maintainer's before this merges, and it is a
yes/no. `src/ir/analysis/liveness.zig` is chaploud's design (2026-05-05,
and the terminator handling from 05-06 through 05-30), and the second
commit changes one of its contracts:

**Terminators (`return`, `unreachable`, `br`, `throw*`, `return_call*`) no
longer pop liveness's simulated operand stack.** They still close the ranges
above the innermost frame's entry depth; the vregs stay in place, and the
frame's `.end` keeps the top `result_arity` of them as the frame's result —
exactly what the emit does with its frozen `pushed_vregs`. The cost is a
range extension for a value a terminator read, into code that is dead at
runtime: conservative. The alternative that keeps your "drain at the
terminator" contract is a separate frozen-length state restored at `.end`
— a second state variable the emit does not have.

- **Yes** — the mirror follows the emit's freeze; merge as is (four
  commits).
- **No, keep the drain** — say so and I drop commits 2–4; commit 1 (#259's
  assert) stands alone and merges by itself.

Everything below is what the four commits do and how they were measured.

---

Two defects in the same `.end` arm of `liveness.compute`, taken together
because #259 asked for exactly that ("worth folding into whatever next
touches this function"); one commit each, in that order.

**#259** — the three pads below a frame's base are dead. With a panic ahead
of each, `zig build test-all` is green with 0 hits; with the condition
flipped it fires 253 times. Replaced by the assert the issue names.

**#326** — the snapshot side never re-established a frame's results at
`.end`. The repro's mismatch is not a missing pad but a missing *keep*: the
emit freezes `pushed_vregs` at a terminator and its `.end` hands the top
`result_arity` of the frozen stack on as the frame's result, while liveness
drained them. Hence the decision above, plus `.end` closing the frame the
way `emitEndIntra` does (truncate to `base + result_arity`, placeholder
vreg 0 for a result no path produced). The repro's digests agree, and
`liveverify` over `test-all` goes from 226 events to 75. One existing
test's expectation moves with the model (a function-level `br` keeps its
operand to the final `end`, as the emit reads it there).

Commits 3 and 4, from review: the frozen stack must first lose what the
op itself consumed (a tail call's arguments, a `throw`'s payload — the
emit pops both before freezing), and the parity check no longer skips the
`.end` that follows a terminator, since both sides now hold the same
stack there. With those, `liveverify` over `test-all` reports 77 events,
all in three pre-existing classes and none in the `.end` arm: frames
closed before the function has minted any vreg (#399, 24 events), blocks
whose first forward edge is `br_on_null` / `br_on_non_null` /
`br_on_cast(_fail)`, where the emit captures a merge vreg and liveness does
not (#400, 45), and the else arm of a param-less `if` whose then-arm ended
in a terminator, where `emitElse` keeps the then-arm's leftover underneath
(#401, 8). Those 77 are `test-all`-wide; the 68 that ADR-0226 (#402)
seeds its table from is the 3.0 JIT spec lane alone — different scope,
not a disagreement.

Found on the way, not fixed here: the emit's placeholder is a dangling id
when the function has minted no vreg yet, and
`(func (param f64) (block (result f64) unreachable) local.set 0)` panics in
`regalloc.slot` on the default engine (#399). The liveness mirror stops
short of that on purpose, so `liveverify` still reports that shape.

Both issues give the file as `src/engine/codegen/shared/liveness.zig`; it
is `src/ir/analysis/liveness.zig` now.

Closes #259.
Closes #326.
