### PR TITLE
scripts(gate): the local pre-flight names what it does not cover, and runs doc-truth's two missing checks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,7 +22,8 @@ zwasm v2 is a ground-up redesign of zwasm (v1 git history at commit 517cc5a).
   push, PR required, and the `ci-required` status check (CI's 3-OS gate) must be
   green to merge; only the repo admin can bypass. Doc-only PRs auto-skip the
   heavy gate (still green via `ci-required`). The local `scripts/gate_merge.sh`
-  (3-host SSH fan-out) is an **optional** pre-PR pre-flight mirroring CI
+  (3-host SSH fan-out) is an **optional** pre-PR pre-flight that runs
+  `test-all` per host, not the CI leg — its header names what it leaves out
   (ADR-0076 D9) — CI's `ci-required` is authoritative. `--force`
   always forbidden. Root is kept lean (ADR-mirroring the CW layout): this file
   is `.claude/CLAUDE.md`; community-health files (CONTRIBUTING / CODE_OF_CONDUCT /
@@ -90,9 +91,11 @@ text or code identifiers.
   would dominate every PR's wall-clock (rationale in `ci.yml`).
   Doc-only PRs auto-skip the heavy legs (still green via `ci-required`). The
   local `scripts/gate_merge.sh` (3-host SSH fan-out) + `scripts/gate_commit.sh`
-  (pre-commit) are now **optional pre-PR pre-flight** mirroring CI — no longer
-  load-bearing for merge safety. The campaign-era Windows-BATCHED / `--suspend`
-  cadence is RETIRED (its scripts are deleted; ADR-0174 superseded-in-part).
+  (pre-commit) are now **optional pre-PR pre-flight** — a preview of part of
+  the leg, not a reproduction of it (`gate_merge.sh`'s header names what it
+  leaves out); no longer load-bearing for merge safety. The campaign-era
+  Windows-BATCHED / `--suspend` cadence is RETIRED (its scripts are deleted;
+  ADR-0174 superseded-in-part).
   Per-machine host aliases for the optional fan-out live in
   `scripts/dev_hosts.env` (gitignored; template `dev_hosts.env.example` —
   ADR-0206).
@@ -213,7 +216,8 @@ call it before `git commit`.
 
 The **authoritative** merge gate is CI's `ci-required` 3-OS `scripts/ci_gate.sh`
 run on every PR. [`scripts/gate_merge.sh`](../scripts/gate_merge.sh) (local
-3-host SSH fan-out) is now an **optional** pre-PR pre-flight that mirrors CI
+3-host SSH fan-out) is now an **optional** pre-PR pre-flight that runs
+`test-all` per host, not `ci_gate.sh` — its header names what it leaves out
 (ADR-0076 D9) — not required for merge safety.
 
 ## References

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@
 # script — `test-wasi-p1-official`, whose own block below says why it sits
 # here. And `gate_merge.sh` does not invoke `ci_gate.sh` at all: it runs
 # `gate_commit.sh` locally and `run_remote_*.sh test-all` on the two remote
-# hosts, so it approximates the leg rather than reproducing it. Workflow-wide
-# the same already holds for `doc-truth`, which blocks through `ci-required`
-# while its `check_wasi03_coverage_claims` / `check_doc_fossils` have no local
-# counterpart. `ci-required` is authoritative; the local scripts are
-# pre-flight (ADR-0076 D9).
+# hosts, so it approximates the leg rather than reproducing it — its header
+# names what it leaves out. The `doc-truth` job's three checks do have a local
+# counterpart: `gate_commit.sh` runs them above its docs-only short-circuit.
+# `ci-required` is authoritative; the local scripts are pre-flight
+# (ADR-0076 D9).
 #
 # Triggers: pull_request (any target) + push to `main` + manual dispatch.
 # `main` is the trunk and is ruleset-protected: no direct pushes — every change

--- a/docs/development.md
+++ b/docs/development.md
@@ -184,9 +184,10 @@ toolchains — see [`.dev/toolchain_provisioning.md`](../.dev/toolchain_provisio
 ## Things you may see referenced but do NOT need
 
 - **Remote pre-flight scripts** (`scripts/gate_merge.sh`,
-  `scripts/run_remote_*.sh`): an *optional* local mirror of the CI matrix for
-  anyone with spare x86_64 Linux / Windows machines. CI is the authoritative
-  gate — you never need these. To use them, copy
+  `scripts/run_remote_*.sh`): an *optional* way to run `zig build test-all`
+  on spare x86_64 Linux / Windows machines before opening a PR. That is one
+  step of each CI leg, not the leg — the script's header names what it leaves
+  out. CI is the authoritative gate — you never need these. To use them, copy
   [`scripts/dev_hosts.env.example`](../scripts/dev_hosts.env.example) to
   `scripts/dev_hosts.env` (gitignored) and point the three values at your own
   hosts; every remote-gate script sources it. No host name is baked into the

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # scripts/ci_gate.sh — single source of truth for the HOST-LOCAL verification
-# gate. Both CI (.github/workflows/ci.yml, once per matrix OS) and the local
-# maintainer flow (gate_merge.sh mirrors these same steps) run this, so CI can
-# never verify LESS than the per-host gate. It checks the CURRENT host only;
-# multi-host fan-out is the caller's job (the CI matrix / gate_merge's SSH legs).
+# gate. CI (.github/workflows/ci.yml, once per matrix OS) runs this; the local
+# pre-flight (gate_merge.sh) does NOT — it runs `test-all` per host, and its
+# header names the steps below it leaves out. It checks the CURRENT host only;
+# multi-host fan-out is the caller's job (the CI matrix).
 #
 #   Core — every OS: zig fmt --check (src/ + bench/latency/ + tools/) +
 #     zig build test-all + bench-latency-build + test-discovery guard +

--- a/scripts/gate_commit.sh
+++ b/scripts/gate_commit.sh
@@ -11,7 +11,9 @@
 #   9. scripts/check_fallback_patterns.sh (report)          — info; skipped on docs-only.
 #  10. scripts/check_invariant_comments.sh --strict         — gate (ADR-0077, B128); skipped on docs-only.
 #  11. scripts/check_engine_default_claims.sh --gate        — gate; ALWAYS (docs are the thing it guards).
-#  12. zig build test (Mac native)                          — skipped on docs-only.
+#  12. scripts/check_wasi03_coverage_claims.sh --gate       — gate; ALWAYS (same reason).
+#  13. scripts/check_doc_fossils.sh --gate                  — gate; ALWAYS (same reason).
+#  14. zig build test (Mac native)                          — skipped on docs-only.
 #
 # Per the A6 gate consolidation study (§9.12-A / A6), docs/config-only
 # diffs cannot move src/-related gate outcomes, so they short-circuit.
@@ -141,10 +143,19 @@ else
     echo "(no src/*.zig yet — skipping fmt)"
 fi
 
-# --- gate: engine-default claims (always — docs are exactly what rots) --
+# --- gates: prose-truth checks (always — docs are exactly what rots) ----
+#
+# The three checks CI's `doc-truth` job runs on every PR, doc-only included.
+# They sit ABOVE the docs-only short-circuit for the reason that job exists:
+# their subject is the prose the short-circuit would otherwise skip. Each
+# writes its findings to stderr, so `> /dev/null` hides only the OK chatter.
 
 echo "[gate_commit] check_engine_default_claims --gate ..."
 bash scripts/check_engine_default_claims.sh --gate > /dev/null
+echo "[gate_commit] check_wasi03_coverage_claims --gate ..."
+bash scripts/check_wasi03_coverage_claims.sh --gate > /dev/null
+echo "[gate_commit] check_doc_fossils --gate ..."
+bash scripts/check_doc_fossils.sh --gate > /dev/null
 
 # --- gates: zone + file_size + skip_adrs (skipped on docs-only) ---------
 

--- a/scripts/gate_merge.sh
+++ b/scripts/gate_merge.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env bash
-# OPTIONAL local pre-PR pre-flight that MIRRORS CI. Runs the commit gate plus a
-# three-host test:
-#   - zig build test-all on Mac native
-#   - zig build test-all on the configured Linux x86_64 SSH host
-#     (`ZWASM_UBUNTU_HOST`; per ADR-0067 native, not OrbStack-Rosetta)
-#   - zig build test-all on the configured Windows SSH host
-#     (`ZWASM_WINDOWS_HOST`, if reachable)
+# OPTIONAL local pre-PR pre-flight. Runs the commit gate here, then
+# `zig build test-all` on three hosts:
+#   - Mac native
+#   - the configured Linux x86_64 SSH host (`ZWASM_UBUNTU_HOST`; per ADR-0067
+#     native, not OrbStack-Rosetta)
+#   - the configured Windows SSH host (`ZWASM_WINDOWS_HOST`, if reachable)
 #
 # `main` is ruleset-protected (no direct pushes) — changes land via a
 # develop/<slug> branch → PR → CI. The AUTHORITATIVE 3-OS merge gate is the
-# server-side `ci-required` status check on the PR. This script is a
-# convenience: it mirrors that same `scripts/ci_gate.sh` matrix on real
-# hardware so a maintainer CAN verify locally before opening a PR — but it is
-# not required, and green here is not a substitute for green ci-required.
+# server-side `ci-required` status check on the PR, whose legs run
+# `scripts/ci_gate.sh` (ADR-0076 D9). This script does NOT invoke
+# `ci_gate.sh`: it runs `gate_commit.sh` locally and `test-all` on each host,
+# so it approximates a leg rather than reproducing it. Blocking in CI and run
+# by nothing below — a green run here cannot predict a red PR on these:
+#   - `zig build bench-latency-build`         (ci_gate.sh core, every leg)
+#   - `check_test_discovery --gate`           (ci_gate.sh core, every leg;
+#                                              host-dependent, so one local
+#                                              run covers one arch)
+#   - `zig build test -Doptimize=ReleaseSafe` (ci_gate.sh, Linux leg)
+#   - `zig build run-rust-host`               (ci_gate.sh, Linux leg)
+#   - `zig build test-wasi-p1-official`       (a leg step outside ci_gate.sh;
+#                                              not in test-all)
+# The prose-truth checks of CI's `doc-truth` job run once, in gate_commit.sh.
+# Green here is not a substitute for green ci-required.
 #
 # An unconfigured or unreachable SSH host → WARN and continue (the local Mac
 # gate is the firm floor).
@@ -23,8 +33,8 @@
 #   - test-realworld       (§9.6 / 6.1 chunk a; 50 fixtures, parse)
 #   - test-realworld-run   (§9.6 / 6.1 chunk b; 50 fixtures, run)
 #   - test-spec / test-spec-wasm-2.0 / test-c-api / test-wasi-p1
-# The same layers run in CI's ci-required matrix, which is what actually gates
-# a merge to `main`; this local run just previews that outcome.
+# The same step runs inside `ci_gate.sh` on each CI leg; this local run
+# previews that one step's outcome per host, not the leg's.
 #
 # Exits non-zero on any host that built but had a failed test, on any
 # commit-gate failure, or on missing tools (ssh) — as a local preview signal,


### PR DESCRIPTION
`scripts/gate_merge.sh:13` claimed to mirror the `scripts/ci_gate.sh` matrix; lines 2-8 of the same header said it runs `test-all` on three hosts, and the body agrees with the latter. This PR makes the two local scripts honest about what they do not cover, per #383.

- `scripts/gate_merge.sh`: the header now names the CI-blocking steps it does not run — `bench-latency-build`, `check_test_discovery`, `zig build test -Doptimize=ReleaseSafe`, `run-rust-host`, and `test-wasi-p1-official` (which `build.zig` keeps out of `test-all`). Names, not a count.
- `scripts/gate_commit.sh`: runs all three of the `doc-truth` job's checks, next to the one it already had and above the docs-only short-circuit. Measured on a docs-only run: 13.5 s total, of which the two new checks are 1.1 s.
- `scripts/ci_gate.sh`, `.claude/CLAUDE.md`, `docs/development.md`: the same "mirrors CI" claim, reworded to what the fan-out runs — `test-all` per host — with a pointer to `gate_merge.sh`'s header for what it leaves out.
- `.github/workflows/ci.yml`: the header sentence saying `check_wasi03_coverage_claims` / `check_doc_fossils` have no local counterpart is corrected.

Option 1 of the issue (`gate_merge.sh` runs `ci_gate.sh` per host) is measured only, not implemented; whether to take it is a separate decision. `ci-required` stays authoritative (ADR-0076 D9); nothing it accepts changes.

Closes #383.
