### PR TITLE
test(spec): the liveverify lane fails when its channel is off, and a rising count is not staleness

### DIFF
--- a/.dev/decisions/0226_liveverify_lane.md
+++ b/.dev/decisions/0226_liveverify_lane.md
@@ -30,11 +30,13 @@ six sub-corpora):
 | | wall | `[liveverify]` residual lines, JIT lane |
 |---|---|---|
 | gate off | 7.46 s | 0 |
-| gate on | 7.61 s | **68** |
+| gate on | 7.61 s | **69 over 10 modules** |
 
-By the op the divergence is first seen at: `end` 21, `return` 16,
+That pair is the check's own overhead inside one lane, not what this decision
+costs; D1 carries that figure. The ten commonest ops the divergence is first
+seen at: `end` 21, `return` 16,
 `i32.const` 8, `i32.add` 4, `drop` 4, `call_ref` 4, `unreachable` 3,
-`struct.get_s` 2, `br_on_cast` 2, `block` 2. #269 measured 178 on the spec
+`struct.get_s` 2, `br_on_cast` 2, `block` 2 (66 of the 69). #269 measured 178 on the spec
 corpus; #398 (open) takes the `end` / `return` class next. Every residual so
 far has been found by hand and filed as its own issue — eight numbers for
 one root, which #400 now holds as a table.
@@ -59,10 +61,23 @@ A step beside `test-spec-wasm-3.0-assert`'s JIT run — same runner, same
 corpus, `ZWASM_SPEC_ENGINE=jit`, the product gate `dbg.on("liveverify")`
 on — joins `test-all` and therefore the core `ci-required` gate on all three
 legs. It exits non-zero when the residuals it observes differ from a named
-list: a residual not on the list is `unexpected`, a listed module that
-produces none is `stale`, and either reds the PR. Cost is 2 % of a 7.5 s
-step, which is #376's own argument for the core gate rather than
-`ZWASM_CI_EXTENDED`, and the extended set covers only the Unix legs.
+list: a residual on a module no row names is `unexpected`, and so is a listed
+module that fires MORE than its row enumerates — a divergence the list has not
+seen, on a module that happens to be listed. A listed module that fires fewer,
+none included, is `stale`: the row over-claims and must come down. All three
+red the PR.
+
+The cost is the run, not the check: turning the gate on inside a lane is 2 %
+(the table above), but D1 is a second full JIT lane, so `test-all` grows by one
+JIT lane — the same order as the step it sits beside. That is #376's argument
+for the core gate rather than `ZWASM_CI_EXTENDED`, whose extended set covers
+only the Unix legs.
+
+The step must fail if the channel it asks for is not on. `liveness_parity` is
+comptime-dead in ReleaseFast / ReleaseSmall, and every branch of this gate —
+down to its summary line — is inside `if (lv_mode)`, so a dark channel is an
+exit 0 with nothing printed rather than a quieter lane. The runner says
+`LIVEVERIFY-CHANNEL-DARK` and exits non-zero instead.
 
 ### D2 — The list names modules, per target, and is held in both directions
 
@@ -75,7 +90,7 @@ count is per row so that "one func fixed, one regressed" in the same module
 is visible; the list carries no total.
 
 The seeds are taken the way #376 took its Windows row: the x86_64 SysV table
-is seeded from this host (the 68 above, re-taken on the PR's base), and the
+is seeded from this host (the 69 above, re-taken on the PR's base), and the
 x86_64 Win64 and aarch64 tables start **empty**, so the PR's first CI run
 reports every residual on those legs as `unexpected` and names them. Those
 names are copied into the tables and pushed; the second run is the proof
@@ -116,8 +131,8 @@ is #400's move 2 and is not decided here.
 - **Why not chosen**: `continue-on-error` rewrites `conclusion` to
   `success`, which is what `ci-required` reads — #307 item 6 and ADR-0225's
   Context are the record of a check that reported and was not read. The
-  list mechanism already makes day-one blocking safe: 68 rows are debt made
-  visible, not red PRs. **This is the maintainer's call, not a rejection**:
+  list mechanism already makes day-one blocking safe: 10 rows carrying 69
+  lines are debt made visible, not red PRs. **This is the maintainer's call, not a rejection**:
   if A is preferred, D1 gains the `continue-on-error` and a promotion
   threshold, and the Status line records it.
 
@@ -139,12 +154,17 @@ is #400's move 2 and is not decided here.
 
 - **Positive**: a liveness/emit divergence becomes a red PR on the commit
   that introduces it, on every target CI runs, instead of an issue filed
-  after someone runs the check by hand. The 68 become load-bearing: each
-  is a row someone must retire, and #398's rows must go in #398.
+  after someone runs the check by hand. The 10 rows become load-bearing:
+  each is one someone must retire, and #398's rows must go in #398.
 - **Negative**: a divergence with no demonstrated wrong answer still reds a
   PR until it is listed. That is the point of an invariant gate, but it is
   a new kind of red for this lane and the failure message must say which
   row to add.
+- **Negative**: a row's unit is the module, so a fix and a new divergence in
+  the same module cancel and the gate stays quiet — the objection Alternative
+  C is rejected for, one level down. The residual lines carry `func[N]`, so the
+  granularity to close it exists; it is not spent here because a per-func list
+  is a table an order of magnitude longer for a debt that only ratchets down.
 - **Neutral / follow-ups**: the arm64 and Win64 seeds are taken from CI's
   own legs, not from a Linux host; ADR-0225 D2's "the table describes CI's
   runner" applies. The 2.0 corpus is not in this lane; whether it should be

--- a/build.zig
+++ b/build.zig
@@ -693,8 +693,10 @@ pub fn build(b: *std.Build) void {
     // ADR-0226 — the JIT lane once more with the D-596 liveness parity check
     // on. Same runner, same corpus, one extra env; the runner attributes each
     // residual to its module and gates on `liveverifyKnown()` in both
-    // directions, so this run is red on a new liveness/emit divergence AND
-    // on a listed one that stopped firing. Both env vars are pinned for the
+    // directions, so this run is red on a new liveness/emit divergence — on a
+    // listed module as well as an unlisted one — AND on a listed one that
+    // stopped firing. It is also red if the channel it sets is not on, which
+    // ReleaseFast / ReleaseSmall would otherwise make a silent exit 0. Both env vars are pinned for the
     // reason given on the interp run above. This is the ONLY place the build
     // sets `ZWASM_DEBUG=liveverify`: `test-all` under that env is unsupported,
     // because any active dbg channel makes AOT produce refuse and the AOT

--- a/src/engine/codegen/shared/liveness_parity.zig
+++ b/src/engine/codegen/shared/liveness_parity.zig
@@ -40,12 +40,13 @@ pub const compiled_in: bool =
 
 /// Hoist this out of the emit loop; `dbg.on` is a whitelist walk.
 ///
-/// Reach: the CLI, the C API, and every test runner (each calls
-/// `dbg.initFromEnv` at startup). One lane runs with it on:
-/// `test-spec-wasm-3.0-assert-liveverify` (ADR-0226), which reads
-/// `takeResiduals` below and gates on the count. This module does not read
-/// the env itself, which Zone 2 cannot do without pulling `std.c.getenv` out
-/// of its one Zone 3 call site.
+/// Reach: the CLI, the C API, and the test runners that call `dbg.initFromEnv`
+/// at startup — `scripts/check_runner_dbg_init.sh` holds that line, and the
+/// files it exempts say why in their first lines. One lane runs with the
+/// channel on: `test-spec-wasm-3.0-assert-liveverify` (ADR-0226); its runner
+/// reads `takeResiduals` below and gates on the count. This module does not
+/// read the env itself, which Zone 2 cannot do without pulling `std.c.getenv`
+/// out of its one Zone 3 call site.
 pub fn on() bool {
     if (!compiled_in) return false;
     return dbg.on("liveverify");

--- a/test/spec/spec_assert_runner_wasm_3_0.zig
+++ b/test/spec/spec_assert_runner_wasm_3_0.zig
@@ -538,9 +538,10 @@ const JitFailLog = struct {
 /// for, enumerated so the liveverify lane can gate on an exact match the way
 /// `jitKnownFails` does.
 ///
-/// Same contract as that list: NOT a suppression. An unlisted module turns
-/// the lane red, and so does a listed one that stopped firing (`stale`) — a
-/// fix removes its row in the same PR. Every row has its line in #400's
+/// Same contract as that list: NOT a suppression. A module no row names turns
+/// the lane red, so does a listed one firing more than its row enumerates
+/// (both `unexpected`), and so does one firing fewer (`stale`) — a fix lowers
+/// or removes its row in the same PR. Every row has its line in #400's
 /// table; a new drift lands as a row here AND a row there (ADR-0226 D4).
 const LvKnown = struct {
     /// `<proposal>/<manifest-dir>/<module>.wasm` — the path the runner's
@@ -562,7 +563,8 @@ const LvKnown = struct {
 /// row names its #400 table row; the funcs are the `func[N]` of its stderr
 /// lines. #400's own module list was taken with #398 applied, so a module
 /// (or func) absent from it is in #398's `.end` / `return` class by that
-/// measurement and its row drops when #398 lands — re-take the table then,
+/// measurement: a row wholly of that class drops when #398 lands, a mixed
+/// row's count falls — re-take the table then,
 /// do not edit it by hand.
 const lv_known_x86_64_sysv: []const LvKnown = &.{
     // `.end` ×20, `i32.add` ×4, `drop` ×1 over 17 funcs — #398's class.
@@ -636,6 +638,12 @@ comptime {
                 if (std.mem.eql(u8, a.key, b.key)) {
                     @compileError("liveverify table lists '" ++ a.key ++ "' twice");
                 }
+            }
+            // `record` is called only for n > 0 and `countFor` returns 0 when
+            // absent, so a zero row matches whether the module fires or not:
+            // it can never red the lane, and it inflates `enumerated`.
+            if (a.count == 0) {
+                @compileError("liveverify row '" ++ a.key ++ "' has count 0 — it can never fire; delete the row");
             }
         }
     }
@@ -777,6 +785,24 @@ pub fn main(init: std.process.Init) !void {
     // of the jit lane: with the env unset, or on the interp lane, none of the
     // `lv_mode` branches run and the lane's output is what it is without them.
     const lv_mode = jit_mode and liveness_parity.on();
+    // The gate below lives entirely inside `if (lv_mode)`, down to its summary
+    // line, so a dark channel is not a quieter lane — it is this step exiting 0
+    // having compared nothing, with no line saying so. `compiled_in` is false
+    // in ReleaseFast / ReleaseSmall and `core_rs` takes `-Doptimize` above
+    // Debug, so `zig build test-all -Doptimize=ReleaseFast` reaches it today.
+    // The step asked for the channel; if it is not on, that is the failure.
+    if (jit_mode and !lv_mode) {
+        if (init.environ_map.get("ZWASM_DEBUG")) |v| {
+            if (std.mem.indexOf(u8, v, "liveverify") != null) {
+                try stdout.print(
+                    "LIVEVERIFY-CHANNEL-DARK  ZWASM_DEBUG={s} asked for the channel and liveness_parity.on() is false (compiled_in={}, mode={s}) — this lane would have compared nothing and exited 0\n",
+                    .{ v, liveness_parity.compiled_in, @tagName(builtin.mode) },
+                );
+                try stdout.flush();
+                std.process.exit(1);
+            }
+        }
+    }
 
     const cwd = std.Io.Dir.cwd();
     var dir = cwd.openDir(io, corpus_root, .{}) catch |err| {
@@ -1245,9 +1271,10 @@ pub fn main(init: std.process.Init) !void {
                                 break :blk pp;
                             };
                             // ADR-0226 D3 — attribute this module's residuals.
-                            // The counter is read here and nowhere else, so a
-                            // residual fired outside a module compile is carried
-                            // into the next module's count, where it reds the
+                            // Read here per module, and once more after the
+                            // loop for what fired outside any compile, so a
+                            // residual is carried into the next module's count,
+                            // where it reds the
                             // lane as unexpected or stale, instead of being
                             // dropped. Read after `initLinked` whether or not it
                             // succeeded: the emit ran either way.
@@ -2185,9 +2212,19 @@ pub fn main(init: std.process.Init) !void {
         for (known) |kf| {
             const seen = jit_fail_log.countFor(kf.key);
             if (seen == kf.count) continue;
+            // Same split as the liveverify block below: a rise is a regression
+            // on an enumerated key, not a row that stopped firing.
+            if (seen > kf.count) {
+                jit_unexpected += 1;
+                try stdout.print(
+                    "JIT-UNEXPECTED-FAIL  {s}: {d} failing directive(s) against the {d} its row enumerates — the JIT got more wrong here than the row claims\n",
+                    .{ kf.key, seen, kf.count },
+                );
+                continue;
+            }
             jit_stale += 1;
             try stdout.print(
-                "JIT-EXPECTATION-STALE  {s}: enumerated {d} failing directive(s), observed {d} — correct the {s} row in spec_assert_runner_wasm_3_0.zig\n",
+                "JIT-EXPECTATION-STALE  {s}: enumerated {d} failing directive(s), observed {d} — the row over-claims; lower the {s} row in spec_assert_runner_wasm_3_0.zig\n",
                 .{ kf.key, kf.count, seen, jit_target_label },
             );
         }
@@ -2220,9 +2257,22 @@ pub fn main(init: std.process.Init) !void {
         for (known) |k| {
             const seen = lv_log.countFor(k.key);
             if (seen == k.count) continue;
+            // A row can miss in two directions and they call for opposite work.
+            // Fewer lines than enumerated is the ratchet: the row over-claims,
+            // lower it. More is a divergence this list never saw, on a module
+            // that happens to be listed — the same event as an unlisted module
+            // firing, so it counts as that and the text says so.
+            if (seen > k.count) {
+                lv_unexpected += 1;
+                try stdout.print(
+                    "LIVEVERIFY-UNEXPECTED  {s}: {d} residual line(s) against the {d} its row enumerates — a new liveness/emit divergence on an enumerated module; fix it or add its funcs to #400 before the {s} row moves\n",
+                    .{ k.key, seen, k.count, jit_target_label },
+                );
+                continue;
+            }
             lv_stale += 1;
             try stdout.print(
-                "LIVEVERIFY-EXPECTATION-STALE  {s}: enumerated {d} residual line(s), observed {d} — correct the {s} row in spec_assert_runner_wasm_3_0.zig and its line on #400\n",
+                "LIVEVERIFY-EXPECTATION-STALE  {s}: enumerated {d} residual line(s), observed {d} — the row over-claims; lower the {s} row in spec_assert_runner_wasm_3_0.zig and retire its line on #400\n",
                 .{ k.key, k.count, seen, jit_target_label },
             );
         }
@@ -2487,4 +2537,23 @@ test "wasm-3.0-assert §1: JIT error classification — unwired-shape → skip, 
     // observable behaviour → genuine fail (the meaningful both-backends
     // RED signal). `error.Trap` and any unanticipated error stay fail.
     try std.testing.expect(!jitErrorIsUnwiredShape(error.Trap));
+}
+
+test "ADR-0226: LvLog sums a module's residuals and reports 0 for one that never fired" {
+    // `record`'s accumulate branch has no counterpart in `JitFailLog` (which
+    // stores one entry per fail), and both halves of the exact-match gate
+    // read through it: a module counted twice would red the lane as a false
+    // regression, and an absent key returning anything but 0 would hide a
+    // stale row.
+    var log: LvLog = .{ .gpa = std.testing.allocator };
+    defer log.deinit();
+
+    try log.record("gc", "br_on_cast", "br_on_cast.0.wasm", 4);
+    try log.record("gc", "br_on_cast", "br_on_cast.0.wasm", 9);
+    try log.record("gc", "br_on_cast", "br_on_cast.1.wasm", 1);
+
+    try std.testing.expectEqual(@as(usize, 2), log.entries.items.len);
+    try std.testing.expectEqual(@as(u32, 13), log.countFor("gc/br_on_cast/br_on_cast.0.wasm"));
+    try std.testing.expectEqual(@as(u32, 1), log.countFor("gc/br_on_cast/br_on_cast.1.wasm"));
+    try std.testing.expectEqual(@as(u32, 0), log.countFor("gc/br_on_cast/br_on_cast.2.wasm"));
 }


### PR DESCRIPTION
Patch for #402, based on that PR's head so it merges into it directly. Two of
these change what the gate does; the rest make the ADR and the comments around
it describe the gate that is there.

## The lane can pass having compared nothing

Every branch of ADR-0226 D1's gate is inside `if (lv_mode)`, its summary line
included, so a channel that is not on is not a quieter lane — it is exit 0 with
no `liveverify` output at all, and nothing in the log to say the comparison did
not happen. `liveness_parity` is comptime-dead in ReleaseFast / ReleaseSmall and
`core_rs` takes `-Doptimize` above Debug, so
`zig build test-spec-wasm-3.0-assert-liveverify -Doptimize=ReleaseFast` reaches
it today. Measured on aarch64-macos before this patch: zero `liveverify` lines
in the whole run, exit 0.

No CI leg selects those modes, and `ci_gate.sh` explains why it picks
ReleaseSafe — but that is prose, and `comment_as_invariant.md` is the rule it
has to satisfy. The step asks for the channel; not having it is the failure.
It now prints `LIVEVERIFY-CHANNEL-DARK` and exits non-zero.

## A rising count is not staleness

`if (seen == k.count) continue; lv_stale += 1;` made every mismatch `stale`, so
a module firing MORE lines than its row enumerates — a divergence the list has
never seen — was reported as a row that had stopped firing, and the text told
the reader to correct the row. The two directions call for opposite work. A
rise is `unexpected`, which is the same event as an unlisted module firing.

The `jitKnownFails` block above is this block's source and carries the same
conflation. It moves with it, so the file does not hold two meanings for one
event.

## Two smaller ones

`.count = 0` names a row that can never fire — `record` runs only for `n > 0`
and `countFor` returns 0 when absent — so it matches either way and inflates
`enumerated`. That is the reason the duplicate-key guard beside it already
gives, so it joins that `comptime` block.

`LvLog.record`'s accumulate branch has no counterpart in `JitFailLog`, and both
halves of the exact-match gate read through it; the in-source test module is
already wired into `test-all`.

## The ADR

- **Cost.** 7.46 → 7.61 s is the check's overhead inside one lane. D1 adds a
  second full JIT lane to `test-all`, which is the same order as the step it
  sits beside — 13.9 s against 18.0 s for the two-engine step on aarch64-macos.
  The core-gate argument survives the real number, so it carries it.
- **69, not 68**, and 10 rows, not 68 — the committed SysV table sums to 69
  lines over 10 modules, and D2 makes the module the row.
- **D1's `stale`** described only "produces none", which is narrower than what
  the code reds on and than what D2's per-row count relies on.
- The op breakdown sums to 66; it is the ten commonest, and now says so.
- The module is the row's unit, so a fix and a new divergence inside one module
  cancel — Alternative C's objection one level down. Recorded as a Negative
  with why the `func[N]` granularity is not spent on it.

Comments corrected where they differ from the code: the counter is read a
second time for the stray bucket; a mixed row's count falls when #398 lands
rather than the row dropping; the runner reads `takeResiduals`, not the build
step; `check_runner_dbg_init.sh` holds the "every test runner" line and its
exemptions say why.

Verified on aarch64-macos: the lane is green (`10 enumerated, 0 unexpected,
0 stale`), red with `LIVEVERIFY-CHANNEL-DARK` under ReleaseFast, and a row set
below its measured count now reports `LIVEVERIFY-UNEXPECTED` rather than
`STALE`.
