### PR TITLE
ci: the ReleaseSafe unit tests run on the Windows leg too, inside its headroom (#303)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -81,8 +81,9 @@ text or code identifiers.
   (aarch64-macos + x86_64-linux + x86_64-windows) for **every** PR. That IS the
   merge gate. A PR run gets the **core** gate — zig fmt + `test-all` +
   `bench-latency-build` (compile-only, ADR-0209) + the test-discovery guard,
-  plus on the Linux leg only `run-rust-host` and the unit tests built
-  ReleaseSafe (#347) — and, as a blocking step OUTSIDE `ci_gate.sh`,
+  plus `run-rust-host` on the Linux leg only and the unit tests built
+  ReleaseSafe on the Linux and Windows legs (#347, #303) — and, as a blocking
+  step OUTSIDE `ci_gate.sh`,
   `test-wasi-p1-official` (ADR-0225; the only leg content the script does not
   define). The **extended** checks (lint /
   build-option DCE / ReleaseSafe JIT smoke / AOT cross-compile / `zone_check` /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,11 @@ jobs:
             runs-on: ubuntu-22.04
             zig-dir: zig-x86_64-linux-0.16.0
             extended: true
+            # #347 — the unit tests built ReleaseSafe, on every PR. A row gets
+            # this when its leg finishes far enough ahead of aarch64-macos
+            # (the critical path) to absorb a second optimised build; the
+            # numbers are on the block in ci_gate.sh.
+            releasesafe_unit: true
           - name: x86_64-windows
             runs-on: windows-2022
             zig-dir: zig-x86_64-windows-0.16.0
@@ -194,6 +199,9 @@ jobs:
             # the Win64 entry thunks optimised, and Windows is where the JIT is
             # the default engine.
             jit_releasesafe: true
+            # #303 — the other half: the JIT ships by default here, so the
+            # optimised unit lane runs on this leg too, not on Linux alone.
+            releasesafe_unit: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -320,13 +328,15 @@ jobs:
       # JIT smoke + AOT cross-compile) are up to ~20 cold-cache ReleaseSafe builds
       # and dominate wall-clock (~2.5-4.5 min/build on hosted runners), so they
       # run ONLY on the merge to `main` (push) — not on every PR / dispatch, which
-      # get the core gate (fmt + test-all + the Linux-only ReleaseSafe unit tests
-      # and rust-host; see ci_gate.sh's header). windows is always core.
+      # get the core gate (fmt + test-all + the Linux-only rust-host + the
+      # ReleaseSafe unit tests on the `releasesafe_unit` rows; see ci_gate.sh's
+      # header). windows is always core.
       - name: ci_gate.sh
         shell: bash
         env:
           ZWASM_CI_EXTENDED: ${{ (github.event_name == 'push' && matrix.extended) && '1' || '0' }}
           ZWASM_CI_JIT_RELEASESAFE: ${{ (github.event_name == 'push' && matrix.jit_releasesafe) && '1' || '0' }}
+          ZWASM_CI_RELEASESAFE_UNIT: ${{ matrix.releasesafe_unit && '1' || '0' }}
         run: bash scripts/ci_gate.sh
 
       # Official wasi-testsuite wasm32-wasip1 corpus (D-582). BLOCKING, with

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,8 @@ required **`ci-required`** status check. CI runs
 macOS aarch64, Linux x86_64, Windows x86_64. Your PR gets the *core* gate: fmt
 + `test-all` + the rust-host consumer + the test-discovery guard + the
 ReleaseSafe-runner floor guard (ADR-0177) + the unit tests built
-ReleaseSafe (Linux leg only; the mode every release binary is built in) — plus
+ReleaseSafe (Linux and Windows legs; the mode every release binary is built
+in) — plus
 `test-wasi-p1-official`, which blocks from a step of its own rather than from
 inside the script (ADR-0225). The extended
 static/build checks (lint, the build-option DCE matrix, AOT cross-compile,
@@ -120,6 +121,7 @@ leg's content except for the one blocking step beside it:
 
 ```sh
 bash scripts/ci_gate.sh                    # core (fmt + test-all)
+ZWASM_CI_RELEASESAFE_UNIT=1 bash scripts/ci_gate.sh  # + the ReleaseSafe unit tests (the Linux + Windows rows)
 ZWASM_CI_EXTENDED=1 bash scripts/ci_gate.sh  # + lint/DCE/AOT/zone checks (Unix)
 zig build test-wasi-p1-official            # the blocking step outside the script
 ```

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -8,13 +8,16 @@
 #   Core — every OS: zig fmt --check (src/ + bench/latency/ + tools/) +
 #     zig build test-all + bench-latency-build + test-discovery guard +
 #     spec-manifest shape guard + ReleaseSafe-runner floor
-#   Core — Linux only: run-rust-host (D-254) + ReleaseSafe unit tests
-#     (zig build test -Doptimize=ReleaseSafe, #347). Still core — they run on
-#     every PR — but only on the leg that has the wall-clock headroom for
-#     them (rust-host also needs the runner's gnu-target rustc to be
-#     ABI-compatible with zig's native libzwasm.a). Listed separately because
-#     "every OS" above is load-bearing: anything added here is verified on
-#     ONE leg.
+#   Core — Linux only: run-rust-host (D-254). Still core — it runs on every
+#     PR — but the runner's gnu-target rustc has to be ABI-compatible with
+#     zig's native libzwasm.a, and only that leg's is. Listed separately
+#     because "every OS" above is load-bearing: anything added here is
+#     verified on ONE leg.
+#   Core — legs whose ci.yml matrix row says `releasesafe_unit: true`
+#     (Linux + Windows), read here as ZWASM_CI_RELEASESAFE_UNIT: the unit
+#     tests built ReleaseSafe (zig build test -Doptimize=ReleaseSafe, #347,
+#     #303). Every PR, but only on the legs with the wall-clock headroom for
+#     a second optimised build.
 #   ReleaseSafe JIT smoke: ZWASM_CI_EXTENDED (Unix legs) or
 #     ZWASM_CI_JIT_RELEASESAFE (the Windows leg; #303).
 #   Extended (ZWASM_CI_EXTENDED=1; Unix legs): lint + build-option DCE +
@@ -25,6 +28,7 @@
 #
 # Usage:
 #   bash scripts/ci_gate.sh                    # core gate on this host
+#   ZWASM_CI_RELEASESAFE_UNIT=1 bash scripts/ci_gate.sh   # + ReleaseSafe unit tests
 #   ZWASM_CI_EXTENDED=1 bash scripts/ci_gate.sh   # + extended checks
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -81,14 +85,19 @@ fi
 # release binary is built ReleaseSafe. ReleaseSafe and not ReleaseFast /
 # ReleaseSmall: `support.dbg` is comptime-disabled in those two, so five of its
 # tests fail there by construction, and ReleaseSafe is the mode that names the
-# fault instead of exiting 70 silently. LINUX-only: the leg finishes ~12 min
-# before aarch64-macos, so the ~5 min this adds does not move the gate's
-# wall-clock. Core, not extended — extended does not run on every PR, which is
-# not a regression barrier. `--summary all` for the same reason `test-all`
-# carries it. No graceful-skip arm: unlike rust-host this needs no external
-# toolchain.
-if [ "$(uname -s)" = "Linux" ]; then
-    echo "[ci_gate] ReleaseSafe unit tests (Linux-only core, #347)"
+# fault instead of exiting 70 silently. Which legs run it is a matrix fact in
+# ci.yml (`releasesafe_unit: true`, read here as ZWASM_CI_RELEASESAFE_UNIT),
+# and the rule for a row is #347's: the leg has to finish far enough ahead of
+# aarch64-macos, the critical path, that what this adds does not move the
+# gate's wall-clock. Measured on PR #423's run (2026-09-09): Linux 5m48s on a
+# 14m04s leg, Windows 6m17s on a 20m44s leg, against a 24m11s macOS leg —
+# both inside the headroom (#303). Windows also skips 156 tests here where
+# Linux skips 12: #370's Win64 guard, the same set as the Debug lane. Core, not
+# extended — extended does not run on every PR, which is not a regression
+# barrier. `--summary all` for the same reason `test-all` carries it. No
+# graceful-skip arm: unlike rust-host this needs no external toolchain.
+if [ "${ZWASM_CI_RELEASESAFE_UNIT:-0}" = "1" ]; then
+    echo "[ci_gate] ReleaseSafe unit tests (core on the releasesafe_unit legs, #347 / #303)"
     zig build test -Doptimize=ReleaseSafe --summary all
 fi
 

--- a/scripts/gate_merge.sh
+++ b/scripts/gate_merge.sh
@@ -18,7 +18,7 @@
 #                                              host-dependent, so one local
 #                                              run covers one arch)
 #   - `check_runner_dbg_init --gate`          (ci_gate.sh core, every leg)
-#   - `zig build test -Doptimize=ReleaseSafe` (ci_gate.sh, Linux leg)
+#   - `zig build test -Doptimize=ReleaseSafe` (ci_gate.sh, Linux + Windows legs)
 #   - `zig build run-rust-host`               (ci_gate.sh, Linux leg)
 #   - `zig build test-wasi-p1-official`       (a leg step outside ci_gate.sh;
 #                                              not in test-all)


### PR DESCRIPTION
#303's remaining half: `zig build test -Doptimize=ReleaseSafe` on the Windows
leg. #347 kept it Linux-only for wall-clock, not correctness; the Windows cost
was unmeasured. Now it is.

Measured on this PR's run (34348809397, 2026-09-09), leg totals and the lane:

| leg | total | ReleaseSafe unit tests |
|---|---|---|
| aarch64-macos | 24m11s | — |
| x86_64-linux | 14m04s | 5m48s (3287/3299, 12 skipped) |
| x86_64-windows | 20m44s | 6m17s (3143/3299, 156 skipped — #370's guard) |

Baseline (PR #420's run): macOS 22m59s / Linux 15m17s / Windows 16m02s.
Windows stays inside its headroom against macOS, so by #347's rule the lane
is core on the Windows row too — every PR, which a push-only flag is not.

The gate reads the matrix (`releasesafe_unit: true` → ZWASM_CI_RELEASESAFE_UNIT)
instead of `uname`, so "which legs" is one place in ci.yml. Locally the lane
now needs that env set; `ci_gate.sh`'s usage line says so.

Prose that said "Linux only" for this lane, fixed here: `ci_gate.sh` header
and block, `ci.yml`, `.claude/CLAUDE.md`, `docs/development.md`,
`scripts/gate_merge.sh`. `run-rust-host` stays Linux-only (rustc).

Closes #303
