### PR TITLE
fix(lint): entry.zig's three void else-arms say they are deliberate (#409)

### DIFF
--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -154,7 +154,9 @@ const x86_64_win64_call_clobbers_all: if (builtin.target.cpu.arch == .x86_64) st
         .xmm15 = true,
         .cc = true,
         .memory = true,
-    } else {};
+    } else {
+        // void: this constant has no value on other targets
+    };
 
 const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .x86_64 and builtin.target.os.tag == .windows)
@@ -207,7 +209,9 @@ const x86_64_win64_jit_cohort: if (builtin.target.cpu.arch == .x86_64) std.built
         .xmm14 = true,
         .xmm15 = true,
         .memory = true,
-    } else {};
+    } else {
+        // void: this constant has no value on other targets
+    };
 
 const x86_64_sysv_jit_cohort: if (builtin.target.cpu.arch == .x86_64) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .x86_64) .{
@@ -217,7 +221,9 @@ const x86_64_sysv_jit_cohort: if (builtin.target.cpu.arch == .x86_64) std.builti
         .r14 = true,
         .r15 = true,
         .memory = true,
-    } else {};
+    } else {
+        // void: this constant has no value on other targets
+    };
 
 pub const jit_cohort_clobbers: if (builtin.target.cpu.arch == .aarch64 or builtin.target.cpu.arch == .x86_64) std.builtin.assembly.Clobbers else void =
     if (builtin.target.cpu.arch == .aarch64) .{


### PR DESCRIPTION
Since #409 (`5e989fe22`) the push-to-`main` run fails in the extended `zig build lint` step, on both Unix legs: zlinter's `no_empty_block` flags the `else {}` of three target-conditional constants in `src/engine/codegen/shared/entry.zig` (:157, :210, :220). Those arms are the `void` value the constant takes on other targets, not empty if blocks — the rule cannot tell the two apart.

The fix is the escape the rule itself names: a comment inside each arm. Measured on `main` at `00ea30c71`: bare, the three errors; with the comments, `zig build lint` exits 0 and `zig fmt` is unchanged.

Lint is extended (push to `main` only), so no PR run could catch this; #312 is why the red run went unremarked. Refs #409, #312.
