### PR TITLE
ci: make the repository ready for a merge queue (ADR-0227)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -25,7 +25,8 @@ zwasm v2 is a ground-up redesign of zwasm (v1 git history at commit 517cc5a).
   (3-host SSH fan-out) is an **optional** pre-PR pre-flight that runs
   `test-all` per host, not the CI leg — its header names what it leaves out
   (ADR-0076 D9) — CI's `ci-required` is authoritative. `--force`
-  always forbidden. Root is kept lean (ADR-mirroring the CW layout): this file
+  always forbidden; `--force-with-lease` only in the pinned form ROADMAP §14
+  permits. Root is kept lean (ADR-mirroring the CW layout): this file
   is `.claude/CLAUDE.md`; community-health files (CONTRIBUTING / CODE_OF_CONDUCT /
   SECURITY) are in `.github/`; `THIRD_PARTY.md` is in `legal/`; `examples/` is
   under `docs/examples/`. Only README / LICENSE / CHANGELOG / build+flake files

--- a/.dev/ROADMAP.md
+++ b/.dev/ROADMAP.md
@@ -2161,7 +2161,8 @@ that's fine, but the act of typing it is the act of re-deciding.
 
 ```
 ❌ Pushing directly to main (PR-only; ruleset-protected)
-❌ git push --force / --force-with-lease to any branch
+❌ git push --force anywhere
+❌ git push --force-with-lease to main, to a branch another worktree holds, or without a pinned <ref>:<sha>
 ❌ git reset --hard discarding committed work
 ❌ git commit --no-verify
 ❌ git rebase -i (interactive, unsupported in CI)

--- a/.dev/decisions/0227_merge_queue.md
+++ b/.dev/decisions/0227_merge_queue.md
@@ -1,0 +1,186 @@
+# 0227 — `main` merges through a queue; `strict` comes off and the workflow gains `merge_group`
+
+- **Status**: Proposed (gate definition per ADR-0212 D1 — D1 and D2 flip to
+  Accepted on the maintainer's word on the PR that carries them, the way
+  ADR-0225 did on #380. D3 is apparatus-internal and needs no sign-off; it
+  lands either way, inert until a queue exists.)
+- **Date**: 2026-09-07
+- **Author**: chaploud
+- **Tags**: ci, gate, merge-queue, process
+
+## Context
+
+`main`'s ruleset carries `strict_required_status_checks_policy: true`, so a
+branch must be up to date with `main` to merge. With several PRs open, each
+merge invalidates the others: they need a manual update and a full 3-OS
+re-run, whose macOS leg is the long pole.
+
+#299 measured what that costs. Over the last 100 PR runs (29 branches):
+**3.4 runs per branch** (median 3, max 10), **36 % ending `cancelled`**. Its
+follow-up comment measured the parameters a queue would need against this
+repository: core-gate leg durations over n=41 — macOS **median 33.5 min, max
+39.7 min**, windows median 14.8, linux median 8.0 — and merges to `main`
+arriving a **median 50 min apart**, with only 5 of 29 gaps at 30 min or less.
+Everything below rests on those numbers; this ADR adds the mechanism they did
+not cover.
+
+GitHub's documentation states the mechanism plainly: a merge queue "provides
+the same benefits as the **Require branches to be up to date before merging**
+branch protection, but does not require a pull request author to update their
+pull request branch." The guarantee moves rather than weakens — the queue
+tests the *result* of merging each entry.
+
+Three facts about this repository decide the rest.
+
+**The workflow does not run on `merge_group`.** `ci.yml`'s triggers are
+`pull_request`, `push` to `main` and `workflow_dispatch`. GitHub's
+documentation: "You **must** use the `merge_group` event to trigger your
+GitHub Actions workflow when a pull request is added to a merge queue", and
+"the `merge_group` event is separate from the `pull_request` and `push`
+events". A required check that never reports is not a pending check — the
+ruleset's `check_response_timeout_minutes` elapses and the check "will be
+assumed to have failed", so **every entry would be ejected**. This is the one
+change without which enabling a queue makes the repository unmergeable.
+
+**The doc-only skip does not survive the queue on its own.** The `changes`
+job branches on `pull_request` and `push`, and its `else` arm sets
+`code=true`. A `merge_group` run would take that arm, so a doc-only PR would
+pay a full 3-OS gate in the queue that it is excused from on its own PR. Four
+of the last six merges were docs or scripts.
+
+**The concurrency group already handles it.** The key is
+`ci-<workflow>-<ref>`, and a merge-group run's ref is the queue's own
+`refs/heads/gh-readonly-queue/...`, distinct per entry — entries cannot
+cancel each other, including the speculative ones. No change needed, recorded
+here so the next reader does not re-derive it.
+
+## Decision
+
+### D1 — `main` gains a `merge_queue` rule and loses `strict`
+
+The ruleset keeps `deletion`, `non_fast_forward`, `pull_request` and
+`required_status_checks` with `ci-required` as the required check.
+`strict_required_status_checks_policy` comes off in the same change: left on,
+the forced update this ADR is about survives the queue.
+
+Settings, each with the measurement or the documented meaning behind it:
+
+| parameter | value | why |
+|---|---|---|
+| `check_response_timeout_minutes` | 60 | Checks that have not reported by then are assumed failed. The macOS leg's measured max is 39.7 min, and an entry also waits for a runner; 60 leaves headroom without letting a genuinely stuck entry sit. |
+| `grouping_strategy` | `ALLGREEN` | Each PR's own merge commit must pass. `HEADGREEN` checks only the group head, which is a weaker guarantee than `ci-required` gives today. |
+| `max_entries_to_build` | 1 | No speculation to begin with. Speculative builds multiply concurrent macOS jobs at ~33 min each; whether that trades queue latency for runner starvation is a measurement, and it should be taken after the queue is real. |
+| `min_entries_to_merge` | 1 | Merges arrive a median 50 min apart and an entry costs ~32 min, so waiting to group costs more than it saves. |
+| `min_entries_to_merge_wait_minutes` | 0 | Same reason. |
+| `max_entries_to_merge` | 1 | Nothing to batch at this arrival rate; raise it with `max_entries_to_build` if the rate changes. |
+| `merge_method` | see D2 | |
+
+### D2 — `merge_method` is `REBASE`
+
+This is the parameter #299's follow-up listed and did not price, and it
+decides a question that reads as separate. `squash_merge_commit_message` is
+`COMMIT_MESSAGES`, and the last fifteen commits on `main` carry curated
+6–23 line bodies that are neither concatenated branch commits nor PR bodies:
+they are written at merge time through `gh pr merge --body-file`. A queue
+merges automatically, so that override is gone — but only under `SQUASH`.
+
+- `SQUASH` + `PR_BODY` puts the PR body in `main`. PR bodies here are decision
+  documents, with tables and options; that is not what the history should
+  carry.
+- `SQUASH` + `BLANK` keeps `main` clean and drops the 6–23 lines of recorded
+  reasoning, which is the more useful half.
+- `MERGE` brings each branch's `Merge branch 'main' into …` commits with it —
+  exactly what the `--body-file` override has been keeping out.
+- `REBASE` replays the branch's own commits, drops the merge commits, and
+  each keeps its own message.
+
+`REBASE` preserves what `main` reads like today; the cost is that the writing
+moves from merge time to the branch, so a branch's final commit messages have
+to stand as the record. That is a real change in habit and it is the part of
+this ADR most worth disagreeing with.
+
+### D3 — The workflow changes (apparatus-internal)
+
+Two, both inert until a queue exists:
+
+- `ci.yml` gains an unfiltered `merge_group:` trigger, the shape wasmtime's
+  `main.yml` uses.
+- The `changes` job gains a `merge_group` arm reading
+  `github.event.merge_group.base_sha` / `head_sha`, so the doc-only skip
+  applies to a queue entry as it does to a PR. Fail-closed like the push arm:
+  an absent or unreachable base runs the gate rather than reading as
+  doc-only.
+
+`ZWASM_CI_EXTENDED` is untouched. It keys on `github.event_name == 'push'`,
+and a queue still produces a push to `main` on merge, so the extended checks
+keep running exactly where they run now.
+
+## Applying D1
+
+Not a script: it runs once and would then be a caller-less file (ADR-0212 D3).
+The transform reads the live ruleset and edits two things, so nothing else in
+it is retyped or disturbed:
+
+```sh
+gh api repos/zwasm/zwasm/rulesets/13308987 > /tmp/ruleset.json
+
+jq '(.rules[] | select(.type=="required_status_checks")
+       | .parameters.strict_required_status_checks_policy) = false
+    | .rules += [{ type: "merge_queue", parameters: {
+        check_response_timeout_minutes: 60,
+        grouping_strategy: "ALLGREEN",
+        max_entries_to_build: 1,
+        max_entries_to_merge: 1,
+        merge_method: "REBASE",
+        min_entries_to_merge: 1,
+        min_entries_to_merge_wait_minutes: 0 }}]
+    | {name, target, enforcement, conditions, bypass_actors, rules}' \
+  /tmp/ruleset.json > /tmp/ruleset-queued.json
+
+# read it, then:
+gh api --method PUT repos/zwasm/zwasm/rulesets/13308987 --input /tmp/ruleset-queued.json
+```
+
+Run against the live ruleset on 2026-09-07, the transform produced the five
+rules with `strict=false`, and `deletion` / `non_fast_forward` /
+`pull_request` / `name` / `target` / `enforcement` / `conditions` /
+`bypass_actors` diffed clean against the original. The `PUT` was not run.
+
+To undo, `PUT` the saved `/tmp/ruleset.json` back.
+
+## Alternatives rejected
+
+- **Do nothing.** The measured loop is 3.4 runs per branch at 36 % cancelled,
+  and it grows with the number of open PRs rather than staying flat.
+- **#298's content-keyed skip instead.** Complementary, not a substitute: it
+  removes the CI cost of updating a branch, where a queue removes the update.
+  Neither subsumes the other.
+- **`merge_group` without the `changes` arm** (wasmtime's shape). Simpler, and
+  correct — it just pays a 3-OS gate for every doc-only entry. The arm is
+  eight lines and the skip is already built.
+
+## Consequences
+
+- **Positive**: a branch stops being invalidated by someone else's merge. The
+  gate does not weaken — `ci-required` runs on the merge result rather than on
+  a branch that was up to date an hour ago.
+- **Negative**: a merged PR pays two gate runs, its own and the queue's, where
+  today it pays one plus however many re-runs the invalidation forces. At the
+  measured 3.4 that is a reduction, but it is not free per PR.
+- **Negative**: under `REBASE`, commit messages have to be right on the branch.
+  There is no merge-time edit.
+- **Neutral**: the ruleset change is a settings action, not a repository one.
+  This ADR and D3 make the repository ready; nothing here enables a queue.
+- **Follow-up**: `max_entries_to_build` above 1 is a measurement to take once
+  the queue has run for a week, against runner concurrency rather than in the
+  abstract.
+
+## References
+
+- #299 (the row, and the parameter measurements this ADR rests on), #298
+  (the content-keyed skip), #312 (cancelled `main` runs — why the concurrency
+  key is shaped as it is)
+- ADR-0212 D1 (gate definitions need sign-off; apparatus does not),
+  ADR-0076 D9 (CI is authoritative)
+- GitHub docs: "Managing a merge queue"; the `merge_queue` rule parameters in
+  the repository-rules REST reference

--- a/.dev/decisions/0227_merge_queue.md
+++ b/.dev/decisions/0227_merge_queue.md
@@ -2,8 +2,8 @@
 
 - **Status**: Proposed (gate definition per ADR-0212 D1 — D1 and D2 flip to
   Accepted on the maintainer's word on the PR that carries them, the way
-  ADR-0225 did on #380. D3 is apparatus-internal and needs no sign-off; it
-  lands either way, inert until a queue exists.)
+  ADR-0225 did on #380. D4 rides with D2. D3 is apparatus-internal and needs
+  no sign-off; it lands either way, inert until a queue exists.)
 - **Date**: 2026-09-07
 - **Author**: chaploud
 - **Tags**: ci, gate, merge-queue, process
@@ -134,6 +134,58 @@ sentence in a comment asking the next person not to forget.
 `ZWASM_CI_EXTENDED` is untouched. It keys on `github.event_name == 'push'`,
 and a queue still produces a push to `main` on merge, so the extended checks
 keep running exactly where they run now.
+
+### D4 — a topic branch may be tidied before it merges
+
+Rides with D2. Under any other `merge_method` the branch's commits are not
+what `main` reads, and this has no motivation.
+
+`REBASE` makes them the record, and a queue merges without a dialog, so a
+branch whose review left a chain of fixups has no later point at which it can
+be corrected — and reviews here routinely reshape a change (#380, #398, #406).
+ROADMAP §14's `git push --force / --force-with-lease to any branch` becomes:
+
+```
+❌ git push --force anywhere
+❌ git push --force-with-lease to main, to a branch another worktree holds, or without a pinned <ref>:<sha>
+```
+
+**A lease is not enough on its own.** Both forms compare against
+`refs/remotes/origin/<branch>`, and the worktrees share one set of those refs.
+git's documentation calls the bare form "trivially defeated if some background
+process is updating refs in the background"; pinning only makes the same
+assumption explicit — that the ref's value is evidence the content was seen.
+If another worktree pushed and fetched first, the pin captures *its* commit,
+the rewrite omits it, and the push is accepted because the remote really is
+where the pin says. So the lease is the second half; the first is a
+precondition that refuses to rewrite unless the remote tip is already here.
+
+`git rebase -i` and `git reset --hard` stay on §14 unchanged — the first is
+interactive and this environment has no editor, the second names `--hard`, and
+discarding work is what `--soft` does not do. The non-interactive procedure:
+
+```sh
+git fetch origin "develop/<slug>"
+git merge-base --is-ancestor "origin/develop/<slug>" HEAD || exit 1
+expected=$(git rev-parse "origin/develop/<slug>")
+git reset --soft "$(git merge-base HEAD origin/main)"
+git commit -F <message-file>
+git push --force-with-lease="refs/heads/develop/<slug>:$expected" origin "develop/<slug>"
+```
+
+Only the last line needs this decision; the second is what makes it safe, and
+it fails closed.
+
+§18.2 step 3 syncs one live document: `.claude/CLAUDE.md` summarised the old
+§14 line as "`--force` always forbidden", which now reads as banning the
+carve-out too. `continue/LOOP.md` and `continue/STOP_BUCKETS.md` say the
+harness denies this and are retired campaign machinery; nothing enforced it in
+any case — `.claude/settings.json` has four `permissions.deny` rules and none
+concerns push.
+
+Rejected: cutting a fresh branch instead reaches the same history at the price
+of a new PR and review thread; keeping the ban and taking `SQUASH` is coherent
+but gives up the recorded reasoning D2 calls the more useful half.
 
 ## Applying D1
 

--- a/.dev/decisions/0227_merge_queue.md
+++ b/.dev/decisions/0227_merge_queue.md
@@ -27,13 +27,15 @@ not cover.
 GitHub's documentation states the mechanism plainly: a merge queue "provides
 the same benefits as the **Require branches to be up to date before merging**
 branch protection, but does not require a pull request author to update their
-pull request branch." The guarantee moves rather than weakens — the queue
-tests the *result* of merging each entry.
+pull request branch and wait for status checks to finish before trying to
+merge." The guarantee moves rather than weakens — the queue tests the *result*
+of merging each entry, and the tail of that sentence is the cost this ADR is
+about.
 
 Three facts about this repository decide the rest.
 
-**The workflow does not run on `merge_group`.** `ci.yml`'s triggers are
-`pull_request`, `push` to `main` and `workflow_dispatch`. GitHub's
+**The workflow did not run on `merge_group`.** `ci.yml`'s triggers were
+`pull_request`, `push` to `main` and `workflow_dispatch`; D3 adds it. GitHub's
 documentation: "You **must** use the `merge_group` event to trigger your
 GitHub Actions workflow when a pull request is added to a merge queue", and
 "the `merge_group` event is separate from the `pull_request` and `push`
@@ -45,8 +47,10 @@ change without which enabling a queue makes the repository unmergeable.
 **The doc-only skip does not survive the queue on its own.** The `changes`
 job branches on `pull_request` and `push`, and its `else` arm sets
 `code=true`. A `merge_group` run would take that arm, so a doc-only PR would
-pay a full 3-OS gate in the queue that it is excused from on its own PR. Four
-of the last six merges were docs or scripts.
+pay a full 3-OS gate in the queue that it is excused from on its own PR. Two
+of the last six merges are doc-only under that filter — it excludes `.md`,
+`docs/`, `.dev/`, `.claude/` and `LICENSE`, and not `scripts/` or `test/`, so
+the hit rate is smaller than the shape of the merge log suggests.
 
 **The concurrency group already handles it.** The key is
 `ci-<workflow>-<ref>`, and a merge-group run's ref is the queue's own
@@ -67,7 +71,7 @@ Settings, each with the measurement or the documented meaning behind it:
 
 | parameter | value | why |
 |---|---|---|
-| `check_response_timeout_minutes` | 60 | Checks that have not reported by then are assumed failed. The macOS leg's measured max is 39.7 min, and an entry also waits for a runner; 60 leaves headroom without letting a genuinely stuck entry sit. |
+| `check_response_timeout_minutes` | 60 | Checks that have not reported by then are assumed failed. The macOS leg's measured max is 39.7 min, and an entry also waits for a runner; 60 leaves headroom without letting a genuinely stuck entry sit. Note the asymmetry: the `gate` job's own `timeout-minutes` is 120, so a run that lands between the two has its entry ejected while it is still working — recovery is re-queueing, not waiting. |
 | `grouping_strategy` | `ALLGREEN` | Each PR's own merge commit must pass. `HEADGREEN` checks only the group head, which is a weaker guarantee than `ci-required` gives today. |
 | `max_entries_to_build` | 1 | No speculation to begin with. Speculative builds multiply concurrent macOS jobs at ~33 min each; whether that trades queue latency for runner starvation is a measurement, and it should be taken after the queue is real. |
 | `min_entries_to_merge` | 1 | Merges arrive a median 50 min apart and an entry costs ~32 min, so waiting to group costs more than it saves. |
@@ -79,10 +83,18 @@ Settings, each with the measurement or the documented meaning behind it:
 
 This is the parameter #299's follow-up listed and did not price, and it
 decides a question that reads as separate. `squash_merge_commit_message` is
-`COMMIT_MESSAGES`, and the last fifteen commits on `main` carry curated
+`COMMIT_MESSAGES`, and fourteen of the last fifteen commits on `main` carry
 6–23 line bodies that are neither concatenated branch commits nor PR bodies:
-they are written at merge time through `gh pr merge --body-file`. A queue
-merges automatically, so that override is gone — but only under `SQUASH`.
+they are written at merge time through `gh pr merge --body-file`. The
+fifteenth, `67772ed72`, is a 45-line PR body carrying `## Sign-off` and
+`## Why this does not red main` — the artefact the next bullet rejects
+`SQUASH` + `PR_BODY` to avoid, already in `main` under the current setup. The
+discipline is a habit, not a mechanism, which is worth knowing before choosing
+what replaces it.
+
+A queue merges automatically, so the `--body-file` override is gone under
+every method. What takes its place differs: under `SQUASH` it is
+`squash_merge_commit_message`, today `COMMIT_MESSAGES`.
 
 - `SQUASH` + `PR_BODY` puts the PR body in `main`. PR bodies here are decision
   documents, with tables and options; that is not what the history should
@@ -110,6 +122,14 @@ Two, both inert until a queue exists:
   applies to a queue entry as it does to a PR. Fail-closed like the push arm:
   an absent or unreachable base runs the gate rather than reading as
   doc-only.
+
+And `scripts/check_ci_changes_detect.sh`, in the `doc-truth` job and the
+pre-commit gate: the `merge_group` arm does not run until a queue exists, so
+CI cannot be what proves it, and under a queue its answer is acted on with
+nobody looking. The check reads the step out of `ci.yml` rather than copying
+it and runs eleven event × path-class cases against a throwaway repository.
+It also pins #297's `docs/examples/` case, whose guard until now was a
+sentence in a comment asking the next person not to forget.
 
 `ZWASM_CI_EXTENDED` is untouched. It keys on `github.event_name == 'push'`,
 and a queue still produces a push to `main` on merge, so the extended checks
@@ -146,7 +166,25 @@ rules with `strict=false`, and `deletion` / `non_fast_forward` /
 `pull_request` / `name` / `target` / `enforcement` / `conditions` /
 `bypass_actors` diffed clean against the original. The `PUT` was not run.
 
-To undo, `PUT` the saved `/tmp/ruleset.json` back.
+**`strict` and `merge_queue` come off together, as they went on.** The
+intermediate — `strict: false` with no queue — is the one state in this
+change's blast radius that is genuinely weaker than today: a branch based on a
+month-old `main` merges on a `ci-required` that never saw the merge result.
+Removing only the `merge_queue` rule reaches it. The reverse transform,
+written out so it does not depend on a `/tmp` file surviving the weeks in
+between:
+
+```sh
+gh api repos/zwasm/zwasm/rulesets/13308987 > /tmp/ruleset.json
+
+jq '(.rules[] | select(.type=="required_status_checks")
+       | .parameters.strict_required_status_checks_policy) = true
+    | .rules |= map(select(.type != "merge_queue"))
+    | {name, target, enforcement, conditions, bypass_actors, rules}' \
+  /tmp/ruleset.json > /tmp/ruleset-unqueued.json
+
+gh api --method PUT repos/zwasm/zwasm/rulesets/13308987 --input /tmp/ruleset-unqueued.json
+```
 
 ## Alternatives rejected
 
@@ -178,8 +216,8 @@ To undo, `PUT` the saved `/tmp/ruleset.json` back.
 ## References
 
 - #299 (the row, and the parameter measurements this ADR rests on), #298
-  (the content-keyed skip), #312 (cancelled `main` runs — why the concurrency
-  key is shaped as it is)
+  (the content-keyed skip), #312 direction 2 (done in #363) — why the `main`
+  concurrency key carries the SHA
 - ADR-0212 D1 (gate definitions need sign-off; apparatus does not),
   ADR-0076 D9 (CI is authoritative)
 - GitHub docs: "Managing a merge queue"; the `merge_queue` rule parameters in

--- a/.dev/decisions/0227_merge_queue.md
+++ b/.dev/decisions/0227_merge_queue.md
@@ -1,9 +1,9 @@
 # 0227 — `main` merges through a queue; `strict` comes off and the workflow gains `merge_group`
 
-- **Status**: Proposed (gate definition per ADR-0212 D1 — D1 and D2 flip to
-  Accepted on the maintainer's word on the PR that carries them, the way
-  ADR-0225 did on #380. D4 rides with D2. D3 is apparatus-internal and needs
-  no sign-off; it lands either way, inert until a queue exists.)
+- **Status**: Accepted (2026-09-07 — maintainer sign-off on PR #408, on the
+  #299 measurements in Context; D1, D2 and D4 as written. D3 is
+  apparatus-internal and needed none. The ruleset itself is a settings action
+  and is not part of this merge.)
 - **Date**: 2026-09-07
 - **Author**: chaploud
 - **Tags**: ci, gate, merge-queue, process

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ change lands the same way:
    Doc-only changes (Markdown, `docs/`, `.dev/`, `.claude/`, `LICENSE`) skip the
    heavy 3-OS build/test automatically, so a docs PR goes green in seconds — but
    still merges through the same gate.
-4. Squash-merge when green; the branch is auto-deleted.
+4. Merge when it is green; the branch is auto-deleted.
 
 Releases (tags / published artifacts) are cut manually by the maintainer only.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,12 @@
 # `ci-required` is authoritative; the local scripts are pre-flight
 # (ADR-0076 D9).
 #
-# Triggers: pull_request (any target) + push to `main` + manual dispatch.
+# Triggers: pull_request (any target) + merge_group + push to `main` + manual
+# dispatch. `merge_group` is what a merge queue dispatches, and a required
+# check that does not run on it never reports, so every queue entry would be
+# ejected on the ruleset's `check_response_timeout_minutes` as an assumed
+# failure (ADR-0227 D3). It fires only while a queue is enabled, so the
+# trigger is inert until then.
 # `main` is the trunk and is ruleset-protected: no direct pushes — every change
 # lands via a `develop/*` branch → PR → this gate must pass → merge. A push to
 # `main` is therefore a merged PR (its `push` run does the extended checks).
@@ -41,6 +46,9 @@ name: ci
 
 on:
   pull_request:
+  # A merge queue dispatches this; unfiltered, as wasmtime's does. Inert while
+  # no queue is enabled (ADR-0227 D3).
+  merge_group:
   push:
     branches: [main]
   workflow_dispatch:
@@ -59,6 +67,10 @@ permissions:
 # only the newest pending run per group, so a burst of merges would still
 # drop the middle ones. The event name is part of the key so that a manual
 # dispatch on `main` (core-only) cannot cancel the push run for the same SHA.
+# A merge-group run needs no special case: its ref is the queue's own
+# `refs/heads/gh-readonly-queue/...`, distinct per entry, so entries never
+# cancel each other — including the speculative ones a `max_entries_to_build`
+# above 1 would create.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}${{ github.ref == 'refs/heads/main' && format('-{0}-{1}', github.event_name, github.sha) || '' }}
   cancel-in-progress: true
@@ -87,11 +99,25 @@ jobs:
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE: ${{ github.event.before }}
           PUSH_HEAD: ${{ github.sha }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
           if [ "$EVENT" = "pull_request" ]; then
             range="${PR_BASE}...${PR_HEAD}"
+          elif [ "$EVENT" = "merge_group" ]; then
+            # Without this arm the `else` below runs the 3-OS gate for every
+            # queue entry, so a doc-only PR would pay in the queue what it is
+            # excused from on its PR. The group's head contains its base, so
+            # the two-dot range is the push analogue, and it covers the whole
+            # group when more than one entry is batched. Same fail-closed guard
+            # as the push arm: an unreachable base means the range cannot be
+            # computed, and an uncomputed range must not read as doc-only.
+            if [ -z "$MG_BASE" ] || ! git cat-file -e "${MG_BASE}^{commit}" 2>/dev/null; then
+              echo "code=true" >> "$GITHUB_OUTPUT"; echo "merge_group base unreachable -> run gate"; exit 0
+            fi
+            range="${MG_BASE}..${MG_HEAD}"
           elif [ "$EVENT" = "push" ]; then
             if ! git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
               echo "code=true" >> "$GITHUB_OUTPUT"; echo "new-branch push -> run gate"; exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,6 @@ name: ci
 
 on:
   pull_request:
-  # A merge queue dispatches this; unfiltered, as wasmtime's does. Inert while
-  # no queue is enabled (ADR-0227 D3).
   merge_group:
   push:
     branches: [main]
@@ -107,13 +105,10 @@ jobs:
           if [ "$EVENT" = "pull_request" ]; then
             range="${PR_BASE}...${PR_HEAD}"
           elif [ "$EVENT" = "merge_group" ]; then
-            # Without this arm the `else` below runs the 3-OS gate for every
-            # queue entry, so a doc-only PR would pay in the queue what it is
-            # excused from on its PR. The group's head contains its base, so
-            # the two-dot range is the push analogue, and it covers the whole
-            # group when more than one entry is batched. Same fail-closed guard
-            # as the push arm: an unreachable base means the range cannot be
-            # computed, and an uncomputed range must not read as doc-only.
+            # The group's head contains its base, so the two-dot range is the
+            # push analogue, and it covers the whole group when entries are
+            # batched. Same fail-closed guard as the push arm: an uncomputable
+            # range must not read as doc-only.
             if [ -z "$MG_BASE" ] || ! git cat-file -e "${MG_BASE}^{commit}" 2>/dev/null; then
               echo "code=true" >> "$GITHUB_OUTPUT"; echo "merge_group base unreachable -> run gate"; exit 0
             fi
@@ -165,6 +160,11 @@ jobs:
       - name: Doc fossils (prerelease pins + dead script refs)
         shell: bash
         run: bash scripts/check_doc_fossils.sh --gate
+      # Here and not in `ci_gate.sh`: the check needs `yq`, which the macOS and
+      # Windows legs do not carry, so there it would SKIP and gate nothing.
+      - name: The changes job's own doc-only decision
+        shell: bash
+        run: bash scripts/check_ci_changes_detect.sh --gate
 
   gate:
     name: gate (${{ matrix.name }})

--- a/scripts/check_ci_changes_detect.sh
+++ b/scripts/check_ci_changes_detect.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# check_ci_changes_detect.sh — the `changes` job's doc-only decision, exercised.
+#
+# `ci.yml`'s `changes` step decides whether a run pays the 3-OS gate. Its
+# failure mode is a silent pass: `ci-required` treats a FAILED `changes` as
+# fatal (D-520), but a `changes` that succeeds while answering `code=false`
+# wrongly is green with nothing behind it. That has happened — #297, where
+# `^docs/` swallowed `docs/examples/` and a build input skipped the whole gate.
+# The guard against a repeat is a sentence in the step's own comment, which is
+# the prose-only invariant `.claude/rules/comment_as_invariant.md` forbids.
+#
+# The `merge_group` arm (ADR-0227 D3) needs this more than the others: it does
+# not run until a merge queue exists, so CI never exercises it, and under a
+# queue the answer is acted on without anyone looking.
+#
+# The step's script is read out of `ci.yml` rather than copied, so the two
+# cannot drift, and runs against a throwaway repository built here.
+#
+#   bash scripts/check_ci_changes_detect.sh          # informational, exit 0
+#   bash scripts/check_ci_changes_detect.sh --gate   # exit 1 on any mismatch
+set -euo pipefail
+
+# yq (mikefarah v4) is not part of the base toolchain (Zig-only clones lack
+# it). Absent -> SKIP with a pointer, never a bash stack trace (ADR-0206).
+# git exports GIT_DIR and GIT_INDEX_FILE to its hooks, and GIT_DIR outranks
+# `-C`: run from the pre-commit hook without clearing them, every git command
+# below addresses the repository being committed to instead of the throwaway
+# one. Measured — it re-inits that repository and lands this file's fixture
+# commits in it, while still reporting OK. Nothing here needs the caller's git
+# context, so the whole redirecting set goes.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE \
+      GIT_CEILING_DIRECTORIES GIT_PREFIX GIT_QUARANTINE_PATH
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "[check_ci_changes_detect] SKIP — yq (mikefarah v4) not found; install it (https://github.com/mikefarah/yq) or use 'nix develop'" >&2
+  exit 0
+fi
+cd "$(dirname "$0")/.."
+
+MODE="${1:-info}"
+WF=.github/workflows/ci.yml
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+yq -r '.jobs.changes.steps[] | select(.id == "detect") | .run' "$WF" > "$TMP/detect.sh"
+if [ ! -s "$TMP/detect.sh" ]; then
+  echo "[check_ci_changes_detect] FAIL — no step with id 'detect' in the changes job of $WF" >&2
+  exit 1
+fi
+
+# A repository whose history holds one commit per path class the step sorts on.
+#
+# Every git call names its repository with `-C "$REPO"`, and nothing here runs
+# in a subshell or changes directory. Both matter: bash fires an inherited EXIT
+# trap when a subshell exits, so a `( cd "$REPO"; ... )` block would run this
+# script's own `rm -rf` cleanup and leave the git commands below executing in
+# the checkout that invoked it.
+REPO="$TMP/repo"
+mkdir -p "$REPO/docs/examples" "$REPO/.dev" "$REPO/src"
+git -C "$REPO" init -q -b work .
+git -C "$REPO" config user.email check@example.invalid
+git -C "$REPO" config user.name check
+echo base > "$REPO/README.md"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm base
+BASE=$(git -C "$REPO" rev-parse HEAD)
+
+echo doc >> "$REPO/README.md"
+echo note > "$REPO/.dev/note.md"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm doc
+DOC=$(git -C "$REPO" rev-parse HEAD)
+
+git -C "$REPO" reset -q --hard "$BASE"
+echo code > "$REPO/src/thing.zig"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm code
+CODE=$(git -C "$REPO" rev-parse HEAD)
+
+git -C "$REPO" reset -q --hard "$BASE"
+echo host > "$REPO/docs/examples/host.zig"
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm example
+EXAMPLE=$(git -C "$REPO" rev-parse HEAD)
+
+fails=0
+cases=0
+
+check() { # name event base head want
+  cases=$((cases + 1))
+  local out
+  : > "$TMP/gh_output"
+  # `-C` is not available for the step's own `git diff`, so the working
+  # directory has to be the throwaway repo — `env -C` keeps that to the child.
+  env -C "$REPO" \
+    EVENT="$2" \
+    PR_BASE="$3" PR_HEAD="$4" \
+    PUSH_BEFORE="$3" PUSH_HEAD="$4" \
+    MG_BASE="$3" MG_HEAD="$4" \
+    GITHUB_OUTPUT="$TMP/gh_output" \
+    bash "$TMP/detect.sh" >/dev/null 2>&1 || true
+  out=$(grep -o 'code=[a-z]*' "$TMP/gh_output" | tail -1 || true)
+  if [ "$out" != "code=$5" ]; then
+    # No output means the step itself died on this input — a case that cannot
+    # answer is as much a finding as one that answers wrongly.
+    echo "[check_ci_changes_detect] FAIL $1 -> ${out:-(step produced no code=; it exited non-zero)} (want code=$5)" >&2
+    fails=$((fails + 1))
+  fi
+}
+
+# The arm this repository has no CI coverage for until a queue exists.
+check "merge_group doc-only"        merge_group "$BASE" "$DOC"     false
+check "merge_group code"            merge_group "$BASE" "$CODE"    true
+check "merge_group docs/examples"   merge_group "$BASE" "$EXAMPLE" true
+check "merge_group base unreachable" merge_group 0000000000000000000000000000000000000000 "$CODE" true
+check "merge_group base empty"      merge_group ""      "$CODE"    true
+# The arms that do run, so a change to the shared filter cannot pass by
+# fixing one event and breaking another.
+check "pull_request doc-only"       pull_request "$BASE" "$DOC"     false
+check "pull_request code"           pull_request "$BASE" "$CODE"    true
+check "pull_request docs/examples"  pull_request "$BASE" "$EXAMPLE" true
+check "push doc-only"               push         "$BASE" "$DOC"     false
+check "push code"                   push         "$BASE" "$CODE"    true
+check "workflow_dispatch"           workflow_dispatch "" ""         true
+
+if [ "$fails" -gt 0 ]; then
+  echo "[check_ci_changes_detect] $fails of $cases case(s) disagree with the step in $WF" >&2
+  [ "$MODE" = "--gate" ] && exit 1
+  exit 0
+fi
+echo "[check_ci_changes_detect] OK ($cases cases)" >&2

--- a/scripts/check_ci_changes_detect.sh
+++ b/scripts/check_ci_changes_detect.sh
@@ -93,14 +93,18 @@ check() { # name event base head want
   local out
   : > "$TMP/gh_output"
   # `-C` is not available for the step's own `git diff`, so the working
-  # directory has to be the throwaway repo — `env -C` keeps that to the child.
-  env -C "$REPO" \
+  # directory has to be the throwaway repo. A subshell and not `env -C` — that
+  # option is GNU coreutils only and macOS's BSD `env` rejects it. `$TMP` and
+  # `$REPO` are absolute, so the paths below survive the `cd`.
+  (
+    cd "$REPO"
     EVENT="$2" \
     PR_BASE="$3" PR_HEAD="$4" \
     PUSH_BEFORE="$3" PUSH_HEAD="$4" \
     MG_BASE="$3" MG_HEAD="$4" \
     GITHUB_OUTPUT="$TMP/gh_output" \
-    bash "$TMP/detect.sh" >/dev/null 2>&1 || true
+    bash "$TMP/detect.sh" >/dev/null 2>&1
+  ) || true
   out=$(grep -o 'code=[a-z]*' "$TMP/gh_output" | tail -1 || true)
   if [ "$out" != "code=$5" ]; then
     # No output means the step itself died on this input — a case that cannot

--- a/scripts/gate_commit.sh
+++ b/scripts/gate_commit.sh
@@ -13,6 +13,7 @@
 #  11. scripts/check_engine_default_claims.sh --gate        — gate; ALWAYS (docs are the thing it guards).
 #  12. scripts/check_wasi03_coverage_claims.sh --gate       — gate; ALWAYS (same reason).
 #  13. scripts/check_doc_fossils.sh --gate                  — gate; ALWAYS (same reason).
+#  14. scripts/check_ci_changes_detect.sh --gate            — gate; ALWAYS (it guards the doc-only short-circuit itself).
 #  14. zig build test (Mac native)                          — skipped on docs-only.
 #
 # Per the A6 gate consolidation study (§9.12-A / A6), docs/config-only
@@ -156,6 +157,8 @@ echo "[gate_commit] check_wasi03_coverage_claims --gate ..."
 bash scripts/check_wasi03_coverage_claims.sh --gate > /dev/null
 echo "[gate_commit] check_doc_fossils --gate ..."
 bash scripts/check_doc_fossils.sh --gate > /dev/null
+echo "[gate_commit] check_ci_changes_detect --gate ..."
+bash scripts/check_ci_changes_detect.sh --gate > /dev/null
 
 # --- gates: zone + file_size + skip_adrs (skipped on docs-only) ---------
 


### PR DESCRIPTION
Draft for #299. jtakakura proposed the queue and measured its parameters; this
is the repository-side homework so that adopting it is a settings change rather
than a project. Nothing here enables anything — `merge_group` fires only from a
queue, so both changes are inert until one exists, and the ruleset stays out of
the diff because it is a settings action.

## Two things have to be true first, and neither is today

**`ci.yml` does not run on `merge_group`.** GitHub's documentation is explicit
that a workflow must use that event for merge queue entries, and that it is
separate from `pull_request` and `push`. A required check that never reports is
not pending — the ruleset's `check_response_timeout_minutes` elapses and the
check "will be assumed to have failed", so every entry would be ejected.
Enabling a queue without this makes `main` unmergeable. The trigger is
unfiltered, the shape wasmtime's `main.yml` uses.

**The doc-only skip does not survive the queue.** The `changes` job branches on
`pull_request` and `push`; its `else` arm sets `code=true`. A `merge_group` run
takes that arm, so a doc-only PR would pay a full 3-OS gate in the queue that it
is excused from on its own PR — four of the last six merges were docs or
scripts. It gains a `merge_group` arm reading the group's own `base_sha` /
`head_sha`, fail-closed like the push arm.

Measured by extracting the step's script and running all eight cases against
real ranges in this repository:

| event | range | result |
|---|---|---|
| merge_group | doc-only | `code=false` |
| merge_group | code | `code=true` |
| merge_group | base unreachable | `code=true` |
| merge_group | base empty | `code=true` |
| pull_request | doc-only / code | `code=false` / `code=true` |
| push | code | `code=true` |
| workflow_dispatch | — | `code=true` |

## Two that already hold

The concurrency key is `ci-<workflow>-<ref>`, and a merge-group run's ref is the
queue's own `refs/heads/gh-readonly-queue/...`, distinct per entry — no
cross-cancellation, including under speculation. And `ci-required` is
`if: always()` with no event condition, so it reports from a merge-group run
unchanged. Both are recorded in the ADR so the next reader does not re-derive
them.

`ZWASM_CI_EXTENDED` is untouched: it keys on the push to `main`, which a queue
still produces.

## ADR-0227

Proposed, not Accepted — D1 (adopt the queue, drop `strict`), D2
(`merge_method`) and D4 (§14's force-push line) are gate definitions, so they
are yours; D3 is the workflow change above and lands either way.

D1's table gives each of the seven parameters against the measurement or
documented meaning behind it, on your numbers from #299. D2 is the parameter
your comment listed and did not price, and it turns out to subsume the
`squash_merge_commit_message` prerequisite: that question only exists under
`SQUASH`. `REBASE` keeps `main` reading as it does today — the curated 6–23 line
bodies survive as the branch's own commit messages — at the cost of writing them
on the branch rather than at merge time. That is the part I would expect you to
disagree with, and the ADR says so.

**D4** (#410) is the consequence of taking `REBASE`. If the branch's commits
are what `main` reads, a branch whose review left a chain of fixups has to be
tidied before it merges, and a queue leaves no merge-time dialog in which to do
it. ROADMAP §14's force-push line becomes two: `--force` stays forbidden
everywhere, and `--force-with-lease` is forbidden to `main`, to a branch another
worktree holds, and bare. The bare form goes because the worktrees under
`.claude/worktrees/` share the remote-tracking refs both forms read, so the
procedure fetches the branch and refuses to rewrite unless the remote tip is
already in this history before pinning the lease to it. `.claude/CLAUDE.md`'s
one-line summary of §14 is synced with it — §18.2 step 3's only live target.
D4 rides with D2: if `merge_method` goes to `SQUASH`, D4 comes off with it.

Applying D1 is a `jq` transform over the live ruleset rather than a script — it
runs once, and a script would be caller-less after that. Run against the live
ruleset today it produced the five rules with `strict=false`, with everything
else diffing clean; the `PUT` was not run.

Entirely yours whether any of this is the right shape, including whether to take
D3 and leave D1, D2 and D4 for later.

