### PR TITLE
jit: a const expression reads any immutable global in scope, as the validator already allows (#397)

### DIFF
--- a/src/engine/compile.zig
+++ b/src/engine/compile.zig
@@ -52,6 +52,38 @@ pub fn boundsChecksMode() BoundsChecks {
 /// binds the guarded reservation, ADR-0202 D5 clauses D-515(1)), so the
 /// historical forced-`.explicit` is gone. Kept as a named entry point so
 /// AOT-destined call sites stay greppable.
+/// #397 — a const expression's validity is judged once, by the shared
+/// validator (Wasm 3.0 §3.3.13.1); `runner_validate.zig` only evaluates.
+/// `.undeterminable` is the GC shapes that walker does not type: they are
+/// not rejected here, setup evaluates or declines them.
+fn checkConstExpr(expr: []const u8, want: zir.ValType, scope: validator_mod.ConstExprScope) Error!void {
+    switch (validator_mod.validateConstExpr(expr, want, scope)) {
+        .ok, .undeterminable => {},
+        .invalid => return Error.InvalidGlobalInitExpr,
+    }
+}
+
+/// The global index space as the validator sees it: the imported globals
+/// first, then the global section, each as (valtype, mutable).
+fn collectGlobalEntries(a: Allocator, imports_buf: ?sections.Imports, globals: ?sections.Globals) Error![]validator_mod.GlobalEntry {
+    var n: usize = if (globals) |g| g.items.len else 0;
+    if (imports_buf) |ib| for (ib.items) |imp| {
+        if (imp.kind == .global) n += 1;
+    };
+    const out = try a.alloc(validator_mod.GlobalEntry, n);
+    var gi: usize = 0;
+    if (imports_buf) |ib| for (ib.items) |imp| {
+        if (imp.kind != .global) continue;
+        out[gi] = .{ .valtype = imp.payload.global.valtype, .mutable = imp.payload.global.mutable };
+        gi += 1;
+    };
+    if (globals) |g| for (g.items) |gd| {
+        out[gi] = .{ .valtype = gd.valtype, .mutable = gd.mutable };
+        gi += 1;
+    };
+    return out;
+}
+
 pub fn compileWasmForAot(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledWasm {
     return compileWasm(allocator, wasm_bytes);
 }
@@ -455,42 +487,69 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
                 num_global_imports_empty += 1;
             };
         }
-        // §9.9 / 9.9-l-1b-d093-d82 — total_funcs for empty-fn
-        // path = number of function imports only (no defined
-        // functions). Used by validateGlobalInitExpr's ref.func
-        // arm for range-checking funcidxs in global / offset
-        // const-exprs.
-        const total_funcs_empty_for_init: u32 = sig_count;
-        if (module.find(.global)) |gs| {
-            var gs_buf = try sections.decodeGlobals(a, gs.body);
-            defer gs_buf.deinit();
-            for (gs_buf.items) |gd| {
-                try rv.validateGlobalInitExpr(gd.init_expr, gd.valtype, num_global_imports_empty, imports_buf, total_funcs_empty_for_init);
+        // The type section as the validator's scope wants it — decoded
+        // as an empty vector when absent, the way the validate path does.
+        const empty_type_body = [_]u8{0x00};
+        var types_empty = try sections.decodeTypes(a, if (module.find(.type)) |ts| ts.body else &empty_type_body);
+        defer types_empty.deinit();
+        var globals_empty: ?sections.Globals = null;
+        defer if (globals_empty) |*g| g.deinit();
+        if (module.find(.global)) |gs| globals_empty = try sections.decodeGlobals(a, gs.body);
+        const global_entries_empty = try collectGlobalEntries(a, imports_buf, globals_empty);
+        if (globals_empty) |gs_buf| {
+            for (gs_buf.items, 0..) |gd, i| {
+                // §3.3.13.1 — a global's init sees the imports and the
+                // globals defined before it. `typeidxs` = the import
+                // funcs, the whole function index space on this path.
+                try checkConstExpr(gd.init_expr, gd.valtype, .{
+                    .globals = global_entries_empty[0 .. num_global_imports_empty + i],
+                    .func_type_indices = typeidxs,
+                    .types = &types_empty,
+                });
             }
         }
         // §9.9 / 9.9-l-1b-d093-d78 mirror — empty-fn path
-        // elem + data active-offset_expr validation.
+        // elem + data active-offset_expr validation. An offset sees
+        // every global (§3.3.13.1).
+        const offset_scope_empty: validator_mod.ConstExprScope = .{
+            .globals = global_entries_empty,
+            .func_type_indices = typeidxs,
+            .types = &types_empty,
+        };
         if (module.find(.data)) |ds| {
             var ds_buf = try sections.decodeData(a, ds.body);
             defer ds_buf.deinit();
             for (ds_buf.items) |seg| {
                 if (seg.kind == .active) {
-                    try rv.validateGlobalInitExpr(seg.offset_expr, data_off_vt, num_global_imports_empty, imports_buf, total_funcs_empty_for_init);
+                    try checkConstExpr(seg.offset_expr, data_off_vt, offset_scope_empty);
                 }
+            }
+        }
+        // D-475: a table64 elem offset is i64-typed (§3.3.6) — decode
+        // the table section for the per-table expected offset type.
+        var empty_tables_buf: ?sections.Tables = null;
+        defer if (empty_tables_buf) |*t| t.deinit();
+        if (module.find(.table)) |ts| empty_tables_buf = try sections.decodeTables(a, ts.body);
+        // §3.3.13.1 — a table's own init expr sees the imported globals
+        // only: the reference interpreter checks tables before any defined
+        // global enters the context (PR #428 review).
+        if (empty_tables_buf) |t| {
+            const table_scope_empty: validator_mod.ConstExprScope = .{
+                .globals = global_entries_empty[0..num_global_imports_empty],
+                .func_type_indices = typeidxs,
+                .types = &types_empty,
+            };
+            for (t.items) |tbl| {
+                if (tbl.init_expr.len != 0) try checkConstExpr(tbl.init_expr, tbl.elem_type, table_scope_empty);
             }
         }
         if (module.find(.element)) |es| {
             var es_buf = try sections.decodeElement(a, es.body);
             defer es_buf.deinit();
-            // D-475: a table64 elem offset is i64-typed (§3.3.6) — decode
-            // the table section for the per-table expected offset type.
-            var empty_tables_buf: ?sections.Tables = null;
-            defer if (empty_tables_buf) |*t| t.deinit();
-            if (module.find(.table)) |ts| empty_tables_buf = try sections.decodeTables(a, ts.body);
             for (es_buf.items) |seg| {
                 if (seg.kind == .active) {
                     const off_vt = elemOffsetValType(imports_buf, empty_tables_buf, seg.tableidx);
-                    try rv.validateGlobalInitExpr(seg.offset_expr, off_vt, num_global_imports_empty, imports_buf, total_funcs_empty_for_init);
+                    try checkConstExpr(seg.offset_expr, off_vt, offset_scope_empty);
                 }
             }
         }
@@ -706,26 +765,23 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     if (module.find(.data)) |s| datas_buf = try sections.decodeData(allocator, s.body);
     if (module.find(.element)) |s| elems_buf = try sections.decodeElement(allocator, s.body);
 
-    // §9.9 / 9.9-l-1b-d093-d77 (skip-impl drainage):
-    // Wasm spec §3.4.3 / §3.3.2 global init-expression
-    // validation. Per spec, a defined global's init_expr
-    // must be a "constant expression": single const opcode
-    // (i32/i64/f32/f64.const, ref.null, ref.func, or
-    // global.get of an *imported* *immutable* global)
-    // followed by `end (0x0B)`, AND the result type must
-    // match the declared valtype.
-    // Count global imports once for d-77 + d-78 const-expr
-    // checks (init-expr `global.get` must reference an
-    // imported immutable global).
-    var num_global_imports_main: u32 = 0;
-    if (imports_buf) |ib| {
-        for (ib.items) |imp| if (imp.kind == .global) {
-            num_global_imports_main += 1;
-        };
-    }
+    // §9.12-E / B158: validator_globals indexed by FULL wasm global
+    // index space (imports prefix + defined; mirrors B153/B154's
+    // globals_offsets shape). Without this, opGlobalGet/Set rejects
+    // imported-global references as out-of-bounds (B156 Errors 1+2).
+    const validator_globals = try collectGlobalEntries(a, imports_buf, globals_buf);
+
+    // §9.9 / 9.9-l-1b-d093-d77 (skip-impl drainage): Wasm spec §3.4.3
+    // global init-expression validation — the shared validator's verdict
+    // (#397). §3.3.13.1: a defined global's init sees the imports and the
+    // globals defined before it, never itself or a later one.
     if (globals_buf) |g| {
-        for (g.items) |gd| {
-            try rv.validateGlobalInitExpr(gd.init_expr, gd.valtype, num_global_imports_main, imports_buf, total_funcs);
+        for (g.items, 0..) |gd, i| {
+            try checkConstExpr(gd.init_expr, gd.valtype, .{
+                .globals = validator_globals[0 .. nm_global_imports + i],
+                .func_type_indices = func_typeidxs,
+                .types = &types,
+            });
         }
     }
 
@@ -735,11 +791,16 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
     // expressions per §3.3.2. Drains `elem` + `data`
     // SKIP-VALIDATOR-GAP entries with "type mismatch",
     // "constant expression required", "unknown global" in
-    // offset positions.
+    // offset positions. An offset sees every global (§3.3.13.1).
+    const offset_scope: validator_mod.ConstExprScope = .{
+        .globals = validator_globals,
+        .func_type_indices = func_typeidxs,
+        .types = &types,
+    };
     if (datas_buf) |d| {
         for (d.items) |seg| {
             if (seg.kind == .active) {
-                try rv.validateGlobalInitExpr(seg.offset_expr, data_off_vt, num_global_imports_main, imports_buf, total_funcs);
+                try checkConstExpr(seg.offset_expr, data_off_vt, offset_scope);
             }
         }
     }
@@ -748,28 +809,21 @@ pub fn compileWasm(allocator: Allocator, wasm_bytes: []const u8) Error!CompiledW
             if (seg.kind == .active) {
                 // D-475: a table64 elem offset is i64-typed (§3.3.6).
                 const off_vt = elemOffsetValType(imports_buf, tables_buf, seg.tableidx);
-                try rv.validateGlobalInitExpr(seg.offset_expr, off_vt, num_global_imports_main, imports_buf, total_funcs);
+                try checkConstExpr(seg.offset_expr, off_vt, offset_scope);
             }
         }
     }
-
-    // §9.12-E / B158: validator_globals indexed by FULL wasm global
-    // index space (imports prefix + defined; mirrors B153/B154's
-    // globals_offsets shape). Without this, opGlobalGet/Set rejects
-    // imported-global references as out-of-bounds (B156 Errors 1+2).
-    const defined_globals_n: usize = if (globals_buf) |g| g.items.len else 0;
-    const validator_globals = try a.alloc(validator_mod.GlobalEntry, @as(usize, nm_global_imports) + defined_globals_n);
-    if (imports_buf) |ib| {
-        var gi: usize = 0;
-        for (ib.items) |imp| {
-            if (imp.kind != .global) continue;
-            validator_globals[gi] = .{ .valtype = imp.payload.global.valtype, .mutable = imp.payload.global.mutable };
-            gi += 1;
-        }
-    }
-    if (globals_buf) |g| {
-        for (g.items, 0..) |gd, gi| {
-            validator_globals[@as(usize, nm_global_imports) + gi] = .{ .valtype = gd.valtype, .mutable = gd.mutable };
+    // §3.3.13.1 — a table's own init expr sees the imported globals only:
+    // the reference interpreter checks tables before any defined global
+    // enters the context (PR #428 review).
+    if (tables_buf) |t| {
+        const table_scope: validator_mod.ConstExprScope = .{
+            .globals = validator_globals[0..nm_global_imports],
+            .func_type_indices = func_typeidxs,
+            .types = &types,
+        };
+        for (t.items) |tbl| {
+            if (tbl.init_expr.len != 0) try checkConstExpr(tbl.init_expr, tbl.elem_type, table_scope);
         }
     }
 

--- a/src/engine/compile_init.zig
+++ b/src/engine/compile_init.zig
@@ -50,15 +50,18 @@ pub fn applyDefinedGlobalsInit(
     // Callers that haven't populated the import prefix get the
     // ctx but its buf reads zeros — matching pre-cohort-1 behaviour
     // for fixtures that don't use global.get in init exprs.
-    const gctx: rv.GlobalsCtx = .{
-        .offsets = globals_offsets,
-        .valtypes = globals_valtypes,
-        .buf = globals_buf,
-        .num_imports = num_global_imports,
-    };
     for (globals_decoded.items, 0..) |gd, gi| {
         const off = globals_offsets[num_global_imports + gi];
         const vt = globals_valtypes[num_global_imports + gi];
+        // §3.3.13.1 — this global's init may read the imports and the
+        // globals before it, all written by the time it is evaluated.
+        const gctx: rv.GlobalsCtx = .{
+            .offsets = globals_offsets,
+            .valtypes = globals_valtypes,
+            .buf = globals_buf,
+            .num_imports = num_global_imports,
+            .readable = num_global_imports + @as(u32, @intCast(gi)),
+        };
         // Post-ADR-0110 widen: every slot is uniform 16 bytes.
         if (off + 16 > globals_buf.len) return Error.UnsupportedEntrySignature;
         switch (vt) {

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -168,10 +168,15 @@ pub const Error = error{
     /// called. An unsatisfied import MUST fail instantiation regardless
     /// of whether it is reached at runtime (D-451).
     ImportUnsatisfied,
+    /// Wasm 3.0 §3.3.13.1: a global's init expression or an active
+    /// segment's offset expression is not a valid constant expression
+    /// for its position — the shared validator's `.invalid` verdict
+    /// (`validateConstExpr`), raised by `compile.zig` (#397).
+    InvalidGlobalInitExpr,
 } || compile_func.Error || parser.Error || sections.Error || linker.Error || entry.Error || validator_mod.Error || rv.Error;
-// `InvalidGlobalInitExpr` / `UnsupportedEntrySignature` /
-// `UnsupportedConstExpr` originate in `runner_validate.zig`
-// (per ADR-0064) and are merged in via `|| rv.Error` above.
+// `UnsupportedEntrySignature` / `UnsupportedConstExpr` originate in
+// `runner_validate.zig` (per ADR-0064) and are merged in via
+// `|| rv.Error` above.
 
 /// Compile every defined function in `wasm_bytes` and link into
 /// a single JitModule. Caller owns the module — pair with

--- a/src/engine/runner_const_expr_test.zig
+++ b/src/engine/runner_const_expr_test.zig
@@ -1,0 +1,128 @@
+//! JIT const-expression tests: the shared validator judges a constant
+//! expression's validity once (Wasm 3.0 §3.3.13.1) and the JIT only
+//! evaluates (#397). Split from `runner_test.zig`, which sits at its
+//! file-size cap; mirrors the `runner_trap_test.zig` split. Discovered by
+//! the unit-test loader via `src/zwasm.zig`'s `test {}` block.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const testing = std.testing;
+const skip = @import("../test_support/skip.zig");
+
+const runner = @import("runner.zig");
+const compileWasm = runner.compileWasm;
+const JitInstance = runner.JitInstance;
+// ── #397: a const expression reads any immutable global in scope ──
+// Wasm 3.0 §3.3.13.1 (extended-const) lets a global init `global.get` an
+// immutable global declared before it, imported or defined. The JIT's
+// own const-expr check applied the 2.0 rule (imports only); its validity
+// is now the shared validator's verdict and `runner_validate.zig` only
+// evaluates.
+
+// (module
+//   (global $a i32 (i32.const 5))
+//   (global $b i32 (global.get $a))
+//   (func (export "test") (result i32) global.get $b))
+const defined_global_read_bytes = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, // type ()->(i32)
+    0x03, 0x02, 0x01, 0x00, // func 0: type 0
+    // global sec: $a i32 immutable (i32.const 5); $b i32 immutable (global.get 0)
+    0x06, 0x0b, 0x02, 0x7f,
+    0x00, 0x41, 0x05, 0x0b,
+    0x7f, 0x00, 0x23, 0x00,
+    0x0b,
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00, // export "test" func 0
+    0x0a, 0x06, 0x01, 0x04, 0x00, 0x23, 0x01, 0x0b, // code: global.get 1; end
+};
+
+test "JitInstance: a global init reads a defined immutable global (#397)" {
+    if (builtin.os.tag == .windows) return skip.phaseEnd(.win64);
+    var inst = try JitInstance.init(testing.allocator, &defined_global_read_bytes);
+    defer inst.deinit(testing.allocator);
+    try testing.expectEqual(@as(?u64, 5), try inst.invoke(testing.allocator, "test", &.{}));
+}
+
+test "compileWasm: a global init that reads itself, a later global, or a mutable global is invalid (§3.3.13.1)" {
+    // (module (global i32 (global.get 0)))
+    const self_ref = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x06, 0x01, 0x7f, 0x00, 0x23, 0x00, 0x0b };
+    try testing.expectError(error.InvalidGlobalInitExpr, compileWasm(testing.allocator, &self_ref));
+    // (module (global i32 (global.get 1)) (global i32 (i32.const 0)))
+    const forward_ref = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x0b, 0x02, 0x7f, 0x00, 0x23, 0x01, 0x0b, 0x7f, 0x00, 0x41, 0x00, 0x0b };
+    try testing.expectError(error.InvalidGlobalInitExpr, compileWasm(testing.allocator, &forward_ref));
+    // (module (global $m (mut i32) (i32.const 1)) (global i32 (global.get $m)))
+    const mutable_read = [_]u8{ 0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x06, 0x0b, 0x02, 0x7f, 0x01, 0x41, 0x01, 0x0b, 0x7f, 0x00, 0x23, 0x00, 0x0b };
+    try testing.expectError(error.InvalidGlobalInitExpr, compileWasm(testing.allocator, &mutable_read));
+}
+
+test "applyDefinedGlobalsInit: a defined-global read evaluates in index order, and a reference read declines" {
+    const gpa = testing.allocator;
+    {
+        var c = try compileWasm(gpa, &defined_global_read_bytes);
+        defer c.deinit(gpa);
+        const buf = try gpa.alloc(u8, c.globals_offsets.len * 16);
+        defer gpa.free(buf);
+        @memset(buf, 0);
+        try runner.applyDefinedGlobalsInit(gpa, &defined_global_read_bytes, c.globals_offsets, c.globals_valtypes, buf, c.num_global_imports);
+        try testing.expectEqual(@as(u32, 5), std.mem.readInt(u32, buf[c.globals_offsets[1]..][0..4], .little));
+    }
+    {
+        // (module (func $f) (global $a funcref (ref.func $f)) (global $b funcref (global.get $a)))
+        // $a's slot holds the `ref.func` funcidx placeholder until
+        // `resolveFuncrefGlobals`, which rewrites only `ref.func` inits —
+        // so copying it into $b would carry the placeholder past the
+        // resolver. The evaluator declines instead of copying.
+        const funcref_chain = [_]u8{
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type ()->()
+            0x03, 0x02, 0x01, 0x00, // func 0: type 0
+            0x06, 0x0b, 0x02, 0x70,
+            0x00, 0xd2, 0x00, 0x0b,
+            0x70, 0x00, 0x23, 0x00,
+            0x0b,
+            0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b, // code: end
+        };
+        var c = try compileWasm(gpa, &funcref_chain);
+        defer c.deinit(gpa);
+        const buf = try gpa.alloc(u8, c.globals_offsets.len * 16);
+        defer gpa.free(buf);
+        @memset(buf, 0);
+        try testing.expectError(error.UnsupportedEntrySignature, runner.applyDefinedGlobalsInit(gpa, &funcref_chain, c.globals_offsets, c.globals_valtypes, buf, c.num_global_imports));
+    }
+}
+
+test "compileWasm: a table init that reads a defined global is invalid — a table sees the imports only (§3.3.13.1)" {
+    // (module (global $g i32 (i32.const 0)) (table 1 funcref (global.get $g)))
+    // PR #428 review: `compileWasm` judged global inits and segment offsets
+    // but never a table's own init expr, and setup then resolved the read.
+    const table_reads_defined = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x04, 0x09, 0x01, 0x40, 0x00, 0x70, 0x00, 0x01, 0x23, 0x00, 0x0b, // table: funcref min 1, init global.get 0
+        0x06, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x00, 0x0b, // global $g i32 (i32.const 0)
+    };
+    try testing.expectError(error.InvalidGlobalInitExpr, compileWasm(testing.allocator, &table_reads_defined));
+}
+
+test "JitInstance: an active data offset that reads a defined global is valid, and setup declines it cleanly" {
+    if (builtin.os.tag == .windows) return skip.phaseEnd(.win64);
+    // (module (memory 1) (global $o i32 (i32.const 8)) (data (global.get $o) "hi")
+    //   (func (export "test") (result i32) i32.const 8 i32.load8_u))
+    // The offset is a valid constant expression (§3.3.13.1: an offset sees
+    // every global), so `compileWasm` accepts it; `setup.zig` evaluates
+    // offsets without a globals context and declines — as one error, with
+    // no instance and nothing half-initialised (PR #428 review). `.auto`
+    // runs it on the interpreter; `--engine jit` fails with this name.
+    const data_offset_reads_global = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, // type () -> (i32)
+        0x03, 0x02, 0x01, 0x00, // func 0
+        0x05, 0x03, 0x01, 0x00, 0x01, // memory 1
+        0x06, 0x06, 0x01, 0x7f, 0x00, 0x41, 0x08, 0x0b, // global $o i32 (i32.const 8)
+        0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x00, // export "test"
+        0x0a, 0x09, 0x01, 0x07, 0x00, 0x41, 0x08, 0x2d, 0x00, 0x00, 0x0b, // code: i32.const 8; i32.load8_u
+        0x0b, 0x08, 0x01, 0x00, 0x23, 0x00, 0x0b, 0x02, 0x68, 0x69, // data (global.get 0) "hi"
+    };
+    var c = try compileWasm(testing.allocator, &data_offset_reads_global);
+    c.deinit(testing.allocator);
+    try testing.expectError(error.UnsupportedEntrySignature, JitInstance.init(testing.allocator, &data_offset_reads_global));
+}

--- a/src/engine/runner_gc_test.zig
+++ b/src/engine/runner_gc_test.zig
@@ -1135,7 +1135,7 @@ test "JitInstance: ref.i31 global init compiles + get returns the i31 value" {
     if (builtin.os.tag == .windows) return skip.phaseEnd(.win64);
     // (module (global $g i31ref (i32.const 1234) (ref.i31))
     //   (func (export "g") (result i32) global.get 0 i31.get_s))
-    // The JIT compile gate's validateGlobalInitExpr was single-opcode and
+    // The JIT compile gate's own const-expr check was single-opcode and
     // rejected the `i32.const; ref.i31; end` sequence (InvalidGlobalInitExpr).
     const bytes = [_]u8{
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
@@ -1163,7 +1163,7 @@ test "runI32Export: array.new_default const-expr global + array.len → 3 (D-223
     //   (type $arr (array (mut i32)))                       ;; type 0
     //   (global $g (ref 0) (i32.const 3) (array.new_default 0)) ;; gc const-expr
     //   (func (export "len") (result i32) global.get 0 array.len))
-    // The JIT compile gate (validateGlobalInitExpr) rejected the multi-op
+    // The JIT compile gate's own const-expr check rejected the multi-op
     // const-expr (i32.const; array.new_default; end → InvalidGlobalInitExpr),
     // so the whole module was compile-skipped. Now the validator walks the
     // const-expr + setup allocates the array on the gc heap at global init.

--- a/src/engine/runner_validate.zig
+++ b/src/engine/runner_validate.zig
@@ -1,31 +1,27 @@
-//! Module-level validation helpers extracted from `runner.zig`
-//! per ADR-0064. Self-contained: takes `expr: []const u8` (and
-//! optional context) → returns a typed result or a tagged error.
+//! Setup-time const-expression evaluation for the JIT runner,
+//! extracted from `runner.zig` per ADR-0064. Self-contained: takes
+//! `expr: []const u8` (and optional context) → returns a typed
+//! result or a tagged error.
 //!
-//! These helpers cover Wasm spec const-expression validation
-//! (`§3.4.3` global init / `§3.4.6` / `§3.4.7` active offset_expr
-//! / `§5.4` instr-encoded reftypes) and minimal const-expression
-//! evaluation (i32 / scalar-as-u64 / v128 16-byte payload).
+//! Evaluation only (i32 / scalar-as-u64 / v128 16-byte payload). A
+//! const expression's *validity* is the shared validator's verdict
+//! (`validate/validator_helpers.zig:validateConstExpr`, Wasm 3.0
+//! §3.3.13.1), which `compile.zig` consults; an expression this
+//! module cannot evaluate is a capability decline
+//! (`UnsupportedConstExpr` / `UnsupportedEntrySignature`), never a
+//! validity verdict (#397).
 //!
 //! Zone 2 (`src/engine/`); imports Zone 0 (`leb128`) and Zone 1
-//! (`ir/zir`, `parse/sections`) only.
+//! (`ir/zir`) only.
 
 const std = @import("std");
 
 const leb128 = @import("../support/leb128.zig");
-const sections = @import("../parse/sections.zig");
 const zir = @import("../ir/zir.zig");
 
 /// Errors originating in this module. Subset of `runner.Error`;
 /// merged in via `runner.Error = ... || runner_validate.Error || ...`.
 pub const Error = error{
-    /// Wasm spec §3.4.3 / §3.3.2: a global section entry's
-    /// init expression is not a valid constant expression for
-    /// its declared type. Triggers: a non-const opcode, a
-    /// `global.get` of a non-imported / non-immutable global,
-    /// an init-expr whose result type doesn't match the
-    /// declared valtype, ref.func funcidx out of range.
-    InvalidGlobalInitExpr,
     /// Const-expression decode failed at the scalar / v128
     /// helper level (mostly: truncated body, unknown opcode,
     /// missing trailing `end`). The runner upgrades this to
@@ -45,8 +41,8 @@ pub const Error = error{
 /// import, SIMD v128.const, or a malformed expression). Used by
 /// `compileWasm` to seed the declared-funcrefs bitset per Wasm
 /// spec §3.4.10. The full validity check (range, trailing
-/// `end`, type match) still lives in `validateGlobalInitExpr`;
-/// this helper is best-effort extraction only.
+/// `end`, type match) is the shared validator's
+/// (`validateConstExpr`); this helper is best-effort extraction only.
 pub fn initExprRefFunc(expr: []const u8) ?u32 {
     if (expr.len < 3) return null;
     if (expr[0] != 0xD2) return null;
@@ -56,173 +52,26 @@ pub fn initExprRefFunc(expr: []const u8) ?u32 {
     return idx;
 }
 
-/// Wasm spec §3.4.3 / §3.3.2 const-expression validator for
-/// global init exprs AND active elem / data offset_expr (d-78
-/// callers pass `.i32` for offset expressions). Naming retained
-/// for git blame continuity; semantically a generic
-/// `validateConstExpr` helper.
-///
-/// Returns `Error.InvalidGlobalInitExpr` for any non-const
-/// opcode, out-of-range global index, mutable-global reference,
-/// type mismatch, or missing trailing `end`.
-pub fn validateGlobalInitExpr(
-    expr: []const u8,
-    want_valtype: zir.ValType,
-    num_global_imports: u32,
-    imports_opt: ?sections.Imports,
-    total_funcs: u32,
-) Error!void {
-    if (expr.len < 1) return Error.InvalidGlobalInitExpr;
-    // Walk the const-expr as a sequence of value-producing ops (Wasm 3.0
-    // §3.4.3 extended GC const-exprs are multi-operand: array.new = 2-op,
-    // struct.new = N-op). This is the JIT compile gate, not the
-    // authoritative validator — the interp validator already checked
-    // operand counts + subtyping, so here we only (a) parse each op's
-    // immediates byte-correctly to reach the trailing `end`, and (b)
-    // track the LAST value-producing op's result type for the want-check
-    // (a global init produces exactly one value = the final producer). D-220 / D-223.
-    var pos: usize = 0;
-    var produced: ?zir.ValType = null;
-    while (pos < expr.len) {
-        const op = expr[pos];
-        pos += 1;
-        switch (op) {
-            0x0B => { // end — must be the final byte with exactly one value produced
-                if (pos != expr.len) return Error.InvalidGlobalInitExpr;
-                const pv = produced orelse return Error.InvalidGlobalInitExpr;
-                // Numeric / v128 must match exactly. For ref types accept any
-                // ref-for-ref (interp validator owns the GC subtype lattice).
-                const both_ref = isRefType(pv) and isRefType(want_valtype);
-                if (!both_ref and !pv.eql(want_valtype)) return Error.InvalidGlobalInitExpr;
-                return;
-            },
-            0x41 => { // i32.const
-                _ = leb128.readSleb128(i32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                produced = .i32;
-            },
-            0x42 => { // i64.const
-                _ = leb128.readSleb128(i64, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                produced = .i64;
-            },
-            // Extended-const proposal (Wasm 3.0): i32/i64 add/sub/mul (no
-            // immediate). Operand-count + operand-type checks are owned by the
-            // interp validator; here we only track the result type for the
-            // final want-check (binop result type == the i32/i64 operand type).
-            0x6A, 0x6B, 0x6C => produced = .i32,
-            0x7C, 0x7D, 0x7E => produced = .i64,
-            0x43 => { // f32.const
-                if (pos + 4 > expr.len) return Error.InvalidGlobalInitExpr;
-                pos += 4;
-                produced = .f32;
-            },
-            0x44 => { // f64.const
-                if (pos + 8 > expr.len) return Error.InvalidGlobalInitExpr;
-                pos += 8;
-                produced = .f64;
-            },
-            0xD0 => { // ref.null heaptype (s33: negative = abstract, non-negative = concrete typeidx)
-                const ht = leb128.readSleb128(i64, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                produced = if (ht >= 0)
-                    // D-239 — concrete typed heaptype `(ref.null $typeidx)`
-                    // (function-references; e.g. `(global (ref null $t)
-                    // (ref.null $t))`). Produce a nullable concrete ref; the
-                    // want-check accepts ref-for-ref + the interp validator
-                    // owns the precise typeidx subtype lattice.
-                    zir.ValType{ .ref = .{ .nullable = true, .heap_type = .{ .concrete = @intCast(ht) } } }
-                else switch (ht) {
-                    -0x10 => zir.ValType.funcref, // 0x70
-                    -0x11 => zir.ValType.externref, // 0x6F
-                    // Wasm 3.0 GC abstract heaptypes (D-220).
-                    -0x12 => zir.ValType.anyref, // 0x6E
-                    -0x13 => zir.ValType.eqref, // 0x6D
-                    -0x14 => zir.ValType.i31ref, // 0x6C
-                    -0x15 => zir.ValType.structref, // 0x6B
-                    -0x16 => zir.ValType.arrayref, // 0x6A
-                    -0x0F, -0x0E, -0x0D, -0x17, -0x18 => zir.ValType.anyref, // none/noextern/nofunc/exn/noexn — lenient
-                    else => return Error.InvalidGlobalInitExpr,
-                };
-            },
-            0xD2 => { // ref.func funcidx (Wasm 2.0)
-                const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                // Wasm spec §3.4.3: ref.func init-expr funcidx must
-                // be in [0, total_funcs). ref_func.2.wasm asserts
-                // rejection of `(global funcref (ref.func 7))` when
-                // only 2 funcs exist.
-                if (idx >= total_funcs) return Error.InvalidGlobalInitExpr;
-                produced = .funcref;
-            },
-            0xFD => { // SIMD prefix — only v128.const (0x0C) is valid in const-expr
-                const sub = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                if (sub != 0x0C) return Error.InvalidGlobalInitExpr;
-                if (pos + 16 > expr.len) return Error.InvalidGlobalInitExpr;
-                pos += 16;
-                produced = .v128;
-            },
-            0x23 => { // global.get N
-                const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                // Init-expr global.get can only reference imported
-                // globals (§3.4.2). Defined-global self/forward
-                // references are not constant expressions.
-                if (idx >= num_global_imports) return Error.InvalidGlobalInitExpr;
-                // The referenced import must be immutable.
-                const imports = imports_opt orelse return Error.InvalidGlobalInitExpr;
-                var seen: u32 = 0;
-                var resolved: ?zir.ValType = null;
-                for (imports.items) |imp| {
-                    if (imp.kind != .global) continue;
-                    if (seen == idx) {
-                        const g = imp.payload.global;
-                        if (g.mutable) return Error.InvalidGlobalInitExpr;
-                        resolved = g.valtype;
-                        break;
-                    }
-                    seen += 1;
-                }
-                produced = resolved orelse return Error.InvalidGlobalInitExpr;
-            },
-            0xFB => { // Wasm 3.0 GC prefix const-exprs
-                const sub = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                switch (sub) {
-                    0x1C => produced = zir.ValType.i31ref, // ref.i31 (wraps preceding i32)
-                    // struct.new / struct.new_default / array.new /
-                    // array.new_default — each carries a typeidx and yields
-                    // (ref $typeidx). The setup-eval allocates on the gc heap.
-                    0x00, 0x01, 0x06, 0x07 => {
-                        const ti = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                        produced = .{ .ref = zir.RefType.conc(ti, false) };
-                    },
-                    0x08 => { // array.new_fixed $t N — typeidx then element count
-                        const ti = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                        _ = leb128.readUleb128(u32, expr, &pos) catch return Error.InvalidGlobalInitExpr;
-                        produced = .{ .ref = zir.RefType.conc(ti, false) };
-                    },
-                    else => return Error.InvalidGlobalInitExpr,
-                }
-            },
-            else => return Error.InvalidGlobalInitExpr,
-        }
-    }
-    return Error.InvalidGlobalInitExpr; // ran off the end with no trailing `end`
-}
-
-fn isRefType(t: zir.ValType) bool {
-    return std.meta.activeTag(t) == .ref;
-}
-
 /// Context for resolving `global.get N` inside a const-expression
 /// during init-time (active data offset, active elem offset,
-/// defined-global init). Wasm spec §3.3.3 restricts const-expr
-/// `global.get` to imported immutable globals (N <
-/// num_global_imports); the importer-side scratch buffer must be
-/// pre-populated with the imported values before any caller of
-/// the eval helpers below is invoked. When `ctx` is `null`, the
+/// defined-global init). `buf` is the importer-side globals buffer;
+/// the caller pre-populates the slots the expression may read
+/// before invoking any eval helper below. When `ctx` is `null`, the
 /// helpers behave as before — `global.get` reaches the `else`
 /// arm and returns `UnsupportedConstExpr` / `UnsupportedEntrySignature`.
 pub const GlobalsCtx = struct {
     offsets: []const u32,
     valtypes: []const zir.ValType,
     buf: []const u8,
+    /// Slots `[0, num_imports)` hold the resolved import values; a
+    /// reference there is a real `FuncEntity` pointer.
     num_imports: u32,
+    /// `global.get N` reads a slot only when `N < readable` — the
+    /// window Wasm 3.0 §3.3.13.1 gives the expression's position:
+    /// the imports plus the globals defined before it for a global
+    /// init, and whatever the caller has evaluated so far for an
+    /// active offset. Never above `offsets.len`.
+    readable: u32,
 };
 
 /// Decode a scalar const-expression's raw bits as a u64. Used by
@@ -231,9 +80,9 @@ pub const GlobalsCtx = struct {
 /// shapes not yet supported (the const-expr corpus consumed by
 /// the Wasm 2.0 spec runner is finite — i32/i64/f32/f64.const,
 /// ref.null, ref.func, v128.const is handled by the separate
-/// `evalConstV128Expr`). `global.get N` for imported immutable
-/// globals is supported when `ctx` is non-null per close-plan
-/// §6 (j) Step B cohort 1.
+/// `evalConstV128Expr`). `global.get N` reads a slot inside
+/// `ctx.readable` when `ctx` is non-null (close-plan §6 (j) Step B
+/// cohort 1; the defined-global window since #397).
 pub fn evalConstScalarRaw(expr: []const u8) Error!u64 {
     return evalConstScalarRawCtx(expr, null);
 }
@@ -283,11 +132,17 @@ pub fn evalConstScalarRawCtx(expr: []const u8, ctx: ?GlobalsCtx) Error!u64 {
         0x23 => blk: { // global.get N — close-plan §6 (j) Step B cohort 1
             const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.UnsupportedEntrySignature;
             const c = ctx orelse return Error.UnsupportedEntrySignature;
-            if (idx >= c.num_imports) return Error.UnsupportedEntrySignature;
+            if (idx >= c.readable) return Error.UnsupportedEntrySignature;
             if (idx >= c.offsets.len or idx >= c.valtypes.len) return Error.UnsupportedEntrySignature;
             // v128 globals are not scalar — caller must dispatch v128 init
             // via `evalConstV128Expr` instead. Reject early.
             if (c.valtypes[idx] == .v128) return Error.UnsupportedEntrySignature;
+            // A defined reference global's slot may still hold the
+            // `ref.func` funcidx placeholder (`resolveFuncrefGlobals`
+            // runs after this pass and rewrites only the globals whose
+            // own init is `ref.func`), so copying it would carry the
+            // placeholder past the resolver. Decline rather than copy.
+            if (idx >= c.num_imports and c.valtypes[idx] == .ref) return Error.UnsupportedEntrySignature;
             // Post-ADR-0110 widen: every slot occupies uniform 16 bytes;
             // scalar values live in the low 8 bytes (little-endian).
             const off = c.offsets[idx];
@@ -323,11 +178,10 @@ pub fn evalConstI32Expr(expr: []const u8) Error!i32 {
 }
 
 /// Context-aware variant per close-plan §6 (j) Step B cohort 1.
-/// Accepts the `global.get N` shape (opcode 0x23) for imported
-/// immutable globals when `ctx` is non-null. The importer-side
-/// `ctx.buf` must be pre-populated with each imported global's
-/// resolved value (see spec runner's
-/// `applyImportedGlobalsFromRegistered`).
+/// Accepts the `global.get N` shape (opcode 0x23) for a slot inside
+/// `ctx.readable` when `ctx` is non-null. The importer-side
+/// `ctx.buf` must be pre-populated with each readable global's
+/// value (see spec runner's `applyImportedGlobalsFromRegistered`).
 pub fn evalConstI32ExprCtx(expr: []const u8, ctx: ?GlobalsCtx) Error!i32 {
     if (expr.len < 2) return Error.UnsupportedConstExpr;
     var pos: usize = 1;
@@ -339,7 +193,7 @@ pub fn evalConstI32ExprCtx(expr: []const u8, ctx: ?GlobalsCtx) Error!i32 {
         0x23 => blk: { // global.get N
             const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.UnsupportedConstExpr;
             const c = ctx orelse return Error.UnsupportedConstExpr;
-            if (idx >= c.num_imports) return Error.UnsupportedConstExpr;
+            if (idx >= c.readable) return Error.UnsupportedConstExpr;
             if (idx >= c.offsets.len or idx >= c.valtypes.len) return Error.UnsupportedConstExpr;
             if (c.valtypes[idx] != .i32) return Error.UnsupportedConstExpr;
             const off = c.offsets[idx];
@@ -356,8 +210,8 @@ pub fn evalConstI32ExprCtx(expr: []const u8, ctx: ?GlobalsCtx) Error!i32 {
 /// Context-aware u64 offset evaluator (D-475 table64). Mirrors
 /// `evalConstI32ExprCtx`'s single-op shape but returns u64: accepts
 /// `i32.const` (zero-extended), `i64.const` (table64 / memory64), and
-/// `global.get N` of an imported immutable i32 (zero-extended) or i64
-/// global when `ctx` is non-null.
+/// `global.get N` of a readable i32 (zero-extended) or i64 global when
+/// `ctx` is non-null.
 pub fn evalConstOffsetU64Ctx(expr: []const u8, ctx: ?GlobalsCtx) Error!u64 {
     if (expr.len < 2) return Error.UnsupportedConstExpr;
     var pos: usize = 1;
@@ -373,7 +227,7 @@ pub fn evalConstOffsetU64Ctx(expr: []const u8, ctx: ?GlobalsCtx) Error!u64 {
         0x23 => blk: { // global.get N (imported i32 / i64)
             const idx = leb128.readUleb128(u32, expr, &pos) catch return Error.UnsupportedConstExpr;
             const c = ctx orelse return Error.UnsupportedConstExpr;
-            if (idx >= c.num_imports) return Error.UnsupportedConstExpr;
+            if (idx >= c.readable) return Error.UnsupportedConstExpr;
             if (idx >= c.offsets.len or idx >= c.valtypes.len) return Error.UnsupportedConstExpr;
             const off = c.offsets[idx];
             switch (c.valtypes[idx]) {

--- a/src/engine/setup.zig
+++ b/src/engine/setup.zig
@@ -371,20 +371,7 @@ pub fn setupRuntimeLinked(
     const ta = temp_arena.allocator();
     var module = try parser.parse(ta, wasm_bytes);
 
-    // D-225 — `[]*Value` view of the resolved imported-global values, in
-    // import order, for the setup-time const-expr evals' `global.get N`
-    // (N < num_global_imports). ta-allocated: read only during setup.
     const Value = @import("../runtime/value.zig").Value;
-    const imp_global_ptrs: []const *Value = blk: {
-        if (imported_global_vals.len == 0) break :blk &.{};
-        const cells = try ta.alloc(Value, imported_global_vals.len);
-        const ptrs = try ta.alloc(*Value, imported_global_vals.len);
-        for (imported_global_vals, 0..) |v, i| {
-            cells[i] = .{ .bits64 = v };
-            ptrs[i] = &cells[i];
-        }
-        break :blk ptrs;
-    };
 
     var num_func_imports: u32 = 0;
     // ADR-0134 D3 — imported-tag count + a within-module aliasing map
@@ -640,6 +627,15 @@ pub fn setupRuntimeLinked(
     for (0..num_global_imports) |i| {
         globals_buf[i] = .{ .bits64 = if (i < imported_global_vals.len) imported_global_vals[i] else 0 };
     }
+    // D-225 / #397 — `[]*Value` view of every global slot, in index order,
+    // for the setup-time const-expr evals' `global.get N`: a prefix of it is
+    // the window §3.3.13.1 gives each expression. ta-allocated: read only
+    // during setup.
+    const global_ptrs: []const *Value = blk: {
+        const ptrs = try ta.alloc(*Value, globals_total);
+        for (ptrs, 0..) |*p, i| p.* = &globals_buf[i];
+        break :blk ptrs;
+    };
 
     // 10.G GC-on-JIT (ADR-0128 §2): materialise the GC heap + type table
     // for modules with a GC type section BEFORE the global-init loop, so
@@ -737,9 +733,12 @@ pub fn setupRuntimeLinked(
         for (g.items, 0..) |gd, i| {
             // Defined globals follow the import slots (D-225) to match the
             // import-inclusive emitted-code layout.
+            // §3.3.13.1 — the init may read the imports and the globals
+            // defined before it, all evaluated by now.
+            const readable = global_ptrs[0 .. num_global_imports + i];
             globals_buf[num_global_imports + i] = instantiate.evalConstExprValue(gd.init_expr) catch |e| blk: {
                 if (e == error.UnsupportedConstExpr) {
-                    break :blk instantiate.evalGlobalInitGc(gd.init_expr, gc_heap_typed, gti_val, func_entities, imp_global_ptrs) catch |e2| {
+                    break :blk instantiate.evalGlobalInitGc(gd.init_expr, gc_heap_typed, gti_val, func_entities, readable) catch |e2| {
                         // A real GC-heap resource trap (the 4 GiB cap — e.g. a
                         // too-large `array.new` const-expr, D-472) must FAIL
                         // instantiation, matching the interp path
@@ -844,14 +843,15 @@ pub fn setupRuntimeLinked(
     // i31ref/ref table trapped on i31.get/use). evalConstExprValue handles
     // ref.null/numeric; evalGlobalInitGc handles ref.i31 / ref.func /
     // struct.new / array.new (with the heap + func_entities built above).
-    // `global.get` of an IMPORTED global in the init-expr is not yet
-    // resolved here (imported_globals = &.{}) — the cross-module piece.
+    // `global.get` in the init-expr reads an imported global only — the
+    // scope §3.3.13.1 gives a table init, and the one `compileWasm` judged
+    // it against; evaluation gets the same prefix (PR #428 review).
     {
         const gti_val: ?gc_type_info.GcTypeInfos = if (gc_type_infos_typed) |t| t.* else null;
         for (table_metas, 0..) |tm, i| {
             if (tm.init_expr.len == 0) continue;
             const v = instantiate.evalConstExprValue(tm.init_expr) catch
-                instantiate.evalGlobalInitGc(tm.init_expr, gc_heap_typed, gti_val, func_entities, imp_global_ptrs) catch continue;
+                instantiate.evalGlobalInitGc(tm.init_expr, gc_heap_typed, gti_val, func_entities, global_ptrs[0..num_global_imports]) catch continue;
             // A table init-expr always yields a reftype; `.ref` (== `.bits64`
             // offset in the extern union) holds the ref-encoded u64.
             const raw: u64 = v.ref;
@@ -1116,7 +1116,7 @@ pub fn setupRuntimeLinked(
                     for (seg.item_exprs, 0..) |ie, k| {
                         const v = instantiate.evalConstExprValue(ie) catch |e| blk: {
                             if (e == error.UnsupportedConstExpr) {
-                                break :blk instantiate.evalGlobalInitGc(ie, gc_heap_typed, elem_gti_val, func_entities, imp_global_ptrs) catch Value{ .ref = Value.null_ref };
+                                break :blk instantiate.evalGlobalInitGc(ie, gc_heap_typed, elem_gti_val, func_entities, global_ptrs) catch Value{ .ref = Value.null_ref };
                             }
                             break :blk Value{ .ref = Value.null_ref };
                         };

--- a/src/validate/validator_helpers.zig
+++ b/src/validate/validator_helpers.zig
@@ -212,6 +212,9 @@ pub fn validateConstExpr(
     var stack: [256]ValType = undefined;
     var sp: usize = 0;
     var pos: usize = 0;
+    // A GC form produced a reference whose exact type this walker does not
+    // compute; structure and arity are still judged all the way to `end`.
+    var gc_result = false;
 
     while (pos < expr.len) {
         const op = expr[pos];
@@ -220,6 +223,7 @@ pub fn validateConstExpr(
             0x0B => { // end — must be the last byte, leaving exactly [expected]
                 if (pos != expr.len) return .invalid;
                 if (sp != 1) return .invalid;
+                if (gc_result) return if (expected == .ref) .undeterminable else .invalid;
                 return if (gc_subtype.gcValTypeSubtype(stack[0], expected, scope.types)) .ok else .invalid;
             },
             0x41 => { // i32.const
@@ -282,11 +286,47 @@ pub fn validateConstExpr(
                 sp += 1;
             },
             // GC + extern-convert const forms (struct.new / array.new* /
-            // ref.i31 / any.convert_extern …). Every one of them yields a
-            // reference, so a numeric `expected` can never be satisfied and is
-            // an outright mismatch. Typing them against a reference needs the
-            // full GC type algebra, which this walker declines to judge.
-            0xFB => return if (expected == .ref) .undeterminable else .invalid,
+            // ref.i31 / any.convert_extern …). Each pops a fixed number of
+            // operands, or one per field of the named type, and pushes one
+            // reference — so arity, the terminating `end` and what follows are
+            // judged here; the reference's exact type needs the full GC type
+            // algebra, which this walker declines (`gc_result` → the `end`
+            // arm answers `undeterminable` for a reference `expected` and
+            // `invalid` for a numeric one). Returning at the first `0xFB`
+            // let a numeric suffix through (PR #428 review).
+            0xFB => {
+                const sub = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                const pops: usize = switch (sub) {
+                    0x00, 0x01 => blk: { // struct.new $t (one per field) / struct.new_default $t
+                        const t = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                        if (t >= scope.types.struct_defs.len) return .invalid;
+                        const sd = scope.types.struct_defs[t] orelse return .invalid;
+                        break :blk if (sub == 0x00) sd.fields.len else 0;
+                    },
+                    0x06, 0x07 => blk: { // array.new $t (elem, len) / array.new_default $t (len)
+                        const t = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                        if (t >= scope.types.array_defs.len or scope.types.array_defs[t] == null) return .invalid;
+                        break :blk if (sub == 0x06) 2 else 1;
+                    },
+                    0x08 => blk: { // array.new_fixed $t N
+                        const t = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                        if (t >= scope.types.array_defs.len or scope.types.array_defs[t] == null) return .invalid;
+                        const n = leb128.readUleb128(u32, expr, &pos) catch return .invalid;
+                        break :blk n;
+                    },
+                    0x1A, 0x1B => 1, // any.convert_extern / extern.convert_any (a reference in)
+                    0x1C => 1, // ref.i31 (an i32 in)
+                    else => return .invalid, // not in `is_const`
+                };
+                if (sp < pops) return .invalid;
+                if (sub == 0x1C and std.meta.activeTag(stack[sp - 1]) != .i32) return .invalid;
+                if ((sub == 0x1A or sub == 0x1B) and std.meta.activeTag(stack[sp - 1]) != .ref) return .invalid;
+                sp -= pops;
+                if (sp >= stack.len) return .undeterminable;
+                stack[sp] = ValType.anyref; // placeholder: a reference of unjudged type
+                sp += 1;
+                gc_result = true;
+            },
             else => return .invalid, // not in `is_const`
         }
     }

--- a/src/validate/validator_helpers_tests.zig
+++ b/src/validate/validator_helpers_tests.zig
@@ -63,12 +63,22 @@ test "validateConstExpr: is_const opcode set + arity + global.get mutability (§
     // Trailing bytes after `end`.
     try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x00, 0x0B, 0x41, 0x00 }, .i32, scope));
 
-    // The GC family is admissible per `is_const` but not typed here. Every one
-    // of its forms yields a reference, so the verdict splits on what the
-    // position expects: a reference is undeterminable (an incomplete walker
-    // must not reject a valid module), a numeric type is an outright mismatch.
-    try testing.expectEqual(validator.ConstExprVerdict.undeterminable, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, ValType.anyref, scope));
-    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, .i32, scope));
+    // The GC family is admissible per `is_const` and walked for arity, but
+    // not typed here. Every one of its forms yields a reference, so the
+    // verdict splits on what the position expects: a reference is
+    // undeterminable (an incomplete walker must not reject a valid module), a
+    // numeric type is an outright mismatch. `ref.i31` wraps one i32.
+    try testing.expectEqual(validator.ConstExprVerdict.undeterminable, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0xFB, 0x1C, 0x0B }, ValType.i31ref, scope));
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0xFB, 0x1C, 0x0B }, .i32, scope));
+    // struct.new names a type this (empty) type section does not define.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0xFB, 0x00, 0x03, 0x0B }, ValType.anyref, scope));
+    // The walk continues past the GC form (PR #428 review): a numeric value
+    // left beside the reference, a missing operand, and a non-const GC op
+    // (`array.len`) are each invalid, as they are for the reference
+    // interpreter.
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0xFB, 0x1C, 0x41, 0x02, 0x0B }, ValType.i31ref, scope));
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0xFB, 0x1C, 0x0B }, ValType.i31ref, scope));
+    try testing.expectEqual(validator.ConstExprVerdict.invalid, validator.validateConstExpr(&[_]u8{ 0x41, 0x01, 0xFB, 0x1C, 0xFB, 0x0F, 0x0B }, ValType.i31ref, scope));
 
     // An expression deeper than a single instruction's arity is typed, not
     // waved through: extended-const can push many operands before folding.

--- a/src/zwasm.zig
+++ b/src/zwasm.zig
@@ -379,6 +379,7 @@ test {
     _ = @import("engine/runner_v128_jit_test.zig");
     _ = @import("engine/runner_multiarg_invoke_test.zig");
     _ = @import("engine/runner_trap_test.zig");
+    _ = @import("engine/runner_const_expr_test.zig");
     _ = @import("ir/analysis/loop_info.zig");
     _ = @import("ir/analysis/liveness.zig");
     _ = @import("ir/verifier.zig");

--- a/test/spec/simd_assert_runner.zig
+++ b/test/spec/simd_assert_runner.zig
@@ -162,6 +162,9 @@ fn simdOnModuleLoaded(
         .valtypes = compiled.globals_valtypes,
         .buf = scratch_globals[0..],
         .num_imports = compiled.num_global_imports,
+        // The import slots only: the data offsets below are evaluated
+        // before the defined globals are written.
+        .readable = compiled.num_global_imports,
     };
 
     // §9.9 / 9.9-d-7: write active data-segment bytes so subsequent

--- a/test/spec/spec_assert_runner_non_simd.zig
+++ b/test/spec/spec_assert_runner_non_simd.zig
@@ -245,6 +245,9 @@ fn nonSimdOnModuleLoaded(
         .valtypes = compiled.globals_valtypes,
         .buf = scratch_globals[0..],
         .num_imports = compiled.num_global_imports,
+        // The import slots only: the data offsets below are evaluated
+        // before the defined globals are written.
+        .readable = compiled.num_global_imports,
     };
 
     runner_mod.applyActiveDataSegmentsCtx(
@@ -1899,6 +1902,9 @@ fn nonSimdHandleAssertUninstantiable(
         .valtypes = compiled.globals_valtypes,
         .buf = scratch_globals[0..],
         .num_imports = compiled.num_global_imports,
+        // The import slots only: the data offsets below are evaluated
+        // before the defined globals are written.
+        .readable = compiled.num_global_imports,
     };
     runner_mod.applyTableInitCtx(
         gpa,


### PR DESCRIPTION
Closes #397.

The JIT judged a const expression's validity with its own walker (`runner_validate.validateGlobalInitExpr`), which applied the Wasm 2.0 rule to `global.get`: imports only. The shared validator (`validateConstExpr`) applies 3.0 §3.3.13.1. `compile.zig` now takes the shared validator's verdict with the positional scope the spec gives each expression (a global init sees the globals before it; an active offset sees them all), and `runner_validate.zig` keeps evaluation only. Whatever the evaluator cannot evaluate is a decline (`Unsupported*`), never a validity verdict.

Evaluation of a defined-global read now works in both setup paths: `engine/setup.zig` hands each global init the prefix of the globals buffer evaluated so far; `applyDefinedGlobalsInit` (spec runner) gets a per-global `readable` window, and declines a reference read there because the slot may still hold the `ref.func` placeholder the resolver rewrites later.

Measured on the module in #397 (`(global $b i32 (global.get $a))`), CLI:

| | before | after |
|---|---|---|
| `--engine interp` | 5 | 5 |
| `--engine jit` | `InvalidGlobalInitExpr` | 5 |
| `auto` | 5 (interp) | 5 (JIT) |
| `zwasm compile` | `InvalidGlobalInitExpr` | `UnsupportedGlobalInit` |

Still declines, honestly: the AOT producer's `collectGlobalInits` evaluates single-op inits only (its doc names `global.get` as cycle-2), and a JIT active data/elem offset that reads a defined global (`setup.zig` evaluates offsets without a globals context) — both fall to the interpreter under `.auto`.

Spec lanes (x86_64-linux): `wasm-3.0-assert` identical on both engines (JIT 13906/8/739, the 8 are the known EH float rows). `wasm-2.0-assert` 25539 → 25543 passed, 0 failed; `SKIP-VALIDATOR-GAP` 10 → 6, and the set turned over: the 6 new ones (global.18/19, elem.10/11, data.9/10) are the 2.0-only rule this PR removes, a defined-global `global.get` that 3.0 §3.3.13.1 makes valid; the 10 that closed (global.12/14/15/16, elem.40-42, data.50-52) are arity and type errors the old walker accepted and the shared validator rejects.
