### PR TITLE
test: a guard catches a runner that owns main and never calls dbg.initFromEnv

### DIFF
--- a/scripts/check_runner_dbg_init.sh
+++ b/scripts/check_runner_dbg_init.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Runner dbg-init guard (issue #329; the #268 incident class).
+#
+# `support/dbg` keeps its channel whitelist in process-global state that only
+# `dbg.initFromEnv` fills. The two callers are `cli/main.zig` and
+# `api/instance.zig:wasm_engine_new`; a `test/` runner that owns its own
+# `pub fn main(init: std.process.Init)` and drives the engine in-process
+# reaches neither, so every `ZWASM_DEBUG` channel is silently off in that
+# lane. #328 put the one-line call at the top of 19 runners and nothing
+# stopped a 20th from omitting it — `test/wasi/stdin_pipe_runner.zig` landed
+# without it the next day (an exemption, as it turned out, but one nobody
+# had been asked to decide).
+#
+# Unlike check_test_discovery.sh this asks no compiler: "does the file with an
+# Init-taking main also call dbg.initFromEnv" is exact under grep, so it costs
+# well under a second and sits in the core gate.
+#
+# A runner that cannot call it (no `zwasm` import — it spawns the CLI, which
+# reads the env itself) or must not (its `main` never runs) carries
+# `// DBG-INIT-EXEMPT: <reason>` on lines 1-5. The reasons live in the files,
+# not here: a list in this script would outlive the file it names.
+#
+# Modes:
+#   bash scripts/check_runner_dbg_init.sh          informational
+#   bash scripts/check_runner_dbg_init.sh --gate   exit 1 on findings
+
+set -euo pipefail
+MODE="${1:-info}"
+cd "$(dirname "$0")/.."
+
+checked=0
+exempt=0
+findings=0
+while IFS= read -r f; do
+    checked=$((checked + 1))
+    if head -n 5 "$f" | grep -qE 'DBG-INIT-EXEMPT: *[^[:space:]]'; then
+        exempt=$((exempt + 1))
+        continue
+    fi
+    if ! grep -q 'dbg\.initFromEnv(' "$f"; then
+        echo "DARK-RUNNER: $f — owns pub fn main(init: std.process.Init) but never calls dbg.initFromEnv" >&2
+        findings=$((findings + 1))
+    fi
+done < <(grep -rlE '^pub fn main\(init: std\.process\.Init\)' --include='*.zig' test/ | sort)
+
+# An empty enumeration is the grep rotting, not a clean tree: the runners
+# this guards are in test/ today and a green run over nothing proves nothing.
+if [ "$checked" -eq 0 ]; then
+    echo "[check_runner_dbg_init] FAIL — no test/ file with 'pub fn main(init: std.process.Init)' found; the pattern no longer matches the runners" >&2
+    exit 1
+fi
+
+if [ "$findings" -gt 0 ]; then
+    echo >&2
+    echo "[check_runner_dbg_init] $findings runner(s) never call dbg.initFromEnv — add 'zwasm.support.dbg.initFromEnv(init.environ_map.get(\"ZWASM_DEBUG\"));' at the top of main, or mark the file '// DBG-INIT-EXEMPT: <reason>' on lines 1-5" >&2
+    [ "$MODE" = "--gate" ] && exit 1
+fi
+echo "[check_runner_dbg_init] OK — $checked runner(s) checked, $exempt exempt, $findings dark" >&2
+exit 0

--- a/scripts/check_runner_dbg_init.sh
+++ b/scripts/check_runner_dbg_init.sh
@@ -37,7 +37,10 @@ while IFS= read -r f; do
         exempt=$((exempt + 1))
         continue
     fi
-    if ! grep -q 'dbg\.initFromEnv(' "$f"; then
+    # Anchored to the start of a statement line: a call inside a `//` comment
+    # or a string literal is text, not a call, and must not satisfy the gate.
+    # Zig has no block comments, so the line anchor is exact.
+    if ! grep -qE '^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)*dbg\.initFromEnv\(' "$f"; then
         echo "DARK-RUNNER: $f — owns pub fn main(init: std.process.Init) but never calls dbg.initFromEnv" >&2
         findings=$((findings + 1))
     fi

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -99,6 +99,15 @@ fi
 echo "[ci_gate] test-discovery guard (check_test_discovery --gate)"
 bash scripts/check_test_discovery.sh --gate
 
+# Runner dbg-init guard (issue #329; the #268 class). A test/ runner that owns
+# its own `main(init: std.process.Init)` reaches `dbg.initFromEnv` only if it
+# calls it, and one that does not runs every ZWASM_DEBUG channel dark with no
+# lane going red. A grep over test/, under 0.1 s, so core rather than
+# extended. Output kept for the same reason as check_spec_manifest_shape
+# below: the finding is the file name.
+echo "[ci_gate] runner dbg-init guard (check_runner_dbg_init --gate)"
+bash scripts/check_runner_dbg_init.sh --gate
+
 # Spec-manifest shape guard (ADR-0210). The spec runners print an
 # enumeration denominator whose whole value is that a third party can
 # re-derive it with `wc -l`. That only holds while the corpora stay one

--- a/scripts/gate_merge.sh
+++ b/scripts/gate_merge.sh
@@ -17,6 +17,7 @@
 #   - `check_test_discovery --gate`           (ci_gate.sh core, every leg;
 #                                              host-dependent, so one local
 #                                              run covers one arch)
+#   - `check_runner_dbg_init --gate`          (ci_gate.sh core, every leg)
 #   - `zig build test -Doptimize=ReleaseSafe` (ci_gate.sh, Linux leg)
 #   - `zig build run-rust-host`               (ci_gate.sh, Linux leg)
 #   - `zig build test-wasi-p1-official`       (a leg step outside ci_gate.sh;

--- a/test/aot/aot_process_diff.zig
+++ b/test/aot/aot_process_diff.zig
@@ -1,3 +1,4 @@
+// DBG-INIT-EXEMPT: no zwasm import — the engine runs in the spawned CLI, which reads ZWASM_DEBUG itself (cli/main.zig). Kept dark on purpose: dbg.anyActive() makes produceFromCompiledWasm refuse, so the compile lane cannot run under any channel and test-aot-diff takes no ZWASM_DEBUG.
 //! CROSS-PROCESS `.wasm`-vs-`.cwasm` differential (AOT-full-fidelity
 //! campaign Phase II; see
 //! `.dev/meta_audits/2026-07-09-aot-full-fidelity-investigation.md`).

--- a/test/realworld/d489_repro.zig
+++ b/test/realworld/d489_repro.zig
@@ -1,3 +1,4 @@
+// DBG-INIT-EXEMPT: manual D-489 isolation harness (zig build d489-repro), in no test lane — the guard exists for lanes whose channels went dark unnoticed, and this one is run by hand for a single investigation.
 //! Minimal D-489 repro — isolates WHY tinygo_json's JIT output is correct (90B)
 //! via the direct CLI but wrong (130B) via the diff-runner. Both use the SAME
 //! `runWasmJitCaptured`; argv/limits/preopen/env are all ruled out. Remaining

--- a/test/runners/eh_frequency_runner.zig
+++ b/test/runners/eh_frequency_runner.zig
@@ -1,3 +1,4 @@
+// DBG-INIT-EXEMPT: addTest target in build.zig — only the in-file test blocks run; this main is never executed.
 //! EH frequency runner skeleton (10.T-3; benchmark scaffolding
 //! pending Phase 8b).
 //!

--- a/test/runners/gc_stress_runner.zig
+++ b/test/runners/gc_stress_runner.zig
@@ -1,3 +1,4 @@
+// DBG-INIT-EXEMPT: addTest target in build.zig — only the in-file test blocks run; this main is never executed.
 //! GC stress runner skeleton (10.T-3; impl-body lands with 10.G).
 //!
 //! Per Phase 10 design plan §3.5 — once `feature/gc/heap.zig` +

--- a/test/wasi/stdin_pipe_runner.zig
+++ b/test/wasi/stdin_pipe_runner.zig
@@ -1,3 +1,4 @@
+// DBG-INIT-EXEMPT: no zwasm import — the engine runs in the spawned CLI, which reads ZWASM_DEBUG itself (cli/main.zig); std.process.spawn with no environ_map hands the child this process's environment, so a channel set on this lane reaches it.
 //! CLI stdin regression (issue #257): `zwasm run` must hand a core module
 //! the process stdin. Spawns the REAL CLI with bytes piped into fd 0 and
 //! checks the `stdin_echo.wasm` guest echoes them back (stdout = the bytes,


### PR DESCRIPTION
Closes #329. The script, the file-side exemptions, and the `ci_gate.sh`
wiring (gate-definition change, ADR-0212 D1, signed off on this PR).

## The guard

`scripts/check_runner_dbg_init.sh` lists every `test/` file with a
`pub fn main(init: std.process.Init)` and requires `dbg.initFromEnv` in it,
or `// DBG-INIT-EXEMPT: <reason>` on lines 1-5 (an empty reason does not
count). Unlike `check_test_discovery.sh` it asks no compiler: the question
is exact under grep. An empty enumeration is also a failure, so the pattern
cannot rot green.

## Measured (x86_64-linux, on top of 08e784d1c)

- 24 runners enumerated, 5 exempt, 0 dark; 0.07 s wall.
- Positive control: deleting the line from `test/spec/runner.zig` → exit 1
  naming that file. Blanking a marker's reason → exit 1.
- The call commented out, its text inside a string literal, or in a
  trailing comment → exit 1 (the match is anchored to a statement line;
  Devin's finding on this PR).
- `scripts/gate_commit.sh` (full, not `--fast`): green.

## The fifth exemption

#328 named four Init-taking runners. `test/wasi/stdin_pipe_runner.zig`
(#366, the day after #328) has an Init `main` and no call — the runner #329
predicted. It imports no `zwasm` and spawns the CLI, which reads
`ZWASM_DEBUG` itself; `std.process.spawn` without `environ_map` hands the
child this process's environment. Exempt, with that reason in the file.

## Wiring

`ci_gate.sh` core, directly after `check_test_discovery`, output kept so a
red leg names the file. `gate_merge.sh`'s header lists it among what the
local pre-flight does not run.
