### PR TITLE
jit: a re-exported import resolves to the instance that defines it, and the importer keeps what it resolved (#388)

### DIFF
--- a/.dev/decisions/0228_bridge_thunk_carries_callee_signature.md
+++ b/.dev/decisions/0228_bridge_thunk_carries_callee_signature.md
@@ -1,0 +1,116 @@
+# 0228 — The cross-module bridge knows the callee's signature and enters the defining module
+
+- **Status**: Proposed
+- **Date**: 2026-09-08
+- **Author**: Junji Takakura
+- **Tags**: jit, cross-module, abi
+
+## Context
+
+A JIT-backed importer reaches a func exported by another JIT-backed instance
+through a bridge thunk (ADR-0066, D-225): setup emits one per resolved func
+import into a per-instance arena and plants it in `dispatch[N]`. The thunk
+swaps the runtime pointer for the callee's and CALLs the callee's entry. It
+was built from `FuncImportTarget = { callee_rt, callee_entry }` and nothing
+else.
+
+Three defects share that contract:
+
+- **#388** — `exportedFuncTarget` answered null for any export whose func
+  index was an import, so a chain A→B→C (B re-exports A's func) could not
+  link. `initLinked` was handed the resolved targets and threw them away.
+- **#390** — the thunk is signature-agnostic and the ABI is not. An argument
+  that overflows the register set is written by the importer relative to its
+  own stack and read by the callee relative to its own frame, with the thunk's
+  frame between them; a MEMORY-class result (`results.len > 2`) loses its
+  hidden buffer pointer because the caller's `emitImportDispatch` puts the
+  runtime where the pointer belongs. #391 fenced both shapes off in
+  `bridgeCanCarry` by copying the call site's marshalling budget — a second
+  copy of a rule that already had one.
+- **#413** — the arm64 thunk saves six of the seven registers
+  `abi.reserved_invariant_gprs` names, hand-written; X23 (`globals_base`) is
+  the one it skips.
+
+An alternative surfaced in review (2026-09-07): drop the thunk and emit a
+direct CALL to the callee's entry at every import call site. It fails on
+funcref identity. An import's `funcptr` — what `ref.func`, table elements and
+`call_ref` see — is `dispatch[fidx]` (`setup.zig`, `compile_init.zig`), i.e.
+the thunk's address. `call_indirect` and `call_ref` do not hold an import
+index statically and cannot be inlined, so whatever sits at that address must
+carry every signature. A direct CALL for the static `call` route would be an
+optimisation layered on a correct thunk, not a replacement for one.
+
+## Decision
+
+1. **`FuncImportTarget` carries the callee's signature.** The exporter fills
+   `sig` from its own `func_sigs`. The thunk is emitted per signature: it
+   copies the importer's overflow arguments into its own outgoing area and,
+   for a MEMORY-class result, keeps the hidden pointer in entry-arg0 and moves
+   the runtime to arg1. Overflow sizes and classes come from the call site's
+   own functions (`computeCallReturnBufferOff`, `computeCallOverflowBytes`),
+   not from a copy. Static `call` and the table / funcref routes go through
+   the same thunk.
+2. **Resolution folds at link time.** `JitInstance` keeps the targets it was
+   linked with (`import_targets`). `exportedFuncTarget` on an import index
+   returns that entry, so C's thunk names A directly; nothing is walked at
+   call time. Unresolved imports (WASI, embedder host funcs) stay null.
+3. **Retention is stated, not counted.** The target names the defining
+   instance's runtime, arena and module bytes, and nothing counts the takers.
+   The defining instance must outlive every importer that took a target from
+   it, transitively. The C API keeps this today by parking every JIT instance
+   until `wasm_store_delete` (`parkJitAsZombie`) and deferring a borrowed
+   module's bytes (`Module.jit_borrowers`); other callers keep it by hand.
+   `cross_module_reexport.c` deletes A and B before calling C.
+4. **The arm64 save block is derived from `abi.reserved_invariant_gprs`**, so
+   #413 cannot recur by omission.
+5. **Land in two PRs.** The first carries (2) and (3) and does not touch
+   codegen. The second carries (1) and (4), retires or narrows the #391 fence
+   to whatever the new thunk still cannot carry, and moves this ADR to
+   Accepted.
+
+## Alternatives considered
+
+### Alternative A — direct CALL at the import call site, no thunk
+
+- **Sketch**: `emitImportDispatch` emits `CALL callee_entry` with the runtime
+  swap inline; no arena.
+- **Why rejected**: funcref identity (Context). The thunk address is what a
+  funcref to an import IS; the indirect routes cannot be inlined.
+
+### Alternative B — walk the chain at call time
+
+- **Sketch**: B's thunk forwards to A's thunk.
+- **Why rejected**: one extra frame per hop for nothing; the callee-side
+  overflow read assumes the caller that wrote the arguments is the frame
+  directly above, so each hop would need its own copy step.
+
+### Alternative C — refcount the defining instance
+
+- **Sketch**: each taken target increments a count on the exporter; free at
+  zero.
+- **Why rejected**: the C API already never frees a JIT instance before its
+  store, so a count would guard nothing today; it would be a second retention
+  mechanism to keep consistent with the first.
+
+## Consequences
+
+- **Positive**: three-module chains link; overflow arguments and MEMORY-class
+  results cross the bridge; the #391 budget copy goes away with the fence.
+- **Negative**: the thunk grows and becomes per-signature (size measured in
+  the second PR); `FuncImportTarget.sig` borrows the exporter's compile arena,
+  which the retention statement already requires to be alive.
+- **Neutral / follow-ups**: the interpreter's binder has the same missing fold
+  for a re-exported import (its thunk runs the re-exporter's `unreachable`
+  placeholder) — tracked separately. `fromCompiled` (`.cwasm`) still links no
+  cross-module imports.
+
+## References
+
+- Issues: zwasm/zwasm#388, zwasm/zwasm#390, zwasm/zwasm#413; fence
+  zwasm/zwasm#391; runtime swap zwasm/zwasm#385
+- Related ADRs: ADR-0066 (bridge thunk), ADR-0185 / D-238 (frame link kept
+  in the thunk), ADR-0200 (JIT-backed C API instances)
+- Files: `src/engine/setup.zig`, `src/engine/runner.zig`,
+  `src/engine/codegen/shared/thunk.zig`, `src/engine/codegen/{x86_64,arm64}/thunk.zig`,
+  `src/api/instance.zig`; tests `src/engine/runner_test.zig`,
+  `test/c_api_conformance/cross_module_reexport.c`

--- a/build.zig
+++ b/build.zig
@@ -1368,6 +1368,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/trap_kind_per_call.c", .name = "trap_kind_per_call" }, // #336 the kind describes the call just made
         .{ .src = "test/c_api_conformance/gc_heap_cap_trap.c", .name = "gc_heap_cap_trap" }, // #361 GC heap cap is OUT_OF_MEMORY
         .{ .src = "test/c_api_conformance/cross_module_func.c", .name = "cross_module_func" }, // #360 cross-module func import on every engine
+        .{ .src = "test/c_api_conformance/cross_module_reexport.c", .name = "cross_module_reexport" }, // #388 a re-exported import links, and the chain outlives A
         .{ .src = "test/c_api_conformance/instance_new_short_imports.c", .name = "instance_new_short_imports" }, // #392 a short import vector is NULL, not a read past it
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -369,6 +369,15 @@ fn parkAsZombie(
 /// bridge thunk (D-225), so the exporter's `JitInstance` must outlive every
 /// importer. Parking defers the free to `wasm_store_delete`, by when nothing
 /// can call in. Takes the erased pointer the `Instance.jit` field carries.
+///
+/// ADR-0228 — "exporter" means the DEFINING instance, not the one the
+/// embedder passed the extern from: a re-exported import resolves to the
+/// module that defines the function (`JitInstance.exportedFuncTarget`), so
+/// in a chain A→B→C, C's thunk names A, and A must live as long as C even
+/// after B is gone. Nothing counts the takers; the unconditional park here
+/// and the byte deferral in `wasm_module_delete` are what keep A alive, and
+/// `test/c_api_conformance/cross_module_reexport.c` deletes A and B before
+/// calling C to hold them to it.
 fn parkJitAsZombie(
     store_alloc: std.mem.Allocator,
     store: *Store,

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -998,6 +998,14 @@ pub const JitInstance = struct {
     /// `Runtime.interrupt_flag_storage`. Stack-allocated callers that drive
     /// interruption via an external atomic (`setInterruptFlag`) leave it unused.
     interrupt_flag: std.atomic.Value(u32) = .init(0),
+    /// ADR-0228 — the resolved func-import targets `initLinked` was handed,
+    /// in func-import order (an owned copy; `fromCompiled` links nothing, so
+    /// it is empty there). Kept so `exportedFuncTarget` can answer for a
+    /// RE-EXPORTED import (#388): the entry it returns is the one this
+    /// instance resolved to, i.e. the defining module's, so a chain A→B→C
+    /// gives C a thunk into A directly — link-time folding, nothing walked at
+    /// call time.
+    import_targets: []setup_mod.FuncImportTarget = &.{},
 
     pub fn init(allocator: Allocator, wasm_bytes: []const u8) Error!JitInstance {
         return initLinked(allocator, wasm_bytes, &.{}, &.{}, &.{}, &.{});
@@ -1021,8 +1029,10 @@ pub const JitInstance = struct {
     ) Error!JitInstance {
         var compiled = try compileWasm(allocator, wasm_bytes);
         errdefer compiled.deinit(allocator);
-        const owned = try setup_mod.setupRuntimeLinked(allocator, &compiled, wasm_bytes, imported_global_vals, func_import_targets, tag_import_targets, host_func_targets);
-        return .{ .compiled = compiled, .owned = owned, .wasm_bytes = wasm_bytes };
+        var owned = try setup_mod.setupRuntimeLinked(allocator, &compiled, wasm_bytes, imported_global_vals, func_import_targets, tag_import_targets, host_func_targets);
+        errdefer owned.deinit(allocator);
+        const import_targets = try allocator.dupe(setup_mod.FuncImportTarget, func_import_targets);
+        return .{ .compiled = compiled, .owned = owned, .wasm_bytes = wasm_bytes, .import_targets = import_targets };
     }
 
     /// ADR-0203 stage 2 — build a JitInstance from an ALREADY-BUILT
@@ -1040,6 +1050,7 @@ pub const JitInstance = struct {
     }
 
     pub fn deinit(self: *JitInstance, allocator: Allocator) void {
+        if (self.import_targets.len > 0) allocator.free(self.import_targets);
         self.owned.deinit(allocator);
         self.compiled.deinit(allocator);
     }
@@ -1058,16 +1069,32 @@ pub const JitInstance = struct {
     }
 
     /// D-225 — resolve THIS instance as a cross-module export target: the
-    /// (callee_rt, callee_entry) an importer plants into a bridge thunk for
-    /// `(import "<this>" "<name>" (func …))`. Null if `name` isn't an
+    /// (callee_rt, callee_entry, sig) an importer plants into a bridge thunk
+    /// for `(import "<this>" "<name>" (func …))`. Null if `name` isn't an
     /// exported func. `callee_rt` is the address of this instance's pinned
     /// JitRuntime (stable — JitInstance must not move while referenced).
+    ///
+    /// ADR-0228 — a re-exported IMPORT answers with the target this instance
+    /// itself resolved (`import_targets`), so the importer's thunk enters the
+    /// defining module directly. Null while that import is unresolved — a
+    /// WASI or embedder host func is planted in `dispatch`, not here, and
+    /// re-exporting one stays unsupported. The returned target names the
+    /// defining instance's runtime, arena and module bytes, not this one's:
+    /// the defining instance must outlive every importer that took it, and
+    /// nothing counts the takers. Today the C API keeps that by never freeing
+    /// a JIT instance before its store (`api/instance.zig` `parkJitAsZombie`
+    /// / `Module.jit_borrowers`); other callers keep it by hand.
     pub fn exportedFuncTarget(self: *JitInstance, allocator: Allocator, name: []const u8) ?setup_mod.FuncImportTarget {
         const idx = findExportFunc(allocator, self.wasm_bytes, name) catch return null;
-        if (idx < self.compiled.num_imports) return null;
+        if (idx < self.compiled.num_imports) {
+            if (idx >= self.import_targets.len) return null;
+            const t = self.import_targets[idx];
+            return if (t.callee_entry != 0) t else null;
+        }
         return .{
             .callee_rt = @intFromPtr(&self.owned.rt),
             .callee_entry = self.compiled.module.entryAddr(idx),
+            .sig = self.compiled.func_sigs[idx],
         };
     }
 

--- a/src/engine/runner_test.zig
+++ b/src/engine/runner_test.zig
@@ -1048,6 +1048,71 @@ test "JitInstance.initLinked: cross-module FUNC import dispatches to exporter (D
     try testing.expectEqual(@as(?u64, 42), try a_inst.invoke(gpa, "test", &.{}));
 }
 
+// #388 — a three-module chain: B re-exports A's func, C imports it from B.
+// `exportedFuncTarget` on B answers with the target B itself resolved, so C's
+// thunk enters A directly. B is deinit'd BEFORE C is called: nothing in the
+// call walks through B (link-time folding, ADR-0228). A stays alive — its
+// runtime, arena and bytes are what C's thunk names.
+test "JitInstance.initLinked: a re-exported import resolves to the defining instance (#388)" {
+    const gpa = testing.allocator;
+    // (module (func (export "get") (result i32) i32.const 42))
+    const a_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x67,
+        0x65, 0x74, 0x00, 0x00, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b,
+    };
+    // (module (import "a" "get" (func $get (result i32))) (export "get" (func $get)))
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x02, 0x09, 0x01, 0x01, 0x61, 0x03, 0x67, 0x65, 0x74,
+        0x00, 0x00, 0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00,
+    };
+    // (module (import "b" "get" (func $get (result i32)))
+    //         (func (export "test") (result i32) call $get))
+    const c_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x02, 0x09, 0x01, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74,
+        0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x74, 0x65,
+        0x73, 0x74, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,
+    };
+    var a_inst = try JitInstance.init(gpa, &a_bytes);
+    defer a_inst.deinit(gpa);
+    const t_a = a_inst.exportedFuncTarget(gpa, "get") orelse return error.TestUnexpectedResult;
+
+    var b_inst = try JitInstance.initLinked(gpa, &b_bytes, &.{}, &.{t_a}, &.{}, &.{});
+    const t_b = b_inst.exportedFuncTarget(gpa, "get") orelse {
+        b_inst.deinit(gpa);
+        return error.TestUnexpectedResult;
+    };
+    // Folded at link time: B hands out A's entry, runtime and signature.
+    try testing.expectEqual(t_a.callee_entry, t_b.callee_entry);
+    try testing.expectEqual(t_a.callee_rt, t_b.callee_rt);
+    try testing.expectEqual(@as(usize, 1), t_b.sig.results.len);
+
+    var c_inst = try JitInstance.initLinked(gpa, &c_bytes, &.{}, &.{t_b}, &.{}, &.{});
+    defer c_inst.deinit(gpa);
+    b_inst.deinit(gpa);
+    try testing.expectEqual(@as(?u64, 42), try c_inst.invoke(gpa, "test", &.{}));
+}
+
+// #388 — the same B, but its import was never resolved (no A handed in). B
+// re-exports an import it cannot dispatch, so it must not hand out a target.
+test "JitInstance.exportedFuncTarget: a re-exported UNRESOLVED import is null (#388)" {
+    const gpa = testing.allocator;
+    const b_bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+        0x00, 0x01, 0x7f, 0x02, 0x09, 0x01, 0x01, 0x61, 0x03, 0x67, 0x65, 0x74,
+        0x00, 0x00, 0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00,
+    };
+    var b_inst = try JitInstance.initLinked(gpa, &b_bytes, &.{}, &.{.{}}, &.{}, &.{});
+    defer b_inst.deinit(gpa);
+    try testing.expect(b_inst.exportedFuncTarget(gpa, "get") == null);
+    // And with no target slice at all (the plain `init` shape).
+    var b2 = try JitInstance.init(gpa, &b_bytes);
+    defer b2.deinit(gpa);
+    try testing.expect(b2.exportedFuncTarget(gpa, "get") == null);
+}
+
 // #381 — the same public `initLinked` path, but the EXPORTER traps. A JIT trap
 // is a flag on the runtime the trap stub sees, and the bridge thunk runs the
 // callee with the callee's runtime pointer installed, so without propagation

--- a/src/engine/setup.zig
+++ b/src/engine/setup.zig
@@ -15,6 +15,7 @@ const entry = @import("codegen/shared/entry.zig");
 const linker = @import("codegen/shared/linker.zig");
 const canonical_type = @import("codegen/shared/canonical_type.zig");
 const rv = @import("runner_validate.zig");
+const zir = @import("../ir/zir.zig");
 
 const runner_mod = @import("runner.zig");
 const instantiate = @import("../runtime/instance/instantiate.zig");
@@ -35,9 +36,17 @@ const CompiledWasm = runner_mod.CompiledWasm;
 /// emits a cohort-safe bridge thunk (ADR-0066 `emitThunk`) into its own
 /// thunk arena and plants the slot in `dispatch[func_import_idx]`. A
 /// zero `callee_entry` = unresolved (slot stays `hostDispatchTrap`).
+///
+/// ADR-0228 — `sig` is the CALLEE's signature, filled by the exporter from
+/// its own `func_sigs` (the module that defines the function, whichever
+/// module re-exported it on the way). The bridge thunk needs it to lay out
+/// what the ABI does not pass in registers (#390); it borrows the exporter's
+/// compile arena, which lives as long as the exporter (see
+/// `JitInstance.exportedFuncTarget`). Empty when unresolved.
 pub const FuncImportTarget = struct {
     callee_rt: usize = 0,
     callee_entry: usize = 0,
+    sig: zir.FuncType = .{ .params = &.{}, .results = &.{} },
 };
 
 /// D-478 — a resolved EMBEDDER host-func import (`wasm_func_new`), in

--- a/test/c_api_conformance/cross_module_reexport.c
+++ b/test/c_api_conformance/cross_module_reexport.c
@@ -1,0 +1,164 @@
+/* zwasm v2 — C-API conformance: a re-exported import links across three
+ * modules, and the chain survives the defining module going away first.
+ *
+ *   A: (module (func (export "get") (result i32) (i32.const 42)))
+ *   B: (module (import "a" "get" (func $get (result i32))) (export "get" (func $get)))
+ *   C: (module (import "b" "get" (func $get (result i32)))
+ *             (func (export "test") (result i32) (call $get)))
+ *
+ * C's import is satisfied with B's export extern, which is A's function
+ * re-exported. Before #388 a JIT-backed B answered "not a defined function"
+ * and C failed to instantiate; the interpreter has always bound this.
+ *
+ * Between instantiating C and calling it, A's instance and module are
+ * deleted, then B's. C's bridge thunk names A's runtime and entry point
+ * (ADR-0228: B hands out what it resolved, so the thunk enters A directly),
+ * and nothing counts that reference — A must stay alive until the store
+ * goes. `wasm_instance_delete` parks every JIT instance on the store and
+ * `wasm_module_delete` defers a borrowed module's bytes, so it does. If a
+ * refcount ever replaced the park, this is the test that would notice.
+ *
+ * Run on `auto` and `jit`. The interpreter is left out: its binder points
+ * C's import at B's runtime and B's func index 0, which is B's import
+ * placeholder (body: `unreachable`, the backstop `instantiate.zig` describes),
+ * so the chained call traps there today — the same missing fold, in the other
+ * engine, tracked separately. Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (func (export "get") (result i32) (i32.const 42))) */
+static const uint8_t kAWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,                   /* type ()->(i32) */
+    0x03, 0x02, 0x01, 0x00,                                     /* func[0]: type 0 */
+    0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00,       /* export "get" -> 0 */
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x2a, 0x0b,             /* body: i32.const 42 */
+};
+
+/* (module (import "a" "get" (func (result i32))) (export "get" (func 0))) */
+static const uint8_t kBWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,                   /* type ()->(i32) */
+    0x02, 0x09, 0x01, 0x01, 0x61, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, /* import a.get */
+    0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00,       /* export "get" -> 0 (the import) */
+};
+
+/* (module (import "b" "get" (func (result i32)))
+ *         (func (export "test") (result i32) (call 0))) */
+static const uint8_t kCWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f,                   /* type ()->(i32) */
+    0x02, 0x09, 0x01, 0x01, 0x62, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, /* import b.get */
+    0x03, 0x02, 0x01, 0x00,                                     /* func[1]: type 0 */
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01, /* export "test" -> 1 */
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,             /* body: call 0 */
+};
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT };
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+/* One module of the chain: parse, instantiate with `imports`, fetch exports. */
+typedef struct {
+    wasm_module_t* module;
+    wasm_instance_t* instance;
+    wasm_extern_vec_t exports;
+} link_t;
+
+static int link_up(wasm_store_t* store, uint8_t engine, const char* who, const char* label,
+                   const uint8_t* wasm, size_t len, wasm_extern_vec_t* imports, link_t* out) {
+    wasm_byte_vec_t binary = { len, (wasm_byte_t*) wasm };
+    out->module = wasm_module_new(store, &binary);
+    if (!out->module) { fprintf(stderr, "[%s] %s failed to parse\n", who, label); return 1; }
+    wasm_trap_t* trap = NULL;
+    out->instance = zwasm_instance_new_ex(store, out->module, imports, &trap, engine);
+    if (trap) wasm_trap_delete(trap);
+    if (!out->instance) { fprintf(stderr, "[%s] %s failed to instantiate\n", who, label); return 1; }
+    wasm_instance_exports(out->instance, &out->exports);
+    if (out->exports.size < 1 || !out->exports.data[0]) {
+        fprintf(stderr, "[%s] %s exposed nothing\n", who, label);
+        return 1;
+    }
+    return 0;
+}
+
+static void unlink_all(link_t* l) {
+    if (l->exports.data) wasm_extern_vec_delete(&l->exports);
+    l->exports.data = NULL;
+    if (l->instance) wasm_instance_delete(l->instance);
+    l->instance = NULL;
+    if (l->module) wasm_module_delete(l->module);
+    l->module = NULL;
+}
+
+static int chain_on(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    link_t a = { 0 }, b = { 0 }, c = { 0 };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    if (link_up(store, engine, who, "A", kAWasm, sizeof(kAWasm), &no_imports, &a) != 0) goto cleanup;
+
+    wasm_extern_t* b_externs[1] = { a.exports.data[0] };
+    wasm_extern_vec_t b_imports = { 1, b_externs };
+    if (link_up(store, engine, who, "B (re-exporting A's func)", kBWasm, sizeof(kBWasm), &b_imports, &b) != 0) goto cleanup;
+
+    wasm_extern_t* c_externs[1] = { b.exports.data[0] };
+    wasm_extern_vec_t c_imports = { 1, c_externs };
+    if (link_up(store, engine, who, "C (importing B's re-export)", kCWasm, sizeof(kCWasm), &c_imports, &c) != 0) goto cleanup;
+    if (wasm_extern_kind(c.exports.data[0]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] C is missing its `test` export\n", who);
+        goto cleanup;
+    }
+
+    /* The defining module goes first, then the re-exporter. C must not. */
+    unlink_all(&a);
+    unlink_all(&b);
+
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(c.exports.data[0]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the chained call trapped after A and B were deleted\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] expected A's 42 through B, got kind=%d value=%d\n",
+                who, (int) results[0].kind, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    unlink_all(&c);
+    unlink_all(&b);
+    unlink_all(&a);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (chain_on(kEngines[i]) != 0) return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
`exportedFuncTarget` refused an export whose func index is an import, so a
three-module chain (B re-exports A's func, C imports it from B) could not
link on the JIT (#388).

- `JitInstance.import_targets` keeps what `initLinked` resolved; an import
  index answers with that entry. Folded at link time: C's thunk names A.
- `FuncImportTarget.sig` is the callee's signature, filled by the defining
  instance. Consumed by the next PR (#390 / #413); no codegen change here.
- Retention is stated (ADR-0228 D3): A lives as long as C, and today the
  C API's unconditional park keeps that. `cross_module_reexport.c` deletes
  A and B before calling C, on `auto` and `jit`.
- ADR-0228, Proposed. Accepted with the second PR.

Found on the way: the interpreter has the same missing fold. Its binder
points C at B's import placeholder (`unreachable` body), so the chained
call traps on `interp` with nothing deleted. Filed separately; the
conformance case leaves `interp` out and says why.

Closes #388
