### PR TITLE
test(component): the spec runner prints its manifest count, and the comments cite it

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -482,9 +482,10 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/zwasm.zig"),
         .target = target,
         // ADR-0177 (Revision 2026-06-14): the Component Model spec runner
-        // (`comp_spec_runner`, 158-manifest corpus in `test-all`) is an
-        // integration runner — floor it at ReleaseSafe like `core_rs`, else a
-        // plain Debug `zig build test-all` runs the whole CM corpus ~100× slower.
+        // (`comp_spec_runner`, the `test-component-spec` lane; its summary
+        // prints the corpus size as `(over N manifests)`) is an integration
+        // runner — floor it at ReleaseSafe like `core_rs`, else a plain Debug
+        // `zig build test-all` runs the whole CM corpus ~100× slower.
         // `core_comp` is consumed ONLY by that runner (no production component
         // exe), so the floor never costs a real Debug build.
         .optimize = runner_optimize,

--- a/scripts/check_releasesafe_runners.sh
+++ b/scripts/check_releasesafe_runners.sh
@@ -10,8 +10,9 @@
 #       justified allowlist (a new runner that forgot the floor), OR
 #   (a2) a runner is handed the Debug `exe` as a SPAWNED BINARY — the channel
 #       (a) cannot see, because the runner imports no zwasm module at all.
-#   (b) `core_comp` (the Component Model spec runner's module, 158-manifest
-#       corpus in test-all) regresses from `runner_optimize` back to raw
+#   (b) `core_comp` (the Component Model spec runner's module; the
+#       `test-component-spec` summary prints its corpus size as
+#       `(over N manifests)`) regresses from `runner_optimize` back to raw
 #       `optimize` (= Debug) — the 2026-06-14 gap.
 #
 # Honours-`-Doptimize` allowlist (verified intentional): `core` itself
@@ -69,7 +70,8 @@ done < <(grep -nE 'add[A-Za-z]*Arg\([^)]*\bexe\b[^)]*\)|\bexe\.getEmittedBin\(' 
 core_comp_block=$(awk '/const core_comp = b\.createModule/{f=1} f{print} /\}\);/{if(f) exit}' "$BUILD")
 if ! grep -qE '\.optimize = runner_optimize' <<<"$core_comp_block"; then
   echo "[check_releasesafe_runners] BLOCK — core_comp is not on \`.optimize = runner_optimize\`."
-  echo "  The Component Model spec runner (158-manifest corpus in test-all) would run Debug."
+  echo "  The Component Model spec runner (the \`test-component-spec\` lane; its summary"
+  echo "  prints the corpus size as \`(over N manifests)\`) would run Debug."
   echo "  Fix: \`.optimize = runner_optimize\` (ADR-0177 Revision 2026-06-14)."
   fail=1
 fi

--- a/test/spec/component_model_assert_runner.zig
+++ b/test/spec/component_model_assert_runner.zig
@@ -87,6 +87,7 @@ pub fn main(init: std.process.Init) !void {
     var failed: u32 = 0;
     var skipped: u32 = 0;
     var skipped_adr: u32 = 0;
+    var manifest_count: u32 = 0;
 
     var engine = try zwasm.Engine.init(gpa, .{});
     defer engine.deinit();
@@ -104,13 +105,14 @@ pub fn main(init: std.process.Init) !void {
     var it = root.iterate();
     while (try it.next(io)) |dir_entry| {
         if (dir_entry.kind != .directory) continue;
+        manifest_count += 1;
         runCorpus(io, gpa, &engine, &root, dir_entry.name, stdout, &passed, &failed, &skipped, &skipped_adr) catch |err| {
             try stdout.print("FAIL  {s}: corpus error {s}\n", .{ dir_entry.name, @errorName(err) });
             failed += 1;
         };
     }
 
-    try stdout.print("\ncomponent_model_assert_runner: {d} passed, {d} failed, {d} skipped (= {d} skip-impl + {d} skip-adr)\n", .{ passed, failed, skipped + skipped_adr, skipped, skipped_adr });
+    try stdout.print("\ncomponent_model_assert_runner: {d} passed, {d} failed, {d} skipped (= {d} skip-impl + {d} skip-adr) (over {d} manifests)\n", .{ passed, failed, skipped + skipped_adr, skipped, skipped_adr, manifest_count });
     try stdout.flush();
     if (failed != 0) std.process.exit(1);
 }


### PR DESCRIPTION
## What

- `component_model_assert_runner` now ends its summary with `(over N manifests)`, the tail every other spec runner already prints.
- The `core_comp` comment in `build.zig` and both mentions in `scripts/check_releasesafe_runners.sh` (header + the BLOCK message) name the lane and its printed count instead of a copied number.

## Why

`158` was the assertion count at campaign close (2026-06-13, 14 manifests then); the tree has 26 manifests. A number copied into a comment rots; a printed one does not.

Dated records that say `158/0/0` (ROADMAP, proposal_watch, ADR-0193, release notes, `validate.zig`) are left as written.

## Check

`bash scripts/gate_commit.sh` green; `zig build test-component-spec` and `test-all` print `(over 26 manifests)`; the BLOCK branch of `check_releasesafe_runners.sh` was provoked against a copy of `build.zig` with the floor removed and its message read.

Closes #396.
