### PR TITLE
jit: the reserved cohort is read or pinned everywhere, not restated (#413)

### DIFF
--- a/.claude/references/abi_callee_saved_pinning.md
+++ b/.claude/references/abi_callee_saved_pinning.md
@@ -18,13 +18,19 @@ called function MUST preserve them across the call. The v2
 project pins some of these regs for project-specific invariant
 use:
 
-- **arm64**: X19 (runtime_ptr) + X24..X28 (typeidx_base /
-  table_size / funcptr_base / mem_limit / vm_base) per
-  ADR-0017 + ADR-0018. **Full six-register cohort** —
-  D-144 (2026-05-18) found §A1's X19-only thunk fix was
-  insufficient because X24-X28 are equally pinned-callee-
-  saved and equally violated by the same prologue shape.
-  The cohort is canonical in `abi.zig::reserved_invariant_gprs`.
+- **arm64**: X19 (runtime_ptr) + X23 (globals_base, ADR-0027) +
+  X24..X28 (typeidx_base / table_size / funcptr_base / mem_limit /
+  vm_base) per ADR-0017 + ADR-0018. D-144 (2026-05-18) found §A1's
+  X19-only thunk fix was insufficient because X24-X28 are equally
+  pinned-callee-saved and equally violated by the same prologue shape.
+  **The cohort is canonical in `abi.zig::reserved_invariant_gprs`, and a
+  boundary must read it rather than restate it.** #413 is the case for
+  that: the array already held X23 when §A2's six-register save list was
+  hand-written, so the list never matched — a copy
+  beside a boundary is unverified from the moment it is typed, not
+  merely at risk of drifting. A boundary that cannot iterate (x86_64's
+  thunk hard-codes its one register in the PUSH/POP and the trap relay)
+  pins the array at comptime instead.
 - **x86_64**: R15 = runtime-ptr save (per ADR-0026 Cc-pivot).
   Single-register pinning — other invariants reload from
   `[R15 + offset]` at point of use (so cross-module bridge
@@ -70,37 +76,11 @@ callee's:
 ### Option A: bridge thunk does call-and-return + saves caller's pinned regs
 
 The bridge thunk wraps the cross-module call with a save-
-restore block for the full pinned-callee-saved cohort:
-
-```text
-arm64 (96 bytes per ADR-0066 §A2 amendment, D-144 cycle 4 —
-was 56 in §A1):
-   STP X29, X30, [SP, #-80]!          ; save FP/LR + alloc frame
-   STR X19, [SP, #16]                 ; save caller's X19
-   STR X24, [SP, #24]                 ; save caller's X24
-   STR X25, [SP, #32]                 ; save caller's X25
-   STR X26, [SP, #40]                 ; save caller's X26
-   STR X27, [SP, #48]                 ; save caller's X27
-   STR X28, [SP, #56]                 ; save caller's X28
-   ADR X16, +<offset>                 ; literal pool ptr
-   LDR X0, [X16]                      ; X0 ← callee_rt
-   LDR X16, [X16, #8]                 ; X16 ← callee_entry
-   BLR X16                            ; CALL
-   LDR X19, [SP, #16]                 ; restore X19
-   LDR X24, [SP, #24]                 ; ... X24
-   LDR X25, [SP, #32]                 ; ... X25
-   LDR X26, [SP, #40]                 ; ... X26
-   LDR X27, [SP, #48]                 ; ... X27
-   LDR X28, [SP, #56]                 ; ... X28
-   LDP X29, X30, [SP], #80            ; restore FP/LR, pop
-   RET
-   (4-byte pad + 16-byte literal pool follow)
-```
-
-ADR-0066 §A2 amendment (D-144 cycle 4) — the §A1 fix
-addressed only X19; §A2 extended to the full reserved-
-invariant cohort once `imports.1.wasm` print64
-call_indirect sig-mismatch surfaced the gap.
+restore block for the whole cohort. The arm64 encoder emits it
+by iterating `reserved_invariant_gprs`, so the frame size,
+instruction count and literal pool follow the array's length;
+the live layout is the header of
+[`arm64/thunk.zig`](../../src/engine/codegen/arm64/thunk.zig).
 
 ```text
 x86_64 (27 bytes — single pinned reg R15 per ADR-0026):

--- a/.claude/rules/abi_callee_saved_pinning.md
+++ b/.claude/rules/abi_callee_saved_pinning.md
@@ -21,9 +21,10 @@ paths:
 
 ## Invariant (PRESERVE — cost 6-cycle root-causes D-142 / D-206 / D-210)
 
-- The **pinned runtime cohort** — arm64 **X19** + **X24–X28**; x86_64 **R15** —
-  is installed by the prologue (ADR-0017 sub-2d-ii: MOV-install from the rt, not
-  stack-save). Any path that **clobbers** a cohort reg across a call to a
+- The **pinned runtime cohort** is `abi.zig::reserved_invariant_gprs` — read it,
+  do not restate it. It is installed by the prologue (ADR-0017 sub-2d-ii:
+  installed from the rt, not stack-saved). Any path that **clobbers** a cohort
+  reg across a call to a
   DIFFERENT runtime (cross-module bridge thunk, frame-consuming tail-jump
   `BR X16` / `JMP R11`) MUST restore the cohort first, else a same-module
   grand-caller's pinned values are corrupted and it traps on garbage.
@@ -37,9 +38,10 @@ paths:
 
 ## Enforcement
 
-Reviewer discipline (no mechanical gate) + the 3-host gate (cohort corruption
-surfaces as a cross-module SEGV / wrong value, esp. x86_64 SysV). Cross-module +
-tail-call fixtures are the regression net.
+Both thunks are gated against the array: arm64 decodes the emitted words,
+x86_64 stops the build. Everything else is reviewer discipline + the 3-host
+gate (cohort corruption surfaces as a cross-module SEGV / wrong value, esp.
+x86_64 SysV). Cross-module + tail-call fixtures are the regression net.
 
 ## Key cases
 

--- a/src/engine/codegen/arm64/abi.zig
+++ b/src/engine/codegen/arm64/abi.zig
@@ -103,30 +103,34 @@ pub const platform_gpr: Xn = 18;
 /// Callee-saved (non-volatile) GPRs per AAPCS64 §6.4.1.
 /// Callee must preserve these across calls; saved in prologue,
 /// restored in epilogue. The full callee-saved range is
-/// X19..X28; `reserved_invariant_gprs` carves out X24..X28 for
-/// JitRuntime-derived invariants (per ADR-0017 / 0018), leaving
-/// `allocatable_callee_saved_gprs` (X19..X23) available to the
+/// X19..X28; `reserved_invariant_gprs` carves out the
+/// JitRuntime-derived invariants (per ADR-0017 / 0018 / 0027) and
+/// `allocatable_callee_saved_gprs` is what is left for the
 /// regalloc.
 pub const callee_saved_gprs = [_]Xn{ 19, 20, 21, 22, 23, 24, 25, 26, 27, 28 };
 
 /// Registers reserved for runtime invariants (per ADR-0017 +
-/// ADR-0018):
+/// ADR-0018 + ADR-0027):
 ///   X28 — vm_base       (linear-memory base pointer)
 ///   X27 — mem_limit     (linear-memory size in bytes)
 ///   X26 — funcptr_base  (table 0 — array of u64 funcptrs)
 ///   X25 — table_size    (W25 = u32 count of entries)
 ///   X24 — typeidx_base  (parallel array of u32 typeidx values)
+///   X23 — globals_base  (the globals array; see the alias below)
 ///   X19 — runtime_ptr   (saved copy of *const JitRuntime; the
 ///                        ADR-0017 sub-2d-ii amendment — used to
 ///                        restore X0 before each BL/BLR since
 ///                        AAPCS64 caller-saves X0)
 ///
-/// The function prologue LDRs the first five from `*X0`, then
-/// MOVs X0 → X19 to preserve the runtime ptr across calls. They
-/// are excluded from the regalloc pool by construction —
-/// `allocatable_gprs` is defined as the complement, so a future
-/// reorganisation that adds or removes a reserved reg
-/// automatically propagates.
+/// The function prologue LDRs X24..X28 from `*X0` and MOVs X0 → X19
+/// to preserve the runtime ptr across calls; X23 is loaded only where
+/// the prescan found a global op (ADR-0027).
+///
+/// A reservation added or removed here reaches everything DERIVED from
+/// this array — `allocatable_gprs` is its complement, and the arm64
+/// bridge thunk's save block iterates it (ADR-0228 D4). A consumer that
+/// writes the members out instead does not follow: the thunk's
+/// hand-written list omitted X23 from the day it was written (#413).
 pub const reserved_invariant_gprs = [_]Xn{ 19, 23, 24, 25, 26, 27, 28 };
 
 /// Mnemonic alias for the X19 = runtime_ptr_save reservation
@@ -137,7 +141,7 @@ pub const runtime_ptr_save_gpr: Xn = 19;
 
 /// Mnemonic alias for the X23 = globals_base_save reservation
 /// (per ADR-0027). Functions touching `global.get` / `global.set`
-/// pre-load `[X19 + globals_base_off]` into X23 at function
+/// pre-load `[X0 + globals_base_off]` into X23 at function
 /// prologue (after the existing 5-invariant load), then the
 /// global op handlers emit `LDR Rd, [X23, Ridx, LSL #3]` etc.
 /// Functions without globals skip the X23 prologue load
@@ -165,14 +169,14 @@ pub const link_register: Xn = 30;
 ///   - X16/X17 (IP0/IP1, used as op-handler scratches per
 ///     `single_slot_dual_meaning.md`)
 ///   - X18 (Apple/Darwin platform-reserved)
-///   - X24..X28 (`reserved_invariant_gprs` per ADR-0017+0018)
+///   - `reserved_invariant_gprs` (ADR-0017 / 0018 / 0027)
 ///   - X29 (FP), X30 (LR), X31 (SP/XZR)
 ///
-/// Pool size: 10 (was 17 pre-ADR-0018). A function with > 10
-/// concurrently-live vregs spills to the function's spill frame
-/// per ADR-0018. Slot ids 0..9 resolve via this table; slot ids
-/// 10+ resolve to `Slot.spill` byte offsets (consumed by the
-/// emit pass via `regalloc.Allocation.slot()`).
+/// A function with more concurrently-live vregs than the pool holds
+/// spills to the function's spill frame per ADR-0018: slot ids below
+/// `allocatable_gprs.len` resolve via this table, the rest resolve to
+/// `Slot.spill` byte offsets (consumed by the emit pass via
+/// `regalloc.Allocation.slot()`). The length is pinned by a test below.
 pub const allocatable_gprs = allocatable_caller_saved_scratch_gprs ++ allocatable_callee_saved_gprs;
 
 // Compile-time invariant: allocatable / reserved / spill_stage

--- a/src/engine/codegen/arm64/op_globals.zig
+++ b/src/engine/codegen/arm64/op_globals.zig
@@ -5,7 +5,7 @@
 //! globals_base_save_gpr]`. Scalar globals (i32/i64/f32/f64/refs)
 //! use 8-byte slots and the legacy `idx*8` offset; v128 globals
 //! use 16-byte slots aligned to 16 bytes, addressed via Q-form
-//! LDR/STR. X23 is pre-loaded from `[X19 + globals_base_off]` at
+//! LDR/STR. X23 is pre-loaded from `[X0 + globals_base_off]` at
 //! the function prologue when the function actually touches a
 //! global op (prescan-driven; functions without globals skip the
 //! X23 load).

--- a/src/engine/codegen/arm64/op_tail_call.zig
+++ b/src/engine/codegen/arm64/op_tail_call.zig
@@ -165,7 +165,7 @@ pub fn emitDirectReturnCall(
 /// Cross-module `return_call $import` (ADR-0112 Amendment 2026-05-30,
 /// D-206 step 2). Lowered as **call-and-return** through the ADR-0066
 /// bridge thunk (planted in `host_dispatch_base[idx]`, which
-/// save/restores the full pinned cohort X19 + X24-X28 across its BLR)
+/// save/restores `abi.reserved_invariant_gprs` across its BLR)
 /// followed by the normal frame teardown + RET — i.e. the emit shape
 /// of `call $import` immediately followed by the function epilogue:
 ///
@@ -174,9 +174,9 @@ pub fn emitDirectReturnCall(
 ///       result lands in X0/V0 and the thunk restores A's cohort
 ///   (3) frame_teardown (ADD SP + LDP X29,X30) + RET
 ///
-/// NOT frame-consuming on the cross-module path: arm64 MOV-installs
-/// X19 and LOADs X24-X28 from the rt (it does not stack-save the
-/// cohort), so a frame-consuming `BR X16` to a different-rt callee
+/// NOT frame-consuming on the cross-module path: arm64 installs the
+/// cohort from the rt and never stack-saves it, so a
+/// frame-consuming `BR X16` to a different-rt callee
 /// would leave the callee's cohort installed when control returns to
 /// a same-module grand-caller — the D-142 corruption class in
 /// tail-call form. The thunk's call-and-return preserves the cohort.
@@ -240,7 +240,7 @@ fn emitCrossModuleReturnCall(
 /// when control reaches a same-module grand-caller. Whatever
 /// `dispatch[i]` holds returns the cohort intact, but for two
 /// DIFFERENT reasons. A cross-module wasm import holds the ADR-0066
-/// thunk, which STRs X19/X24, BLRs, LDRs them back and RETs
+/// thunk, which STRs the reserved cohort, BLRs, LDRs it back and RETs
 /// (`shared/thunk.zig`) — an explicit save list, load-bearing rather
 /// than incidental: an earlier 56-byte thunk saved only X19, left X24
 /// stale, and surfaced as an `imports.1.wasm` sig mismatch. A WASI

--- a/src/engine/codegen/shared/entry.zig
+++ b/src/engine/codegen/shared/entry.zig
@@ -165,10 +165,10 @@ const x86_64_win64_call_clobbers: if (builtin.target.cpu.arch == .x86_64 and bui
         // non-Win64 hosts: const value collapses to void.
     };
 
-/// D-245 — the callee-saved GPRs the JIT prologue clobbers.
-/// The prologue MOV-installs the pinned cohort (arm64 X19/X24-X28; x86_64
-/// RBX/R12-R14 plus the reserved R15) from `rt` WITHOUT stack-saving the caller's values, so a plain
-/// host→JIT `@call` lets ReleaseSafe's optimized host lose any live value it
+/// D-245 — the callee-saved GPRs the JIT prologue clobbers. arm64 installs the
+/// reserved cohort from `rt` and stack-saves none of it; x86_64 pushes its one reserved
+/// register and the regalloc hands RBX/R12-R14 to vregs unsaved. Either way
+/// a plain host→JIT `@call` lets ReleaseSafe's optimized host lose any live value it
 /// kept there → heap-corruption SEGV. `jitTrampoline` clobber-lists this set
 /// so ITS prologue/epilogue saves & restores the cohort around the call,
 /// masking the JIT's clobber. On Win64 the regalloc pool also holds RDI and
@@ -333,7 +333,7 @@ inline fn invokeAndCheckVoid(
     stack_limit_mod.diagOnceWithRt(rt, jit_abi.stack_limit_off, rt.stack_limit);
     if (comptime builtin.target.cpu.arch == .aarch64 and args.len == 0) {
         // D-245: the JIT prologue MOV-installs the pinned cohort (X19 +
-        // X24-X28) from `rt` WITHOUT saving the caller's values
+        // X23-X28) from `rt` WITHOUT saving the caller's values
         // (ADR-0017 / D-210), so it clobbers the host's callee-saved
         // X19-X28 and its epilogue can't restore them. A plain `@call`
         // leaves the host's live X19-X28 unprotected → SEGV in ReleaseSafe.

--- a/src/engine/codegen/shared/jit_abi.zig
+++ b/src/engine/codegen/shared/jit_abi.zig
@@ -3,15 +3,16 @@
 //!
 //! `JitRuntime` is the extern struct passed to every JIT-compiled
 //! Wasm function via X0 (ARM64) / RDI (x86_64 System V). The
-//! function's prologue LDRs the five invariants from `*X0` once
-//! per call, then the body uses them via the
-//! `reserved_invariant_gprs` (ADR-0018):
+//! function's prologue loads these from `*X0` once per call,
+//! then the body uses them via the
+//! `reserved_invariant_gprs` (ADR-0018 / ADR-0027):
 //!
 //!   X28 ← vm_base       (linear-memory base ptr)
 //!   X27 ← mem_limit     (linear-memory size in bytes)
 //!   X26 ← funcptr_base  (table 0 funcptr array)
 //!   X25 ← table_size    (table 0 entry count, X-width u64 — D-475 table64)
 //!   X24 ← typeidx_base  (parallel u32 typeidx side-array)
+//!   X23 ← globals_base  (only where the function uses a global)
 //!
 //! `extern struct` keeps the layout deterministic across Zig
 //! versions and across the ABI boundary the prologue depends on.

--- a/src/engine/codegen/x86_64/abi.zig
+++ b/src/engine/codegen/x86_64/abi.zig
@@ -122,7 +122,8 @@ pub const runtime_ptr_save_gpr: Gpr = .r15;
 /// invariants (vm_base / mem_limit / funcptr_base / table_size
 /// / typeidx_base) reload from `[R15 + offset]` at point of use
 /// rather than holding callee-saved slots — the arm64 mirror
-/// model (6 reserved regs) is unworkable on x86_64 because
+/// model (`arm64/abi.zig::reserved_invariant_gprs`) is
+/// unworkable on x86_64 because
 /// only 6 callee-saved GPRs exist total and `frame_pointer`
 /// (RBP) takes one. See ADR-0026 §"Decision".
 pub const reserved_invariant_gprs = [_]Gpr{runtime_ptr_save_gpr};

--- a/src/engine/codegen/x86_64/thunk.zig
+++ b/src/engine/codegen/x86_64/thunk.zig
@@ -134,6 +134,14 @@ comptime {
         @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; they are no longer adjacent");
     if (jit_abi.trap_flag_off % 8 != 0)
         @compileError("bridge thunk relays trap_flag|trap_kind as one 8-byte pair; trap_flag_off is no longer 8-aligned");
+    // R15 is written literally in the PUSH/POP below, in the trap relay's
+    // store, and in this file's byte offsets, under both conventions.
+    // `x86_64/abi.zig` asserts the same thing, but whoever moves the
+    // reservation edits that file and its tests together; the assumption
+    // lives here, so the failure has to name this file.
+    if (abi.reserved_invariant_gprs.len != 1 or abi.runtime_ptr_save_gpr != .r15 or
+        abi.sysv.runtime_ptr_save_gpr != .r15 or abi.win64.runtime_ptr_save_gpr != .r15)
+        @compileError("bridge thunk hard-codes R15 as the whole reserved-invariant set; it has moved or grown");
 }
 
 /// Total thunk size in bytes — see the layout table. One shape for every

--- a/test/jit/releasesafe_result_probe.zig
+++ b/test/jit/releasesafe_result_probe.zig
@@ -4,7 +4,7 @@
 //! no-arg VOID path (`runVoidExport`). This probe drives the i32 RESULT path
 //! (`runner.runI32Export` → `entry.invokeAndCheck`), which has its own
 //! host→JIT seam: the JIT prologue MOV-installs the pinned callee-saved
-//! cohort (arm64 X19/X24-X28; x86_64 RBX/R12-R15) from `rt` WITHOUT
+//! cohort (arm64 X19/X23-X28; x86_64 RBX/R12-R15) from `rt` WITHOUT
 //! stack-saving the caller's values, so a plain `@call` clobbers the host's
 //! live callee-saved registers. In ReleaseSafe the optimized host keeps live
 //! values there → heap-corruption SEGV; Debug keeps nothing live → no crash.
@@ -48,7 +48,7 @@ const wasm_f_42 = [_]u8{
 
 /// Hold a cohort's-worth of independent live pointers across the JIT call so
 /// ReleaseSafe is forced to keep some of them in the callee-saved registers
-/// the JIT prologue clobbers (arm64 X19/X24-X28; x86_64 RBX/R12-R15). Each
+/// the JIT prologue clobbers (arm64 X19/X23-X28; x86_64 RBX/R12-R15). Each
 /// pointer is dereferenced BOTH before and after the call, and the result
 /// feeds back into the assertion, so the optimizer cannot sink/hoist them out
 /// of the live range. `.never_inline` gives this frame its own register


### PR DESCRIPTION
Patch for #419, based on that PR's head so it merges into it directly — the
shape #406 used for #402 and #410 for #408.

## Why

D4 makes the arm64 thunk read `reserved_invariant_gprs`. The docstring on that
array listed six registers, X23 missing, and so did the two doc comments around
it — so a reader following "read the array" landed on a comment restating it
wrongly. The same file also said X19..X23 were allocatable when X19 and X23 are
both reserved, and gave a pool size of 10 against a length of 8 that a test in
the same file pins.

The case for reading the array is sharper than staleness. `reserved_invariant_gprs`
gained X23 in `f55ddb994`; the six-register save list was hand-written after
that, in `6dd40adef`. It never matched.

## What

**`x86_64/thunk.zig` gains a comptime pin.** That encoder cannot iterate
cheaply: R15 is written literally in its PUSH/POP under both conventions, in the
trap relay's store, and in this file's byte offsets, all of which would have to
follow the cohort's length.

`x86_64/abi.zig` asserts the same reservation, so the pin adds no coverage on
its own. What it adds is placement: whoever moves the reservation edits that
file and its tests together, and with the pool made consistent the way such an
edit would make it, the pin is the only error that names this file. Measured
both ways.

**Prose that described a cohort of six**: `arm64/abi.zig` above all, then
`shared/jit_abi.zig` and `releasesafe_result_probe.zig` (each missing one
register), `op_tail_call.zig`, `entry.zig`, and the auto-loaded
`abi_callee_saved_pinning` rule — injected in full whenever anyone edits `abi`,
`prologue`, `thunk`, `emit`, `op_call` or `op_control`, so it is where the next
copy would be written from. Its reference offered a six-register save block as
the shape to copy; that block predates the signature-aware thunk, so it is now
a pointer to the encoder's own header.

**Two corrections found while in there.** The D-245 note said the prologue
stack-saves none of the cohort; that is arm64's shape, and x86_64 pushes its one
reserved register and loses RBX/R12-R14 to the regalloc instead. And X23 is
loaded from X0, before the runtime pointer reaches X19 — `op_globals.zig` said
X19 too, so both are fixed.

Numbers that rot are out of the prose: the pool length is pinned by a test, so
the doc says that rather than naming a figure, which is how "Pool size: 10"
outlived the pool being 9, and then 8.

`entry.zig` is rewrapped to its original line count, so the growth ratchet stays
quiet on an already-over-cap file.

## Not here

No ADR, lesson or ROADMAP change — recording the decision is yours, and ADR-0228
D4 holds it. The one scaffolding file this touches is the auto-loaded rule and
its reference; revert them if you would rather own that text.

Nothing here waits on my approval. Take it whole, take the parts you want, or
write it yourself — and close this once it has served its purpose.

One thing this does not close: `arm64/emit.zig`'s prologue writes X24..X28 as
five literals and never reads the array, so a reserved register added tomorrow
is saved by the thunk, excluded from the pool, and never installed. Same shape,
no observable yet — worth its own change rather than riding here.

#417 was this fix arrived at from #413 before #419 existed. It is closed in
favour of yours; only the restatements above needed to reach your branch.

