### PR TITLE
ci(jit): the liveness parity check gates the JIT spec lane, with a named list (ADR-0226)

### DIFF
--- a/.dev/decisions/0226_liveverify_lane.md
+++ b/.dev/decisions/0226_liveverify_lane.md
@@ -1,0 +1,162 @@
+# 0226 — The liveness parity check gates the JIT spec lane, with a named list
+
+- **Status**: Proposed (gate definition per ADR-0212 D1 — lands in one PR
+  with the lane it defines, and flips to Accepted on the maintainer's word
+  on that PR, the way ADR-0225 did on #380; D1's placement is the part that
+  needs it, D3 is apparatus-internal)
+- **Date**: 2026-09-05
+- **Author**: Junji Takakura
+- **Tags**: ci, jit, liveness, gate, ratchet
+
+## Context
+
+`ZWASM_DEBUG=liveverify` (#269, 2026-08-24) compares, per instruction, the
+operand stack liveness simulated against the one the emit actually pushed
+(`src/engine/codegen/shared/liveness_parity.zig`, the D-596 invariant). A
+divergence means liveness numbers vregs differently from the emit from that
+point on, and the JIT can read a dead register with no trap. That class
+shipped four silent miscompiles in v2.6.0 (#250, #252, #258, #272) and is the
+one the differential lanes are weakest against: a stale merge register only
+shows in a value when a call sits between the branch and the consumer
+(D-330), which the spec corpus mostly does not do — so a lane can be green
+over a divergence (#400: "no wrong answer is demonstrated").
+
+#269 landed the check as "**Diagnostic, not a gate** — prints and continues"
+and deferred gating explicitly: "Blocking CI on it needs an ADR (ADR-0076 D9,
+ADR-0212 D1)". Two numbers were missing then and are measured now, on `main`
+at `7c7e434ea`, the whole `test-spec-wasm-3.0-assert` step (both engines, all
+six sub-corpora):
+
+| | wall | `[liveverify]` residual lines, JIT lane |
+|---|---|---|
+| gate off | 7.46 s | 0 |
+| gate on | 7.61 s | **68** |
+
+By the op the divergence is first seen at: `end` 21, `return` 16,
+`i32.const` 8, `i32.add` 4, `drop` 4, `call_ref` 4, `unreachable` 3,
+`struct.get_s` 2, `br_on_cast` 2, `block` 2. #269 measured 178 on the spec
+corpus; #398 (open) takes the `end` / `return` class next. Every residual so
+far has been found by hand and filed as its own issue — eight numbers for
+one root, which #400 now holds as a table.
+
+Two facts shape where the check can live. The env must not be set on
+`test-all`: the AOT unit tests fail under it by design
+(`.dev/lessons/2026-08-24-measurement-scaffolding-hid-the-product-gate.md`).
+And the checker is `void` — it prints a line carrying `func[N]` and nothing
+else, so nothing today can attribute a residual to a module or count it.
+
+The house already has two gates of the shape this one needs: #376's JIT spec
+lane, which enumerates known-wrong outcomes per target (`jitKnownFails`,
+`.{ .key, .count }`) and reports `enumerated / unexpected / stale`; and
+ADR-0225's preview1 ratchet, which records names, never a count, and trips
+on a row that stops firing.
+
+## Decision
+
+### D1 — The JIT spec lane runs once more with the parity check on, and blocks
+
+A step beside `test-spec-wasm-3.0-assert`'s JIT run — same runner, same
+corpus, `ZWASM_SPEC_ENGINE=jit`, the product gate `dbg.on("liveverify")`
+on — joins `test-all` and therefore the core `ci-required` gate on all three
+legs. It exits non-zero when the residuals it observes differ from a named
+list: a residual not on the list is `unexpected`, a listed module that
+produces none is `stale`, and either reds the PR. Cost is 2 % of a 7.5 s
+step, which is #376's own argument for the core gate rather than
+`ZWASM_CI_EXTENDED`, and the extended set covers only the Unix legs.
+
+### D2 — The list names modules, per target, and is held in both directions
+
+`test/spec/spec_assert_runner_wasm_3_0.zig` grows a `liveverifyKnown()`
+table in `jitKnownFails`'s shape: rows are `.{ .key =
+"<proposal>/<dir>/<module>.wasm", .count = <residual lines> }`, one table
+per target (x86_64 SysV / x86_64 Win64 / aarch64), selected the way
+`jitKnownFails` selects. A row must name its line in #400's table. The
+count is per row so that "one func fixed, one regressed" in the same module
+is visible; the list carries no total.
+
+The seeds are taken the way #376 took its Windows row: the x86_64 SysV table
+is seeded from this host (the 68 above, re-taken on the PR's base), and the
+x86_64 Win64 and aarch64 tables start **empty**, so the PR's first CI run
+reports every residual on those legs as `unexpected` and names them. Those
+names are copied into the tables and pushed; the second run is the proof
+that the tables describe CI's runners and nothing else (ADR-0225 D2). This
+is why the ADR and the lane are one PR — two of the three tables cannot be
+written before the lane runs in CI.
+
+### D3 — The checker counts, the runner attributes; the env stays off `test-all`
+
+Two apparatus-internal changes, no sign-off (ADR-0212 D1):
+
+- `liveness_parity` keeps a residual counter the runner can read and reset
+  per module. `check` stays `void` and keeps printing; the count is what the
+  gate compares.
+- The runner prints the module path with the first residual of each module
+  and reads the counter after each, so a residual line can be attributed
+  without re-running the module by hand.
+
+The new step is the only place the env is set. `test-all` with
+`ZWASM_DEBUG=liveverify` remains unsupported for the reason the lesson
+records.
+
+### D4 — #400 is the ledger; rows leave with their fix
+
+A PR that fixes a drift removes its row in the same change, which `stale`
+enforces. A new drift lands as a row here **and** a row on #400, not as a
+new issue. #398, if it lands after this, retires the `end` / `return` rows
+it fixes in its own diff. Retiring the root — deriving liveness's
+control-flow mirror from the emit's source (ADR-0088 extended to edges) —
+is #400's move 2 and is not decided here.
+
+## Alternatives considered
+
+### Alternative A — Report first, block later
+
+- **Sketch**: land the same step with `continue-on-error: true`; promote it
+  to blocking at a residual count the maintainer names.
+- **Why not chosen**: `continue-on-error` rewrites `conclusion` to
+  `success`, which is what `ci-required` reads — #307 item 6 and ADR-0225's
+  Context are the record of a check that reported and was not read. The
+  list mechanism already makes day-one blocking safe: 68 rows are debt made
+  visible, not red PRs. **This is the maintainer's call, not a rejection**:
+  if A is preferred, D1 gains the `continue-on-error` and a promotion
+  threshold, and the Status line records it.
+
+### Alternative B — Keep the check diagnostic
+
+- **Sketch**: leave #269 as it is; run it by hand when touching liveness.
+- **Why rejected**: that is the current state, and it produced eight issues
+  and four shipped miscompiles. The class is the one the other lanes cannot
+  see.
+
+### Alternative C — Gate on the total residual count
+
+- **Sketch**: a single number; red when it rises.
+- **Why rejected**: ADR-0225's reason — a count cannot tell "one fixed, one
+  regressed" from "no change", and a copied count has already gone stale
+  against its debt row once in this repository.
+
+## Consequences
+
+- **Positive**: a liveness/emit divergence becomes a red PR on the commit
+  that introduces it, on every target CI runs, instead of an issue filed
+  after someone runs the check by hand. The 68 become load-bearing: each
+  is a row someone must retire, and #398's rows must go in #398.
+- **Negative**: a divergence with no demonstrated wrong answer still reds a
+  PR until it is listed. That is the point of an invariant gate, but it is
+  a new kind of red for this lane and the failure message must say which
+  row to add.
+- **Neutral / follow-ups**: the arm64 and Win64 seeds are taken from CI's
+  own legs, not from a Linux host; ADR-0225 D2's "the table describes CI's
+  runner" applies. The 2.0 corpus is not in this lane; whether it should be
+  is a measurement for later, not a gap in this decision.
+
+## References
+
+- #269 (the check, and its deferral of gating), #376 (`jitKnownFails`, core
+  placement), #380 / ADR-0225 (names not counts, `stale`), #400 (the ledger
+  of rows), #398 (open, the `.end` class)
+- ADR-0212 D1 (gate definitions need sign-off; apparatus does not),
+  ADR-0076 D9 (CI is authoritative), ADR-0088 (stack-effect extraction — the
+  half of the mirror that is table-driven)
+- `.dev/lessons/2026-06-02-jit-liveness-must-mirror-emit-pushed-vregs.md`
+  (D-596), `.dev/lessons/2026-08-24-measurement-scaffolding-hid-the-product-gate.md`

--- a/.dev/decisions/0226_liveverify_lane.md
+++ b/.dev/decisions/0226_liveverify_lane.md
@@ -30,11 +30,13 @@ six sub-corpora):
 | | wall | `[liveverify]` residual lines, JIT lane |
 |---|---|---|
 | gate off | 7.46 s | 0 |
-| gate on | 7.61 s | **68** |
+| gate on | 7.61 s | **69 over 10 modules** |
 
-By the op the divergence is first seen at: `end` 21, `return` 16,
+That pair is the check's own overhead inside one lane, not what this decision
+costs; D1 carries that figure. The ten commonest ops the divergence is first
+seen at: `end` 21, `return` 16,
 `i32.const` 8, `i32.add` 4, `drop` 4, `call_ref` 4, `unreachable` 3,
-`struct.get_s` 2, `br_on_cast` 2, `block` 2. #269 measured 178 on the spec
+`struct.get_s` 2, `br_on_cast` 2, `block` 2 (66 of the 69). #269 measured 178 on the spec
 corpus; #398 (open) takes the `end` / `return` class next. Every residual so
 far has been found by hand and filed as its own issue — eight numbers for
 one root, which #400 now holds as a table.
@@ -59,10 +61,23 @@ A step beside `test-spec-wasm-3.0-assert`'s JIT run — same runner, same
 corpus, `ZWASM_SPEC_ENGINE=jit`, the product gate `dbg.on("liveverify")`
 on — joins `test-all` and therefore the core `ci-required` gate on all three
 legs. It exits non-zero when the residuals it observes differ from a named
-list: a residual not on the list is `unexpected`, a listed module that
-produces none is `stale`, and either reds the PR. Cost is 2 % of a 7.5 s
-step, which is #376's own argument for the core gate rather than
-`ZWASM_CI_EXTENDED`, and the extended set covers only the Unix legs.
+list: a residual on a module no row names is `unexpected`, and so is a listed
+module that fires MORE than its row enumerates — a divergence the list has not
+seen, on a module that happens to be listed. A listed module that fires fewer,
+none included, is `stale`: the row over-claims and must come down. All three
+red the PR.
+
+The cost is the run, not the check: turning the gate on inside a lane is 2 %
+(the table above), but D1 is a second full JIT lane, so `test-all` grows by one
+JIT lane — the same order as the step it sits beside. That is #376's argument
+for the core gate rather than `ZWASM_CI_EXTENDED`, whose extended set covers
+only the Unix legs.
+
+The step must fail if the channel it asks for is not on. `liveness_parity` is
+comptime-dead in ReleaseFast / ReleaseSmall, and every branch of this gate —
+down to its summary line — is inside `if (lv_mode)`, so a dark channel is an
+exit 0 with nothing printed rather than a quieter lane. The runner says
+`LIVEVERIFY-CHANNEL-DARK` and exits non-zero instead.
 
 ### D2 — The list names modules, per target, and is held in both directions
 
@@ -75,7 +90,7 @@ count is per row so that "one func fixed, one regressed" in the same module
 is visible; the list carries no total.
 
 The seeds are taken the way #376 took its Windows row: the x86_64 SysV table
-is seeded from this host (the 68 above, re-taken on the PR's base), and the
+is seeded from this host (the 69 above, re-taken on the PR's base), and the
 x86_64 Win64 and aarch64 tables start **empty**, so the PR's first CI run
 reports every residual on those legs as `unexpected` and names them. Those
 names are copied into the tables and pushed; the second run is the proof
@@ -116,8 +131,8 @@ is #400's move 2 and is not decided here.
 - **Why not chosen**: `continue-on-error` rewrites `conclusion` to
   `success`, which is what `ci-required` reads — #307 item 6 and ADR-0225's
   Context are the record of a check that reported and was not read. The
-  list mechanism already makes day-one blocking safe: 68 rows are debt made
-  visible, not red PRs. **This is the maintainer's call, not a rejection**:
+  list mechanism already makes day-one blocking safe: 10 rows carrying 69
+  lines are debt made visible, not red PRs. **This is the maintainer's call, not a rejection**:
   if A is preferred, D1 gains the `continue-on-error` and a promotion
   threshold, and the Status line records it.
 
@@ -139,12 +154,17 @@ is #400's move 2 and is not decided here.
 
 - **Positive**: a liveness/emit divergence becomes a red PR on the commit
   that introduces it, on every target CI runs, instead of an issue filed
-  after someone runs the check by hand. The 68 become load-bearing: each
-  is a row someone must retire, and #398's rows must go in #398.
+  after someone runs the check by hand. The 10 rows become load-bearing:
+  each is one someone must retire, and #398's rows must go in #398.
 - **Negative**: a divergence with no demonstrated wrong answer still reds a
   PR until it is listed. That is the point of an invariant gate, but it is
   a new kind of red for this lane and the failure message must say which
   row to add.
+- **Negative**: a row's unit is the module, so a fix and a new divergence in
+  the same module cancel and the gate stays quiet — the objection Alternative
+  C is rejected for, one level down. The residual lines carry `func[N]`, so the
+  granularity to close it exists; it is not spent here because a per-func list
+  is a table an order of magnitude longer for a debt that only ratchets down.
 - **Neutral / follow-ups**: the arm64 and Win64 seeds are taken from CI's
   own legs, not from a Linux host; ADR-0225 D2's "the table describes CI's
   runner" applies. The 2.0 corpus is not in this lane; whether it should be

--- a/build.zig
+++ b/build.zig
@@ -690,6 +690,22 @@ pub fn build(b: *std.Build) void {
     const test_spec_wasm_3_0_assert_step = b.step("test-spec-wasm-3.0-assert", "Run Wasm 3.0 spec assertion runner on both engines (§10 / 10.T-2b; 6 sub-corpora enumerated)");
     test_spec_wasm_3_0_assert_step.dependOn(&run_wasm_3_0_assert.step);
     test_spec_wasm_3_0_assert_step.dependOn(&run_wasm_3_0_assert_jit.step);
+    // ADR-0226 — the JIT lane once more with the D-596 liveness parity check
+    // on. Same runner, same corpus, one extra env; the runner attributes each
+    // residual to its module and gates on `liveverifyKnown()` in both
+    // directions, so this run is red on a new liveness/emit divergence AND
+    // on a listed one that stopped firing. Both env vars are pinned for the
+    // reason given on the interp run above. This is the ONLY place the build
+    // sets `ZWASM_DEBUG=liveverify`: `test-all` under that env is unsupported,
+    // because any active dbg channel makes AOT produce refuse and the AOT
+    // unit tests fail by design
+    // (`.dev/lessons/2026-08-24-measurement-scaffolding-hid-the-product-gate.md`).
+    const run_wasm_3_0_assert_lv = b.addRunArtifact(wasm_3_0_assert_runner_exe);
+    run_wasm_3_0_assert_lv.addArg(b.pathFromRoot("test/spec/wasm-3.0-assert"));
+    run_wasm_3_0_assert_lv.setEnvironmentVariable("ZWASM_SPEC_ENGINE", "jit");
+    run_wasm_3_0_assert_lv.setEnvironmentVariable("ZWASM_DEBUG", "liveverify");
+    const test_spec_wasm_3_0_lv_step = b.step("test-spec-wasm-3.0-assert-liveverify", "Run the wasm-3.0 JIT lane with the liveness parity check on; gates on liveverifyKnown() (ADR-0226)");
+    test_spec_wasm_3_0_lv_step.dependOn(&run_wasm_3_0_assert_lv.step);
 
     // In-source test of the runner skeleton (covers PROPOSALS list).
     const wasm_3_0_assert_unit_mod = createSanitizedModule(b, sanitize_opts, .{
@@ -1584,6 +1600,7 @@ pub fn build(b: *std.Build) void {
     // 10.M / 10.R / 10.TC / 10.E / 10.G land.
     test_all_step.dependOn(&run_wasm_3_0_assert.step);
     test_all_step.dependOn(&run_wasm_3_0_assert_jit.step);
+    test_all_step.dependOn(&run_wasm_3_0_assert_lv.step); // ADR-0226 liveverify lane
     // The wasm-3.0 runner's embedded unit tests (§1 JIT-corpus
     // eligibility + manifest parse) were wired only into `test` — so
     // the per-chunk gate (`mac_gate.sh` → test-all) never ran them and

--- a/build.zig
+++ b/build.zig
@@ -693,8 +693,10 @@ pub fn build(b: *std.Build) void {
     // ADR-0226 — the JIT lane once more with the D-596 liveness parity check
     // on. Same runner, same corpus, one extra env; the runner attributes each
     // residual to its module and gates on `liveverifyKnown()` in both
-    // directions, so this run is red on a new liveness/emit divergence AND
-    // on a listed one that stopped firing. Both env vars are pinned for the
+    // directions, so this run is red on a new liveness/emit divergence — on a
+    // listed module as well as an unlisted one — AND on a listed one that
+    // stopped firing. It is also red if the channel it sets is not on, which
+    // ReleaseFast / ReleaseSmall would otherwise make a silent exit 0. Both env vars are pinned for the
     // reason given on the interp run above. This is the ONLY place the build
     // sets `ZWASM_DEBUG=liveverify`: `test-all` under that env is unsupported,
     // because any active dbg channel makes AOT produce refuse and the AOT

--- a/src/engine/codegen/shared/liveness_parity.zig
+++ b/src/engine/codegen/shared/liveness_parity.zig
@@ -44,11 +44,12 @@ pub const compiled_in: bool =
 
 /// Hoist this out of the emit loop; `dbg.on` is a whitelist walk.
 ///
-/// Reach: the CLI, today. `dbg.initFromEnv` is called from `cli/main.zig` and
-/// `api/instance.zig` only, and no test runner reaches either, so the channel
-/// is dark for the whole of `zig build test-all`. Lane coverage arrives when
-/// that gap closes; this module does not read the env itself, which Zone 2
-/// cannot do without pulling `std.c.getenv` out of its one Zone 3 call site.
+/// Reach: the CLI, the C API, and every test runner (each calls
+/// `dbg.initFromEnv` at startup). One lane runs with it on:
+/// `test-spec-wasm-3.0-assert-liveverify` (ADR-0226), which reads
+/// `takeResiduals` below and gates on the count. This module does not read
+/// the env itself, which Zone 2 cannot do without pulling `std.c.getenv` out
+/// of its one Zone 3 call site.
 pub fn on() bool {
     if (!compiled_in) return false;
     return dbg.on("liveverify");
@@ -61,8 +62,23 @@ pub fn on() bool {
 const max_stack: usize = liveness.max_simulated_stack;
 const digest = liveness.snapshotDigest;
 
-/// Compare the operand stack entering instr `pc`. Prints and returns on a
-/// mismatch — a diagnostic, not a gate, mirroring `ZWASM_DEBUG=regverify`.
+/// Residual lines printed since the last `takeResiduals`. Written only on
+/// the mismatch path of `check`, read by the spec runner after each module's
+/// compile (ADR-0226 D3). Single-threaded by construction: the JIT compiles
+/// one module at a time and the runner reads between modules.
+var residuals: u32 = 0;
+
+/// Read-and-reset. The count is what the liveverify lane gates on; `check`'s
+/// print stays for the person fixing the row.
+pub fn takeResiduals() u32 {
+    const n = residuals;
+    residuals = 0;
+    return n;
+}
+
+/// Compare the operand stack entering instr `pc`. Prints, counts and returns
+/// on a mismatch — the print is a diagnostic mirroring `ZWASM_DEBUG=regverify`,
+/// the count is the lane's (ADR-0226).
 ///
 /// `labels` is the emit's own label stack; both arches' `Label` carries the
 /// same `kind` / `merge_captured` / `result_arity` / `param_arity` /
@@ -102,6 +118,7 @@ pub fn check(
 
     if (len == lv.stack_depth[pc] and digest(expect[0..len]) == lv.stack_digest[pc]) return;
 
+    residuals += 1;
     std.debug.print(
         "[liveverify] func[{d}] pc={d} op={s}: liveness depth={d} digest={x}, emit depth={d} digest={x} (raw {d})\n",
         .{

--- a/src/engine/codegen/shared/liveness_parity.zig
+++ b/src/engine/codegen/shared/liveness_parity.zig
@@ -44,12 +44,13 @@ pub const compiled_in: bool =
 
 /// Hoist this out of the emit loop; `dbg.on` is a whitelist walk.
 ///
-/// Reach: the CLI, the C API, and every test runner (each calls
-/// `dbg.initFromEnv` at startup). One lane runs with it on:
-/// `test-spec-wasm-3.0-assert-liveverify` (ADR-0226), which reads
-/// `takeResiduals` below and gates on the count. This module does not read
-/// the env itself, which Zone 2 cannot do without pulling `std.c.getenv` out
-/// of its one Zone 3 call site.
+/// Reach: the CLI, the C API, and the test runners that call `dbg.initFromEnv`
+/// at startup — `scripts/check_runner_dbg_init.sh` holds that line, and the
+/// files it exempts say why in their first lines. One lane runs with the
+/// channel on: `test-spec-wasm-3.0-assert-liveverify` (ADR-0226); its runner
+/// reads `takeResiduals` below and gates on the count. This module does not
+/// read the env itself, which Zone 2 cannot do without pulling `std.c.getenv`
+/// out of its one Zone 3 call site.
 pub fn on() bool {
     if (!compiled_in) return false;
     return dbg.on("liveverify");

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -240,6 +240,7 @@ pub const engine = struct {
             pub const canonical_type = @import("engine/codegen/shared/canonical_type.zig");
             pub const result_abi = @import("engine/codegen/shared/result_abi.zig");
             pub const wrapper_thunk = @import("engine/codegen/shared/wrapper_thunk.zig");
+            pub const liveness_parity = @import("engine/codegen/shared/liveness_parity.zig");
         };
         pub const arm64 = struct {
             pub const inst = @import("engine/codegen/arm64/inst.zig");

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -27,6 +27,7 @@ const builtin = @import("builtin");
 const manifest_parser = @import("wasm_3_0_manifest.zig");
 const zwasm = @import("zwasm");
 const TypedResult = zwasm.engine.runner.TypedResult;
+const liveness_parity = zwasm.engine.codegen.shared.liveness_parity;
 
 /// Widen a multi-value `TypedResult` slot to the u64 carrier
 /// `jitScalarResultMatches` compares (i32/f32 zero-extended in the low 32).
@@ -532,6 +533,134 @@ const JitFailLog = struct {
     }
 };
 
+/// ADR-0226 — one module whose JIT compile the D-596 liveness parity check
+/// (`ZWASM_DEBUG=liveverify`, `liveness_parity.check`) reports residuals
+/// for, enumerated so the liveverify lane can gate on an exact match the way
+/// `jitKnownFails` does.
+///
+/// Same contract as that list: NOT a suppression. An unlisted module turns
+/// the lane red, and so does a listed one that stopped firing (`stale`) — a
+/// fix removes its row in the same PR. Every row has its line in #400's
+/// table; a new drift lands as a row here AND a row there (ADR-0226 D4).
+const LvKnown = struct {
+    /// `<proposal>/<manifest-dir>/<module>.wasm` — the path the runner's
+    /// `[liveverify] module …` line prints, so a new row is copied off the
+    /// output. A `.wasm`, not a directive triple: residuals fire at compile
+    /// time, before any directive runs.
+    key: []const u8,
+    /// Residual LINES for that module (one per `[liveverify] func[N] …`
+    /// print on stderr), not distinct funcs: per row so "one func fixed,
+    /// one regressed" in the same module is visible (ADR-0225's reason).
+    count: u32,
+};
+
+/// x86_64 SysV — measured 2026-09-05 on x86_64-linux at `main` 7c7e434ea
+/// (ADR-0226 D2), by this lane's red-first run with the table empty:
+/// 69 residual lines over 10 modules, `0 enumerated, 10 unexpected`. Each
+/// row names its #400 table row; the funcs are the `func[N]` of its stderr
+/// lines. #400's own module list was taken with #398 applied, so a module
+/// (or func) absent from it is in #398's `.end` / `return` class by that
+/// measurement and its row drops when #398 lands — re-take the table then,
+/// do not edit it by hand.
+const lv_known_x86_64_sysv: []const LvKnown = &.{
+    // `.end` ×20, `i32.add` ×4, `drop` ×1 over 17 funcs — #398's class.
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
+    // `return` ×9 (funcs 8–15, 19) — #398's class.
+    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
+    // #400 `br_on_cast` row (funcs 3, 4); funcs 5, 6 are #398's class.
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
+    // #400 `br_on_cast` row (func 1).
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
+    // #400 `br_on_cast_fail` row (funcs 2, 3); funcs 4–6 are #398's class.
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
+    // #400 `br_on_cast_fail` row (funcs 1, 2).
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    // #400 `br_on_null` / `br_on_non_null` row (funcs 0, 1, 6) — the traced mechanism.
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
+    // `drop` ×3 (funcs 0–2), absent from #400's list — #398's class.
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
+    // #400 `br_on_null` / `br_on_non_null` row (func 1).
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
+    // #400 `br_on_null` / `br_on_non_null` row (func 1).
+    .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
+};
+
+/// x86_64-windows — seeded from this lane's own first CI run (ADR-0226 D2):
+/// the Win64 emit is not the SysV one, so a copied SysV row would describe
+/// nothing CI runs. Empty until that run names the rows.
+const lv_known_x86_64_windows: []const LvKnown = &.{};
+
+/// aarch64 (the macOS leg) — seeded from this lane's own first CI run, for
+/// the same reason. Empty until that run names the rows.
+const lv_known_aarch64: []const LvKnown = &.{};
+
+comptime {
+    // A duplicated key would be counted once by `countFor` and twice in
+    // `enumerated`; the table would then claim more than it checks.
+    for ([_][]const LvKnown{ lv_known_x86_64_sysv, lv_known_x86_64_windows, lv_known_aarch64 }) |table| {
+        for (table, 0..) |a, i| {
+            for (table[i + 1 ..]) |b| {
+                if (std.mem.eql(u8, a.key, b.key)) {
+                    @compileError("liveverify table lists '" ++ a.key ++ "' twice");
+                }
+            }
+        }
+    }
+}
+
+/// Selected the way `jitKnownFails` selects, with the same loud default: a
+/// target with no row expects ZERO residuals and reports every one it sees.
+fn liveverifyKnown() []const LvKnown {
+    return switch (builtin.cpu.arch) {
+        .x86_64 => if (builtin.os.tag == .windows)
+            lv_known_x86_64_windows
+        else
+            lv_known_x86_64_sysv,
+        .aarch64 => lv_known_aarch64,
+        else => &.{},
+    };
+}
+
+/// Every module the liveverify run attributed residuals to, with the count.
+/// One entry per module, not one per residual — the count is the row's unit
+/// — which is the one shape difference from `JitFailLog`.
+const LvLog = struct {
+    gpa: std.mem.Allocator,
+    entries: std.ArrayList(Entry) = .empty,
+
+    const Entry = struct { key: []const u8, count: u32 };
+
+    fn record(self: *LvLog, proposal: []const u8, manifest: []const u8, module_path: []const u8, n: u32) !void {
+        // The manifest name is borrowed from a directory iterator whose
+        // buffer is reused, so the key is copied rather than referenced.
+        const key = try std.fmt.allocPrint(self.gpa, "{s}/{s}/{s}", .{ proposal, manifest, module_path });
+        errdefer self.gpa.free(key);
+        // A manifest that names the same module twice compiles it twice;
+        // the row counts the module, so the second compile adds to it.
+        for (self.entries.items) |*e| {
+            if (std.mem.eql(u8, e.key, key)) {
+                e.count += n;
+                self.gpa.free(key);
+                return;
+            }
+        }
+        try self.entries.append(self.gpa, .{ .key = key, .count = n });
+    }
+
+    fn deinit(self: *LvLog) void {
+        for (self.entries.items) |e| self.gpa.free(e.key);
+        self.entries.deinit(self.gpa);
+    }
+
+    /// 0 when absent — a listed module that never fired is `stale`.
+    fn countFor(self: LvLog, key: []const u8) u32 {
+        for (self.entries.items) |e| {
+            if (std.mem.eql(u8, e.key, key)) return e.count;
+        }
+        return 0;
+    }
+};
+
 /// Shared catch-classifier for the §1 JIT no-arg dispatch arms (i32 / i64 /
 /// f32 / f64): compile/setup rejects → an enumerated skip (the JIT never
 /// executed this shape), execution-stage outcomes (e.g. `error.Trap`) → fail.
@@ -608,6 +737,13 @@ pub fn main(init: std.process.Init) !void {
         std.mem.eql(u8, v, "jit")
     else
         false;
+    // ADR-0226 — the liveverify lane: the jit lane run once more with the
+    // D-596 parity check on. `ZWASM_DEBUG=liveverify` is set by the
+    // `test-spec-wasm-3.0-assert-liveverify` build step and nowhere else.
+    // The check fires only inside JIT compilation, so the mode is a property
+    // of the jit lane: with the env unset, or on the interp lane, none of the
+    // `lv_mode` branches run and the lane's output is what it is without them.
+    const lv_mode = jit_mode and liveness_parity.on();
 
     const cwd = std.Io.Dir.cwd();
     var dir = cwd.openDir(io, corpus_root, .{}) catch |err| {
@@ -633,6 +769,11 @@ pub fn main(init: std.process.Init) !void {
     // the run accumulates and then has to reconcile before it may exit 0.
     var jit_fail_log: JitFailLog = .{ .gpa = gpa };
     defer jit_fail_log.deinit();
+    // ADR-0226 — same kind of thing for the liveverify lane: one entry per
+    // module the parity check reported on, reconciled against
+    // `liveverifyKnown()` after the loop.
+    var lv_log: LvLog = .{ .gpa = gpa };
+    defer lv_log.deinit();
 
     for (PROPOSALS) |proposal| {
         var summary: ProposalSummary = .{ .name = proposal };
@@ -1070,6 +1211,20 @@ pub fn main(init: std.process.Init) !void {
                                     zwasm.engine.runner.eh_registry.registerThunkArena(@intFromPtr(a.bytes.ptr), a.bytes.len);
                                 break :blk pp;
                             };
+                            // ADR-0226 D3 — attribute this module's residuals.
+                            // The counter is read here and nowhere else, so a
+                            // residual fired outside a module compile is carried
+                            // into the next module's count, where it reds the
+                            // lane as unexpected or stale, instead of being
+                            // dropped. Read after `initLinked` whether or not it
+                            // succeeded: the emit ran either way.
+                            if (lv_mode) {
+                                const n = liveness_parity.takeResiduals();
+                                if (n > 0) {
+                                    try stdout.print("[liveverify] module {s}/{s}/{s}: {d} residual line(s)\n", .{ proposal, entry.name, d.module_path, n });
+                                    try lv_log.record(proposal, entry.name, d.module_path, n);
+                                }
+                            }
                         }
                         // 10.M-D195b cycle 71 — compile + instantiate
                         // against the shared engine + linker, then
@@ -2020,6 +2175,51 @@ pub fn main(init: std.process.Init) !void {
             .{ jit_target_label, known.len, jit_unexpected, jit_stale },
         );
     }
+
+    // ADR-0226 — the liveverify lane's exact-match gate, the block above in
+    // its second instance, over the parity check's residuals per module.
+    // Both directions for the same reasons; the failure text names the row
+    // to edit, since a red of this kind is new to the lane.
+    var lv_unexpected: u32 = 0;
+    var lv_stale: u32 = 0;
+    if (lv_mode) {
+        const known = liveverifyKnown();
+        for (known) |k| {
+            const seen = lv_log.countFor(k.key);
+            if (seen == k.count) continue;
+            lv_stale += 1;
+            try stdout.print(
+                "LIVEVERIFY-EXPECTATION-STALE  {s}: enumerated {d} residual line(s), observed {d} — correct the {s} row in spec_assert_runner_wasm_3_0.zig and its line on #400\n",
+                .{ k.key, k.count, seen, jit_target_label },
+            );
+        }
+        for (lv_log.entries.items) |e| {
+            var listed = false;
+            for (known) |k| {
+                if (std.mem.eql(u8, k.key, e.key)) listed = true;
+            }
+            if (listed) continue;
+            lv_unexpected += 1;
+            try stdout.print(
+                "LIVEVERIFY-UNEXPECTED  {s}: {d} residual line(s) and no row enumerates it — liveness and the emit diverge on this module; add the {s} row and a line on #400\n",
+                .{ e.key, e.count, jit_target_label },
+            );
+        }
+        // Residuals after the last module compile have no module to be
+        // carried into; they would otherwise vanish.
+        const stray = liveness_parity.takeResiduals();
+        if (stray > 0) {
+            lv_unexpected += 1;
+            try stdout.print(
+                "LIVEVERIFY-UNEXPECTED  (after the last module): {d} residual line(s) fired outside a module compile, so nothing could attribute them\n",
+                .{stray},
+            );
+        }
+        try stdout.print(
+            "[wasm-3.0-assert] liveverify ({s}): {d} enumerated, {d} unexpected, {d} stale\n",
+            .{ jit_target_label, known.len, lv_unexpected, lv_stale },
+        );
+    }
     try stdout.flush();
 
     // ADR-0174 — GATE on declarative-assert fails (close the "OK-verdict-hides-
@@ -2030,8 +2230,10 @@ pub fn main(init: std.process.Init) !void {
     // In jit mode `ret.fail` is the JIT verdict, and every one of those fails
     // is either enumerated above or already counted as unexpected — summing
     // it here as well would gate the same fail twice and make the enumerated
-    // ones permanently red. The reconciliation IS the gate for this lane.
-    const ret_fail_unaccounted = if (jit_mode) jit_unexpected + jit_stale else grand.ret.fail;
+    // ones permanently red. The reconciliation IS the gate for this lane —
+    // and the liveverify reconciliation joins it the same way (ADR-0226; its
+    // two terms are 0 unless `lv_mode`).
+    const ret_fail_unaccounted = if (jit_mode) jit_unexpected + jit_stale + lv_unexpected + lv_stale else grand.ret.fail;
     const grand_assert_fail = ret_fail_unaccounted + grand.trap.fail +
         grand.invalid.fail + grand.unlinkable.fail + grand.uninstantiable.fail +
         grand.malformed.fail + grand.exception.fail;

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -538,9 +538,10 @@ const JitFailLog = struct {
 /// for, enumerated so the liveverify lane can gate on an exact match the way
 /// `jitKnownFails` does.
 ///
-/// Same contract as that list: NOT a suppression. An unlisted module turns
-/// the lane red, and so does a listed one that stopped firing (`stale`) — a
-/// fix removes its row in the same PR. Every row has its line in #400's
+/// Same contract as that list: NOT a suppression. A module no row names turns
+/// the lane red, so does a listed one firing more than its row enumerates
+/// (both `unexpected`), and so does one firing fewer (`stale`) — a fix lowers
+/// or removes its row in the same PR. Every row has its line in #400's
 /// table; a new drift lands as a row here AND a row there (ADR-0226 D4).
 const LvKnown = struct {
     /// `<proposal>/<manifest-dir>/<module>.wasm` — the path the runner's
@@ -562,7 +563,8 @@ const LvKnown = struct {
 /// row names its #400 table row; the funcs are the `func[N]` of its stderr
 /// lines. #400's own module list was taken with #398 applied, so a module
 /// (or func) absent from it is in #398's `.end` / `return` class by that
-/// measurement and its row drops when #398 lands — re-take the table then,
+/// measurement: a row wholly of that class drops when #398 lands, a mixed
+/// row's count falls — re-take the table then,
 /// do not edit it by hand.
 const lv_known_x86_64_sysv: []const LvKnown = &.{
     // `.end` ×20, `i32.add` ×4, `drop` ×1 over 17 funcs — #398's class.
@@ -636,6 +638,12 @@ comptime {
                 if (std.mem.eql(u8, a.key, b.key)) {
                     @compileError("liveverify table lists '" ++ a.key ++ "' twice");
                 }
+            }
+            // `record` is called only for n > 0 and `countFor` returns 0 when
+            // absent, so a zero row matches whether the module fires or not:
+            // it can never red the lane, and it inflates `enumerated`.
+            if (a.count == 0) {
+                @compileError("liveverify row '" ++ a.key ++ "' has count 0 — it can never fire; delete the row");
             }
         }
     }
@@ -777,6 +785,24 @@ pub fn main(init: std.process.Init) !void {
     // of the jit lane: with the env unset, or on the interp lane, none of the
     // `lv_mode` branches run and the lane's output is what it is without them.
     const lv_mode = jit_mode and liveness_parity.on();
+    // The gate below lives entirely inside `if (lv_mode)`, down to its summary
+    // line, so a dark channel is not a quieter lane — it is this step exiting 0
+    // having compared nothing, with no line saying so. `compiled_in` is false
+    // in ReleaseFast / ReleaseSmall and `core_rs` takes `-Doptimize` above
+    // Debug, so `zig build test-all -Doptimize=ReleaseFast` reaches it today.
+    // The step asked for the channel; if it is not on, that is the failure.
+    if (jit_mode and !lv_mode) {
+        if (init.environ_map.get("ZWASM_DEBUG")) |v| {
+            if (std.mem.indexOf(u8, v, "liveverify") != null) {
+                try stdout.print(
+                    "LIVEVERIFY-CHANNEL-DARK  ZWASM_DEBUG={s} asked for the channel and liveness_parity.on() is false (compiled_in={}, mode={s}) — this lane would have compared nothing and exited 0\n",
+                    .{ v, liveness_parity.compiled_in, @tagName(builtin.mode) },
+                );
+                try stdout.flush();
+                std.process.exit(1);
+            }
+        }
+    }
 
     const cwd = std.Io.Dir.cwd();
     var dir = cwd.openDir(io, corpus_root, .{}) catch |err| {
@@ -1245,9 +1271,10 @@ pub fn main(init: std.process.Init) !void {
                                 break :blk pp;
                             };
                             // ADR-0226 D3 — attribute this module's residuals.
-                            // The counter is read here and nowhere else, so a
-                            // residual fired outside a module compile is carried
-                            // into the next module's count, where it reds the
+                            // Read here per module, and once more after the
+                            // loop for what fired outside any compile, so a
+                            // residual is carried into the next module's count,
+                            // where it reds the
                             // lane as unexpected or stale, instead of being
                             // dropped. Read after `initLinked` whether or not it
                             // succeeded: the emit ran either way.
@@ -2185,9 +2212,19 @@ pub fn main(init: std.process.Init) !void {
         for (known) |kf| {
             const seen = jit_fail_log.countFor(kf.key);
             if (seen == kf.count) continue;
+            // Same split as the liveverify block below: a rise is a regression
+            // on an enumerated key, not a row that stopped firing.
+            if (seen > kf.count) {
+                jit_unexpected += 1;
+                try stdout.print(
+                    "JIT-UNEXPECTED-FAIL  {s}: {d} failing directive(s) against the {d} its row enumerates — the JIT got more wrong here than the row claims\n",
+                    .{ kf.key, seen, kf.count },
+                );
+                continue;
+            }
             jit_stale += 1;
             try stdout.print(
-                "JIT-EXPECTATION-STALE  {s}: enumerated {d} failing directive(s), observed {d} — correct the {s} row in spec_assert_runner_wasm_3_0.zig\n",
+                "JIT-EXPECTATION-STALE  {s}: enumerated {d} failing directive(s), observed {d} — the row over-claims; lower the {s} row in spec_assert_runner_wasm_3_0.zig\n",
                 .{ kf.key, kf.count, seen, jit_target_label },
             );
         }
@@ -2220,9 +2257,22 @@ pub fn main(init: std.process.Init) !void {
         for (known) |k| {
             const seen = lv_log.countFor(k.key);
             if (seen == k.count) continue;
+            // A row can miss in two directions and they call for opposite work.
+            // Fewer lines than enumerated is the ratchet: the row over-claims,
+            // lower it. More is a divergence this list never saw, on a module
+            // that happens to be listed — the same event as an unlisted module
+            // firing, so it counts as that and the text says so.
+            if (seen > k.count) {
+                lv_unexpected += 1;
+                try stdout.print(
+                    "LIVEVERIFY-UNEXPECTED  {s}: {d} residual line(s) against the {d} its row enumerates — a new liveness/emit divergence on an enumerated module; fix it or add its funcs to #400 before the {s} row moves\n",
+                    .{ k.key, seen, k.count, jit_target_label },
+                );
+                continue;
+            }
             lv_stale += 1;
             try stdout.print(
-                "LIVEVERIFY-EXPECTATION-STALE  {s}: enumerated {d} residual line(s), observed {d} — correct the {s} row in spec_assert_runner_wasm_3_0.zig and its line on #400\n",
+                "LIVEVERIFY-EXPECTATION-STALE  {s}: enumerated {d} residual line(s), observed {d} — the row over-claims; lower the {s} row in spec_assert_runner_wasm_3_0.zig and retire its line on #400\n",
                 .{ k.key, k.count, seen, jit_target_label },
             );
         }
@@ -2487,4 +2537,23 @@ test "wasm-3.0-assert §1: JIT error classification — unwired-shape → skip, 
     // observable behaviour → genuine fail (the meaningful both-backends
     // RED signal). `error.Trap` and any unanticipated error stay fail.
     try std.testing.expect(!jitErrorIsUnwiredShape(error.Trap));
+}
+
+test "ADR-0226: LvLog sums a module's residuals and reports 0 for one that never fired" {
+    // `record`'s accumulate branch has no counterpart in `JitFailLog` (which
+    // stores one entry per fail), and both halves of the exact-match gate
+    // read through it: a module counted twice would red the lane as a false
+    // regression, and an absent key returning anything but 0 would hide a
+    // stale row.
+    var log: LvLog = .{ .gpa = std.testing.allocator };
+    defer log.deinit();
+
+    try log.record("gc", "br_on_cast", "br_on_cast.0.wasm", 4);
+    try log.record("gc", "br_on_cast", "br_on_cast.0.wasm", 9);
+    try log.record("gc", "br_on_cast", "br_on_cast.1.wasm", 1);
+
+    try std.testing.expectEqual(@as(usize, 2), log.entries.items.len);
+    try std.testing.expectEqual(@as(u32, 13), log.countFor("gc/br_on_cast/br_on_cast.0.wasm"));
+    try std.testing.expectEqual(@as(u32, 1), log.countFor("gc/br_on_cast/br_on_cast.1.wasm"));
+    try std.testing.expectEqual(@as(u32, 0), log.countFor("gc/br_on_cast/br_on_cast.2.wasm"));
 }

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -556,7 +556,9 @@ const LvKnown = struct {
 
 /// x86_64 SysV — measured 2026-09-05 on x86_64-linux at `main` 7c7e434ea
 /// (ADR-0226 D2), by this lane's red-first run with the table empty:
-/// 69 residual lines over 10 modules, `0 enumerated, 10 unexpected`. Each
+/// 69 residual lines over 10 modules, `0 enumerated, 10 unexpected`; CI's
+/// Linux leg (run 33939200603, job 101233144116) then read the same ten
+/// rows as `10 enumerated, 0 unexpected, 0 stale`. Each
 /// row names its #400 table row; the funcs are the `func[N]` of its stderr
 /// lines. #400's own module list was taken with #398 applied, so a module
 /// (or func) absent from it is in #398's `.end` / `return` class by that
@@ -585,14 +587,45 @@ const lv_known_x86_64_sysv: []const LvKnown = &.{
     .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
 };
 
-/// x86_64-windows — seeded from this lane's own first CI run (ADR-0226 D2):
-/// the Win64 emit is not the SysV one, so a copied SysV row would describe
-/// nothing CI runs. Empty until that run names the rows.
-const lv_known_x86_64_windows: []const LvKnown = &.{};
+/// x86_64-windows — measured 2026-09-05 by this lane's own first CI run
+/// (run 33939200603, job 101233144158; ADR-0226 D2), with the table empty:
+/// `0 enumerated, 10 unexpected, 0 stale`. Written from that output, not
+/// copied from SysV: the Win64 emit is not the SysV one, so a copied row
+/// would have described nothing CI runs. That the rows came out identical
+/// — same ten modules, same counts, on the Linux leg too — is itself the
+/// measurement: the divergence is on the liveness side, which is
+/// arch-independent, not in either emit. Per-row attribution as the SysV
+/// table.
+const lv_known_x86_64_windows: []const LvKnown = &.{
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
+    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
+    .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
+};
 
-/// aarch64 (the macOS leg) — seeded from this lane's own first CI run, for
-/// the same reason. Empty until that run names the rows.
-const lv_known_aarch64: []const LvKnown = &.{};
+/// aarch64 (the macOS leg) — measured 2026-09-05 by the same first CI run
+/// (job 101233144280), table empty: `0 enumerated, 10 unexpected, 0 stale`.
+/// Identical to the two x86_64 tables, for the reason given above; a second
+/// backend agreeing with the first against liveness is what rules the emit
+/// out. Per-row attribution as the SysV table.
+const lv_known_aarch64: []const LvKnown = &.{
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
+    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
+    .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
+    .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
+};
 
 comptime {
     // A duplicated key would be counted once by `countFor` and twice in

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -598,7 +598,7 @@ const lv_known_x86_64_sysv: []const LvKnown = &.{
     .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
 };
 
-/// x86_64-windows — measured 2026-09-05 by this lane's own first CI run
+/// x86_64-windows — seeded 2026-09-05 by this lane's own first CI run
 /// (run 33939200603, job 101233144158; ADR-0226 D2), with the table empty:
 /// `0 enumerated, 10 unexpected, 0 stale`. Written from that output, not
 /// copied from SysV: the Win64 emit is not the SysV one, so a copied row
@@ -607,33 +607,38 @@ const lv_known_x86_64_sysv: []const LvKnown = &.{
 /// measurement: the divergence is on the liveness side, which is
 /// arch-independent, not in either emit. Per-row attribution as the SysV
 /// table.
+///
+/// Re-taken 2026-09-08 the same way, by the leg's run on the SysV re-take
+/// (run 34200535507, job 101978122541) against the seed rows:
+/// `10 enumerated, 4 unexpected, 3 stale`, the same seven moves the SysV
+/// table made, to the same counts.
 const lv_known_x86_64_windows: []const LvKnown = &.{
-    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
-    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
-    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
-    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 1 },
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 15 },
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 2 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 18 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 4 },
     .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
-    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
     .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
     .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
 };
 
-/// aarch64 (the macOS leg) — measured 2026-09-05 by the same first CI run
+/// aarch64 (the macOS leg) — seeded 2026-09-05 by the same first CI run
 /// (job 101233144280), table empty: `0 enumerated, 10 unexpected, 0 stale`.
 /// Identical to the two x86_64 tables, for the reason given above; a second
 /// backend agreeing with the first against liveness is what rules the emit
 /// out. Per-row attribution as the SysV table.
+///
+/// Re-taken 2026-09-08 by the same run as the Win64 table (job
+/// 101978122561): `10 enumerated, 4 unexpected, 3 stale`, the same seven
+/// moves to the same counts — the third backend agreeing on #398's effect.
 const lv_known_aarch64: []const LvKnown = &.{
-    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
-    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
-    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
-    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 1 },
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 15 },
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 2 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 18 },
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 4 },
     .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
-    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
     .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
     .{ .key = "function-references/br_on_null/br_on_null.2.wasm", .count = 1 },
 };

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -802,7 +802,7 @@ pub fn main(init: std.process.Init) !void {
     // The step asked for the channel; if it is not on, that is the failure.
     if (jit_mode and !lv_mode) {
         if (init.environ_map.get("ZWASM_DEBUG")) |v| {
-            if (std.mem.indexOf(u8, v, "liveverify") != null) {
+            if (std.mem.find(u8, v, "liveverify") != null) {
                 try stdout.print(
                     "LIVEVERIFY-CHANNEL-DARK  ZWASM_DEBUG={s} asked for the channel and liveness_parity.on() is false (compiled_in={}, mode={s}) — this lane would have compared nothing and exited 0\n",
                     .{ v, liveness_parity.compiled_in, @tagName(builtin.mode) },

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -555,34 +555,43 @@ const LvKnown = struct {
     count: u32,
 };
 
-/// x86_64 SysV — measured 2026-09-05 on x86_64-linux at `main` 7c7e434ea
+/// x86_64 SysV — seeded 2026-09-05 on x86_64-linux at `main` 7c7e434ea
 /// (ADR-0226 D2), by this lane's red-first run with the table empty:
 /// 69 residual lines over 10 modules, `0 enumerated, 10 unexpected`; CI's
 /// Linux leg (run 33939200603, job 101233144116) then read the same ten
-/// rows as `10 enumerated, 0 unexpected, 0 stale`. Each
-/// row names its #400 table row; the funcs are the `func[N]` of its stderr
-/// lines. #400's own module list was taken with #398 applied, so a module
-/// (or func) absent from it is in #398's `.end` / `return` class by that
-/// measurement: a row wholly of that class drops when #398 lands, a mixed
-/// row's count falls — re-take the table then,
-/// do not edit it by hand.
+/// rows as `10 enumerated, 0 unexpected, 0 stale`.
+///
+/// Re-taken 2026-09-07 at `main` 5e989fe22, with #398 (494b297b7 through
+/// b5bbf89c9) landed: 45 lines over 8 modules. Against the seed the lane
+/// read `4 unexpected, 3 stale`: three rows fell to 0 and left, four rose,
+/// three held. Of the twelve lines the rises add, ten are `end`: #398's last
+/// commit compares at the `.end` that closes a dead body, so a func already
+/// off after its `return` or `unreachable` prints that `.end` too. The other
+/// two are named on their row. No func fires that did not fire at the seed.
+/// Each row names its #400 line; the funcs are the `func[N]` of its stderr
+/// lines, taken one module per run. Re-take the table, do not edit it by
+/// hand.
 const lv_known_x86_64_sysv: []const LvKnown = &.{
-    // `.end` ×20, `i32.add` ×4, `drop` ×1 over 17 funcs — #398's class.
-    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 25 },
-    // `return` ×9 (funcs 8–15, 19) — #398's class.
-    .{ .key = "exception-handling/try_table/try_table.1.wasm", .count = 9 },
-    // #400 `br_on_cast` row (funcs 3, 4); funcs 5, 6 are #398's class.
-    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 13 },
-    // #400 `br_on_cast` row (func 1).
-    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 1 },
-    // #400 `br_on_cast_fail` row (funcs 2, 3); funcs 4–6 are #398's class.
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 11 },
-    // #400 `br_on_cast_fail` row (funcs 1, 2).
-    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 2 },
+    // Func 70 alone, of the 25 the seed had: `drop` after the `.end` of a
+    // dead body (`unreachable`, `br_table`, `end`), liveness depth 0 against
+    // the emit's 1 — not the `.end` / `return` shape #398 took, and not the
+    // capture shape of #400's rows. Its ledger line is not written yet.
+    .{ .key = "memory64/br_table/br_table.0.wasm", .count = 1 },
+    // #400 `br_on_cast` row, funcs 3–6; 5 and 6 fire as 3 and 4 do (equal
+    // depth, liveness one vreg above the emit). +2 on the seed: the `.end`
+    // after `return` in funcs 4 and 6.
+    .{ .key = "gc/br_on_cast/br_on_cast.0.wasm", .count = 15 },
+    // #400 `br_on_cast` row (func 1). +1: the `.end` after `unreachable`.
+    .{ .key = "gc/br_on_cast/br_on_cast.1.wasm", .count = 2 },
+    // #400 `br_on_cast_fail` row, funcs 2–6; 4–6 fire as 2 and 3 do. +7 on
+    // the seed: the `.end` after `return` in each of the five, and func 4's
+    // `i32.const` / `array.get_u`, which #398's first two commits brought in.
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.0.wasm", .count = 18 },
+    // #400 `br_on_cast_fail` row (funcs 1, 2). +2: the `.end` after
+    // `unreachable` in each.
+    .{ .key = "gc/br_on_cast_fail/br_on_cast_fail.1.wasm", .count = 4 },
     // #400 `br_on_null` / `br_on_non_null` row (funcs 0, 1, 6) — the traced mechanism.
     .{ .key = "function-references/br_on_non_null/br_on_non_null.0.wasm", .count = 3 },
-    // `drop` ×3 (funcs 0–2), absent from #400's list — #398's class.
-    .{ .key = "function-references/br_on_non_null/br_on_non_null.1.wasm", .count = 3 },
     // #400 `br_on_null` / `br_on_non_null` row (func 1).
     .{ .key = "function-references/br_on_non_null/br_on_non_null.2.wasm", .count = 1 },
     // #400 `br_on_null` / `br_on_non_null` row (func 1).


### PR DESCRIPTION
One gate decision is the maintainer's before this merges, and it is a
choice of two. #269 landed `liveverify` as "Diagnostic, not a gate —
Blocking CI on it needs an ADR (ADR-0076 D9, ADR-0212 D1)"; this is that
ADR, and the lane it defines, in one PR the way ADR-0225 landed with #380.
The ADR is **Proposed** in this diff and flips to Accepted on the answer.

**D1 — where the liveness parity check gates.** A second run of the
wasm-3.0 JIT spec lane with the check on, in `test-all` and therefore the
core `ci-required` gate, comparing residuals against a named per-target
list (the shape of #376's `jitKnownFails` and ADR-0225's ratchet):
`unexpected` or `stale` exits non-zero.

- **A — block from day one, the measured residuals as the list.** Merge as
  is; the list is the debt, visible per row, and only ratchets down.
- **B — report first, block later.** Say the count at which it should
  block; I add `continue-on-error` and that threshold, and the Status line
  records it. #307 item 6 is the record of what `continue-on-error` costs:
  the outcome stops being readable from `ci-required`.

Answer on the ADR file's review thread. Everything below is what the diff
carries and how it was measured.

---

The numbers #269 was missing are in the ADR's Context: 68 residual lines
over the 3.0 corpus on `main` at `7c7e434ea`, 2 % of a 7.5 s step. The
lane's own re-take counts 69; the Context takes the lane's numbers once all
three legs have run. #400 holds the per-drift rows the list names.

What the diff carries besides the ADR (D3, apparatus-internal):

- `liveness_parity` keeps a per-module residual counter the runner reads;
  `check` is unchanged otherwise.
- the 3.0 runner prints the module path with each module's residual count,
  reads the counter after each module, and compares against
  `liveverifyKnown()` — `unexpected` / `stale` exit non-zero, the summary
  line mirrors the JIT known-wrong one.
- a `test-spec-wasm-3.0-assert-liveverify` step (JIT lane, gate on) that
  `test-all` depends on. The env is set nowhere else.

Proof the gate gates — the step on x86_64-linux with all three tables
empty, before seeding:

```
[wasm-3.0-assert] liveverify (x86_64-linux): 0 enumerated, 10 unexpected, 0 stale
```

exit 1, one `LIVEVERIFY-UNEXPECTED` line per module; 69 residual lines
over 10 modules. With the env unset, both plain lanes' stdout is
byte-identical to `main`'s.

Seeding, per D2: the x86_64 SysV table is in this diff. The Win64 and
aarch64 tables are empty on the first push on purpose — that run's
`unexpected` lines are the measurement, and the second push copies them in.
Until then the Windows and macOS legs are expected red; that is the
seeding, not a defect.

Refs #400, #269. Does not touch #398; if #398 lands first, this rebases and
the `end` / `return` rows leave the SysV table.
