### PR TITLE
capi: a cross-module import binds to the extern the embedder passed, and its types are compared across both spaces (#386, #387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cross-module import through the C API binds to the extern the embedder
+  passed, and its type is compared across both modules' type spaces** (#386,
+  #387). The binder re-resolved the source by the import's field name — an
+  import under a different name failed to instantiate, and an export that
+  happened to share the name was bound in the passed entity's stead — and
+  read the exporter's signature in the importer's type space, so a typed
+  function reference (`(ref $t)`) at a different index failed to link on
+  both engines. Signatures naming a struct or array type still decline on
+  the JIT.
+
 ## [2.6.0] - 2026-08-31
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -1449,6 +1449,8 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/cross_module_func.c", .name = "cross_module_func" }, // #360 cross-module func import on every engine
         .{ .src = "test/c_api_conformance/cross_module_reexport.c", .name = "cross_module_reexport" }, // #388 a re-exported import links, and the chain outlives A
         .{ .src = "test/c_api_conformance/cross_module_abi.c", .name = "cross_module_abi" }, // #390 / #413 overflow args, MEMORY-class results and the arm64 cohort cross the bridge
+        .{ .src = "test/c_api_conformance/cross_module_by_extern.c", .name = "cross_module_by_extern" }, // #386 an import binds to the extern passed, not to the export sharing its field name
+        .{ .src = "test/c_api_conformance/cross_module_type_space.c", .name = "cross_module_type_space" }, // #387 a func import's type-def is compared across both type spaces
         .{ .src = "test/c_api_conformance/instance_new_short_imports.c", .name = "instance_new_short_imports" }, // #392 a short import vector is NULL, not a read past it
         .{ .src = "test/c_api_conformance/auto_rejects_invalid.c", .name = "auto_rejects_invalid" }, // #233 AUTO and JIT return NULL with an INVALID_MODULE trap, AUTO does not retry
         .{

--- a/src/api/handles.zig
+++ b/src/api/handles.zig
@@ -264,9 +264,10 @@ pub const Extern = struct {
     /// For kind = table: index into the source instance's
     /// runtime table list. Only meaningful when `kind == .table`.
     table_idx: u32 = 0,
-    /// For kind = memory: always references the source instance's
-    /// single linear memory (multi-memory unsupported pre-v0.2).
-    /// Only meaningful when `kind == .memory`.
+    /// For kind = memory: index into the source instance's runtime
+    /// memory list (the interpreter carries several under multi-memory;
+    /// the JIT declines such a module). Only meaningful when
+    /// `kind == .memory`.
     memory_idx: u32 = 0,
     /// For kind = global: index into the source instance's
     /// runtime globals list. Only meaningful when `kind == .global`.

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -587,17 +587,23 @@ pub export fn wasm_module_delete(m: ?*Module) callconv(.c) void {
 // Instance constructors / destructors (§9.3 / 3.5 + 3.6)
 // ============================================================
 
-/// Look up the source instance's exported entity descriptor by
-/// `(kind, name)` against `inst.{exports_storage, export_types}`.
+/// Look up the source instance's exported entity descriptor by `(kind,
+/// index)` against `inst.{exports_storage, export_types}`. #386 — the index
+/// is the one the embedder's extern carries (`Func.func_idx`,
+/// `Extern.{table,memory,global}_idx`), so a binding lands on the entity that
+/// was passed, whatever the import's field name says. An entity exported
+/// under several names has one descriptor; the first match serves. A handle
+/// to an unexported entity (a funcref recovered from a table) has no
+/// descriptor here and does not bind — as before, when it had no name.
 fn lookupSourceExportType(
     inst: *const Instance,
     kind: sections.ExportDesc,
-    name: []const u8,
+    idx: u32,
 ) !runtime.ExportType {
     if (inst.exports_storage.len != inst.export_types.len)
         return error.ImportTypeMismatch;
     for (inst.exports_storage, inst.export_types) |exp, et| {
-        if (exp.kind == kind and std.mem.eql(u8, exp.name, name)) return et;
+        if (exp.kind == kind and exp.idx == idx) return et;
     }
     return error.ImportTypeMismatch;
 }
@@ -712,20 +718,17 @@ fn buildBindings(
         const source_inst = ext.instance orelse return error.UnknownImportModule;
         const source_rt = source_inst.runtime orelse return error.UnknownImportModule;
 
+        // #386 — wasm-c-api's import vector is positional: `imports.data[i]`
+        // IS the entity for import `i`, and the import's field name plays no
+        // part in resolving it. Each arm binds the entity the extern names by
+        // index; the name is not consulted.
         switch (it.kind) {
             .func => {
                 const fh = ext.func orelse return error.UnknownImportModule;
-                _ = fh;
-                const source_funcidx = blk: {
-                    for (source_inst.exports_storage) |exp| {
-                        if (exp.kind == .func and std.mem.eql(u8, exp.name, it.name))
-                            break :blk exp.idx;
-                    }
-                    return error.UnknownImportModule;
-                };
-                const src_et = try lookupSourceExportType(source_inst, .func, it.name);
-                const source_sig = switch (src_et) {
-                    .func => |sft| sft.sig,
+                const source_funcidx = fh.func_idx;
+                const src_et = try lookupSourceExportType(source_inst, .func, source_funcidx);
+                const sft = switch (src_et) {
+                    .func => |sft| sft,
                     else => return error.ImportTypeMismatch,
                 };
                 const ctx_ptr = try arena_alloc.create(cross_module.CallCtx);
@@ -734,6 +737,14 @@ fn buildBindings(
                     .source_funcidx = source_funcidx,
                     .dispatch_table = dispatchTable(),
                 };
+                // #387 — hand the exporter's own type section to the type
+                // check, so the two signatures are compared across both type
+                // spaces. What the binding keeps past instantiation is
+                // `source_signature`, whose slices live on the exporter's
+                // arena; `wasm_instance_delete` parks that arena with the
+                // runtime the binding also names, so both outlive the importer
+                // together (the #382 park). `source_types` points into the
+                // exporter's handle and is read at instantiation only.
                 bindings[idx] = .{ .func = .{
                     .host_call = .{
                         .fn_ptr = cross_module.thunk,
@@ -742,13 +753,16 @@ fn buildBindings(
                     .source = .{ .cross_module = .{
                         .source_runtime = source_rt,
                         .source_funcidx = source_funcidx,
-                        .source_signature = source_sig,
+                        .source_signature = sft.sig,
+                        .source_types = if (source_inst.export_src_types) |*t| t else null,
+                        .source_typeidx = sft.typeidx,
+                        .source_final = sft.final,
                     } },
                 } };
             },
             .table => {
                 if (ext.table_idx >= source_rt.tables.len) return error.UnknownImportModule;
-                const src_et = try lookupSourceExportType(source_inst, .table, it.name);
+                const src_et = try lookupSourceExportType(source_inst, .table, ext.table_idx);
                 const desc = switch (src_et) {
                     .table => |t| t,
                     else => return error.ImportTypeMismatch,
@@ -761,18 +775,18 @@ fn buildBindings(
                 } };
             },
             .memory => {
-                const src_et = try lookupSourceExportType(source_inst, .memory, it.name);
+                if (ext.memory_idx >= source_rt.memories.len) return error.UnknownImportModule;
+                const src_et = try lookupSourceExportType(source_inst, .memory, ext.memory_idx);
                 switch (src_et) {
                     .memory => {},
                     else => return error.ImportTypeMismatch,
                 }
-                // D-199 — share the exporter's live memory0 *MemoryInstance.
-                if (source_rt.memories.len == 0) return error.UnknownImportModule;
-                bindings[idx] = .{ .memory = .{ .inst = source_rt.memories[0] } };
+                // D-199 — share the exporter's live *MemoryInstance.
+                bindings[idx] = .{ .memory = .{ .inst = source_rt.memories[ext.memory_idx] } };
             },
             .global => {
                 if (ext.global_idx >= source_rt.globals.len) return error.UnknownImportModule;
-                const src_et = try lookupSourceExportType(source_inst, .global, it.name);
+                const src_et = try lookupSourceExportType(source_inst, .global, ext.global_idx);
                 const desc = switch (src_et) {
                     .global => |g| g,
                     else => return error.ImportTypeMismatch,
@@ -870,42 +884,58 @@ const JitFuncImports = struct {
 /// #360 — resolve one cross-module FUNC import against a JIT-backed source
 /// instance into the D-225 `FuncImportTarget` `initLinked` already consumes.
 /// `error.Unsupported` when the source is interp-backed (JIT-compiled code
-/// cannot enter an interpreter runtime), when it exports no such func, or
-/// when its type is not a subtype of the declared import type — the same
-/// §4.5.10 rule `instantiate.checkImportTypeMatches` applies on the interp
-/// path. Matching is BY NAME, as the interp binder's cross-module arm is.
+/// cannot enter an interpreter runtime), when `func_idx` is not one of its
+/// exported funcs, or when its type-def does not match the declared import
+/// type — the same rule `instantiate.checkImportTypeMatches` applies on the
+/// interp path. #386 — `func_idx` is the one the embedder's extern carries,
+/// so the import binds to that func, whatever export shares its field name.
 fn crossModuleJitTarget(
-    ta: std.mem.Allocator,
     source_inst: *Instance,
+    func_idx: u32,
     it: sections.Import,
     importer_types: *const sections.Types,
 ) error{Unsupported}!setup_mod.FuncImportTarget {
     const jit_ptr = source_inst.jit orelse return error.Unsupported;
     const source_jit: *runner.JitInstance = @ptrCast(@alignCast(jit_ptr));
-    const src_et = lookupSourceExportType(source_inst, .func, it.name) catch return error.Unsupported;
-    const src_sig = switch (src_et) {
-        .func => |sft| sft.sig,
+    const src_et = lookupSourceExportType(source_inst, .func, func_idx) catch return error.Unsupported;
+    const sft = switch (src_et) {
+        .func => |sft| sft,
         else => return error.Unsupported,
     };
+    const src_sig = sft.sig;
     const want_tidx = it.payload.func_typeidx;
     if (want_tidx >= importer_types.items.len) return error.Unsupported;
     const want_sig = importer_types.items[want_tidx];
-    // #387 — `funcTypeImportCompatible` resolves both signatures in ONE type
-    // space, and the only one in hand here is the importer's. That is sound
-    // while every type is structural, and unsound the moment a signature names
-    // a type INDEX: `(ref $t)` means what `$t` means in the module it came
-    // from. The interp path has the same gap, but it carries
-    // `source_signature` to the call; a resolved JIT target becomes a bridge
-    // thunk jumping straight into the callee's body, so a wrongly accepted
-    // link there is an ABI mismatch rather than a semantic one. Decline the
-    // shape until the exporter's own `Types` are retained (the facade linker's
-    // `export_src_types` + `canonicalEqualCross` is the model). Declining is
-    // NOT a graceful degradation: the `.auto` retry lands in `buildBindings`,
-    // which needs the source's interpreter `Runtime` and a JIT-backed source
-    // has none, so this shape stays unsupported — NULL with no trap, #353's
-    // surface. It is unsupported at `main` too, by the same route, so the
-    // guard withholds an acceptance rather than removing one.
-    if (hasConcreteHeapType(want_sig) or hasConcreteHeapType(src_sig)) return error.Unsupported;
+    // #387 — `instantiateJit` retains the exporter's own type section, so the
+    // two type-defs are compared each in its own space (ADR-0127 PHASE C, the
+    // facade linker's rule): the exporter's def IS the declared one, or
+    // declares it as a supertype. The fallback below is the same-space
+    // structural compare, sound only while both signatures are structural.
+    if (source_inst.export_src_types) |*src_types| {
+        const def_ok = sections.canonicalEqualCross(importer_types, want_tidx, src_types, sft.typeidx) or
+            sections.superReachesCross(src_types, sft.typeidx, importer_types, want_tidx);
+        if (!def_ok) return error.Unsupported;
+    } else {
+        if (!validator_helpers.funcTypeImportCompatible(want_sig, src_sig, importer_types))
+            return error.Unsupported;
+        if (importer_types.finals[want_tidx] and !sft.final) return error.Unsupported;
+    }
+    // The link-time compare above is now cross-space, but what a concrete
+    // heap type means at RUN time is still per instance: `ref.test` /
+    // `ref.cast` / `call_indirect` judge a reference by the type index its
+    // defining instance stamped on it (`FuncEntity.raw_typeidx`, the GC
+    // object's info), and no canonical id crosses the boundary with the
+    // value. Whether a GC value handed from one instance to another is
+    // judged correctly there is not verified — no test passes a struct or
+    // array across instances and casts it, on either engine — so a signature
+    // naming a struct / array type keeps declining. Declining is NOT a
+    // graceful degradation: the `.auto` retry lands in `buildBindings`, which
+    // needs the source's interpreter `Runtime` and a JIT-backed source has
+    // none, so the shape stays unsupported — NULL with no trap, #353's
+    // surface. A typed function reference (`(ref $t)` with `$t` a func type)
+    // is not held back: `call_ref` checks nothing at run time, and
+    // `cross_module_type_space.c` measures the link and the call.
+    if (hasNonFuncConcreteHeapType(want_sig, importer_types) or hasNonFuncConcreteHeapType(src_sig, if (source_inst.export_src_types) |*t| t else null)) return error.Unsupported;
     // #390 / ADR-0228 — the bridge thunk is laid out for the callee's
     // signature, so overflow arguments and MEMORY-class results cross it. What
     // it still does not carry is a v128 parameter: the SysV call site's own
@@ -915,9 +945,7 @@ fn crossModuleJitTarget(
     // Mirrors the host-func sibling above, whose `dispatchPtrFor` declines the
     // signatures ITS bridge does not cover.
     if (hasV128Param(want_sig)) return error.Unsupported;
-    if (!validator_helpers.funcTypeImportCompatible(want_sig, src_sig, importer_types))
-        return error.Unsupported;
-    return source_jit.exportedFuncTarget(ta, it.name) orelse error.Unsupported;
+    return source_jit.funcTarget(func_idx) orelse error.Unsupported;
 }
 
 /// #390 / ADR-0228 — the one shape the signature-aware bridge still declines
@@ -935,14 +963,18 @@ test "hasV128Param: only a v128 parameter is declined; results and every scalar 
     try testing.expect(hasV128Param(.{ .params = &.{ .i32, .v128 }, .results = &.{} }));
 }
 
-/// #387 — does this signature name a type-section INDEX anywhere? Such a type
-/// is only meaningful in its own module, so a single-type-space comparison
-/// cannot judge it across a module boundary.
-fn hasConcreteHeapType(sig: zir.FuncType) bool {
+/// #387 — does this signature name a type-section INDEX that is not a func
+/// type (a struct or array def)? `types` is the space the signature's indices
+/// live in; with none retained, any concrete index counts (nothing can say it
+/// is a func).
+fn hasNonFuncConcreteHeapType(sig: zir.FuncType, types: ?*const sections.Types) bool {
     for ([_][]const zir.ValType{ sig.params, sig.results }) |half| {
         for (half) |vt| switch (vt) {
             .ref => |r| switch (r.heap_type) {
-                .concrete => return true,
+                .concrete => |tidx| {
+                    const t = types orelse return true;
+                    if (tidx >= t.kinds.len or t.kinds[tidx] != .func) return true;
+                },
                 .abstract => {},
             },
             else => {},
@@ -1038,12 +1070,12 @@ fn collectFromExterns(
         if (i >= arr.len) return error.Unsupported; // #392 — short vector
         const ext = arr[i] orelse return error.Unsupported;
         if (ext.kind != .func) return error.Unsupported;
+        const fh = ext.func orelse return error.Unsupported;
         if (ext.instance) |source_inst| {
-            cross[i] = try crossModuleJitTarget(ta, source_inst, it, &types);
+            cross[i] = try crossModuleJitTarget(source_inst, fh.func_idx, it, &types);
             any_cross = true;
             continue;
         }
-        const fh = ext.func orelse return error.Unsupported;
         const payload = fh.host orelse return error.Unsupported;
         const dp = jit_host_bridge.dispatchPtrFor(payload.params, payload.results, func_idx) orelse return error.Unsupported;
         try host.append(ta, .{ .idx = func_idx, .dispatch_ptr = dp, .payload = @intFromPtr(payload) });
@@ -1230,7 +1262,16 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
                 null;
             const exports = sections.decodeExports(a, export_section.body) catch break :blk false;
             inst.exports_storage = exports.items;
-            inst.export_types = instantiate.buildExportTypes(a, rt_module, exports.items, imports_decoded) catch break :blk false;
+            // #387 — retain the type section too, as the interp path does
+            // (`instantiate.zig`), so an importer can compare type-defs across
+            // both spaces (`crossModuleJitTarget`); `export_types` aliases
+            // its entries. Read at the importer's link only, while this
+            // handle is alive; the arena goes with the handle at
+            // `wasm_instance_delete`, and nothing an importer keeps points
+            // into it (its bridge thunk names the parked `JitInstance`, whose
+            // `func_sigs` outlive the handle).
+            inst.export_src_types = if (rt_module.find(.type)) |ts| (sections.decodeTypes(a, ts.body) catch break :blk false) else null;
+            inst.export_types = instantiate.buildExportTypes(a, rt_module, exports.items, imports_decoded, if (inst.export_src_types) |*t| t else null) catch break :blk false;
             break :blk true;
         };
         if (!built) {
@@ -1241,8 +1282,11 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
             alloc.destroy(inst);
             return error.Declined;
         }
-        // Retain the arena only if it backs live export storage; else release it.
+        // Retain the arena only if it backs live export storage; else release
+        // it — and with it the type section decoded above, which nothing can
+        // ask for through an instance that exports nothing (PR #434 review).
         if (inst.exports_storage.len > 0) inst.arena = arena else {
+            inst.export_src_types = null;
             arena.deinit();
             alloc.destroy(arena);
         }
@@ -3818,6 +3862,65 @@ test "D-497 JIT C-path: wasm_table_grow on a funcref table (host fail-safe fill)
     try testing.expectEqual(@as(u32, 3), wasm_table_size(tab));
 }
 
+test "#386 lookupSourceExportType resolves by func index, not by export name" {
+    // (module (func (export "a") (result i32) (i32.const 1))
+    //         (func (export "b") (param i32) (result i32) (local.get 0)))
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+    var bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x0a, 0x02, 0x60, 0x00, 0x01, 0x7f, 0x60,
+        0x01, 0x7f, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00,
+        0x01, 0x07, 0x09, 0x02, 0x01, 0x61, 0x00, 0x00,
+        0x01, 0x62, 0x00, 0x01, 0x0a, 0x0b, 0x02, 0x04,
+        0x00, 0x41, 0x01, 0x0b, 0x04, 0x00, 0x20, 0x00,
+        0x0b,
+    };
+    const bv: ByteVec = .{ .size = bytes.len, .data = &bytes };
+    const m = wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer wasm_module_delete(m);
+    for ([_]EngineKind{ .interp, .jit }) |engine| {
+        const inst = instanceNewWithEngine(s, m, null, null, engine) orelse return error.InstanceAllocFailed;
+        defer wasm_instance_delete(inst);
+        // Func 1 is the one-parameter export "b"; the index, not the name, selects it.
+        const b = try lookupSourceExportType(inst, .func, 1);
+        try testing.expectEqual(@as(usize, 1), b.func.sig.params.len);
+        try testing.expectEqual(@as(u32, 1), b.func.typeidx);
+        const a = try lookupSourceExportType(inst, .func, 0);
+        try testing.expectEqual(@as(usize, 0), a.func.sig.params.len);
+        try testing.expectError(error.ImportTypeMismatch, lookupSourceExportType(inst, .func, 2));
+        try testing.expectError(error.ImportTypeMismatch, lookupSourceExportType(inst, .table, 0));
+        // #387 — both engines retain the exporter's type section for the
+        // cross-space compare, and the export sigs alias it.
+        const types = inst.export_src_types orelse return error.TypesNotRetained;
+        try testing.expectEqual(@as(usize, 2), types.items.len);
+        try testing.expectEqual(types.items[1].params.ptr, b.func.sig.params.ptr);
+    }
+}
+
+test "#387 a JIT instance that exports nothing retains neither its arena nor a type section pointing into it (PR #434 review)" {
+    // (module (type (func))) with an empty export section: a type section
+    // to decode, no extern to hand out.
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+    var bytes = [_]u8{
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00, // type ()->()
+        0x07, 0x01, 0x00, // export section, count 0
+    };
+    const bv: ByteVec = .{ .size = bytes.len, .data = &bytes };
+    const m = wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer wasm_module_delete(m);
+    const inst = instanceNewWithEngine(s, m, null, null, .jit) orelse return error.InstanceAllocFailed;
+    defer wasm_instance_delete(inst);
+    try testing.expect(inst.arena == null);
+    try testing.expect(inst.export_src_types == null);
+}
+
 test "ADR-0200 JIT C-path: export_types parallel to exports_storage so by-name discovery resolves (wast_runtime_runner regression)" {
     // (module (func (export "add") (param i32 i32) (result i32) local.get 0 local.get 1 i32.add))
     // The .auto-flip reverted because a JIT instance populated exports_storage but
@@ -3846,7 +3949,7 @@ test "ADR-0200 JIT C-path: export_types parallel to exports_storage so by-name d
     // The invariant the C discovery path requires: parallel arrays.
     try testing.expectEqual(@as(usize, 1), inst.exports_storage.len);
     try testing.expectEqual(inst.exports_storage.len, inst.export_types.len);
-    const et = try lookupSourceExportType(inst, .func, "add");
+    const et = try lookupSourceExportType(inst, .func, 0);
     try testing.expectEqual(@as(usize, 2), et.func.sig.params.len);
     try testing.expectEqual(@as(usize, 1), et.func.sig.results.len);
 

--- a/src/engine/runner.zig
+++ b/src/engine/runner.zig
@@ -1096,11 +1096,20 @@ pub const JitInstance = struct {
     /// / `Module.jit_borrowers`); other callers keep it by hand.
     pub fn exportedFuncTarget(self: *JitInstance, allocator: Allocator, name: []const u8) ?setup_mod.FuncImportTarget {
         const idx = findExportFunc(allocator, self.wasm_bytes, name) catch return null;
+        return self.funcTarget(idx);
+    }
+
+    /// The same target for a func named by its index in this module's func
+    /// space (imports ++ defined). #386 — the C API binds a cross-module
+    /// import to the func the embedder's extern names, not to whichever
+    /// export shares the import's field name, so it resolves by index.
+    pub fn funcTarget(self: *JitInstance, idx: u32) ?setup_mod.FuncImportTarget {
         if (idx < self.compiled.num_imports) {
             if (idx >= self.import_targets.len) return null;
             const t = self.import_targets[idx];
             return if (t.callee_entry != 0) t else null;
         }
+        if (idx >= self.compiled.func_sigs.len) return null;
         return .{
             .callee_rt = @intFromPtr(&self.owned.rt),
             .callee_entry = self.compiled.module.entryAddr(idx),

--- a/src/runtime/instance/import.zig
+++ b/src/runtime/instance/import.zig
@@ -23,6 +23,7 @@
 
 const runtime_mod = @import("../runtime.zig");
 const zir = @import("../../ir/zir.zig");
+const sections = @import("../../parse/sections.zig");
 
 const Runtime = runtime_mod.Runtime;
 const Value = runtime_mod.Value;
@@ -60,6 +61,20 @@ pub const FuncImport = struct {
             source_runtime: *Runtime,
             source_funcidx: u32,
             source_signature: zir.FuncType,
+            /// #387 — the exporter's own decoded type section and the func's
+            /// index into it, so `checkImportTypeMatches` compares the two
+            /// type DEFINITIONS across both type spaces
+            /// (`sections.canonicalEqualCross` / `superReachesCross`) instead
+            /// of reading `source_signature`'s concrete indices in the
+            /// importer's space. Null when the exporter retained none; the
+            /// check then falls back to the same-space structural compare
+            /// plus the finality rule. Read at instantiation only, while the
+            /// exporter's handle is alive (the binder took it from the extern
+            /// the embedder passed); nothing dereferences it afterwards.
+            source_types: ?*const sections.Types = null,
+            source_typeidx: u32 = 0,
+            /// The exporter type-def's finality, for the fallback arm.
+            source_final: bool = true,
         },
         wasi: void,
     },

--- a/src/runtime/instance/instantiate.zig
+++ b/src/runtime/instance/instantiate.zig
@@ -836,22 +836,21 @@ fn preDecodeSectionBodies(alloc: std.mem.Allocator, module: *Module) bool {
 /// - Global: walk imports + decoded globals for type info.
 /// - Table: walk imports + decoded tables for elem_type + limits.
 /// - Memory: walk imports + decoded memories for limits.
+/// `types` is the module's RETAINED type section (`Instance.export_src_types`):
+/// a func entry's `sig` aliases `types.items[typeidx]`, so the `Types` must
+/// outlive the returned slice. Decoding a throwaway copy here instead left
+/// `sig` pointing into a freed child arena — which an arena parent reclaims
+/// and the next allocation overwrites (#387 surfaced it on the JIT path).
 pub fn buildExportTypes(
     a: std.mem.Allocator,
     module: Module,
     exports_items: []sections.Export,
     imports_decoded: ?sections.Imports,
+    types: ?*const sections.Types,
 ) ![]ExportType {
     if (exports_items.len == 0) return &.{};
     const out = try a.alloc(ExportType, exports_items.len);
     errdefer a.free(out);
-
-    // Decode the type section once (used for func sig resolution).
-    var types_owned: ?sections.Types = null;
-    defer if (types_owned) |*t| t.deinit();
-    if (module.find(.type)) |s| {
-        types_owned = try sections.decodeTypes(a, s.body);
-    }
     var func_section_funcs: ?[]u32 = null;
     if (module.find(.function)) |s| {
         func_section_funcs = try sections.decodeFunctions(a, s.body);
@@ -885,7 +884,7 @@ pub fn buildExportTypes(
                         if (it.kind != .func) continue;
                         if (idx == exp.idx) {
                             const tidx = it.payload.func_typeidx;
-                            const t = types_owned orelse return error.UnsupportedImport;
+                            const t = types orelse return error.UnsupportedImport;
                             break :blk .{ .func = .{ .sig = t.items[tidx], .final = t.finals[tidx], .typeidx = tidx } };
                         }
                         idx += 1;
@@ -897,7 +896,7 @@ pub fn buildExportTypes(
                 const fs = func_section_funcs orelse return error.UnsupportedImport;
                 if (def_idx >= fs.len) return error.UnsupportedImport;
                 const tidx = fs[def_idx];
-                const t = types_owned orelse return error.UnsupportedImport;
+                const t = types orelse return error.UnsupportedImport;
                 break :blk .{ .func = .{ .sig = t.items[tidx], .final = t.finals[tidx], .typeidx = tidx } };
             },
             .table => blk: {
@@ -1620,11 +1619,12 @@ pub fn instantiateRuntime(
     if (module.find(.@"export")) |export_section| {
         const exports = try sections.decodeExports(a, export_section.body);
         inst.exports_storage = exports.items;
-        inst.export_types = try buildExportTypes(a, module, exports.items, imports_decoded);
         // ADR-0127 PHASE C — retain the exporter's full type section (arena-
         // backed, freed by arena.deinit) so a cross-module func import can run
-        // the cross-`Types` type-def identity check at link resolve.
+        // the cross-`Types` type-def identity check at link resolve. Decoded
+        // first: `export_types` aliases its entries.
         inst.export_src_types = if (module.find(.type)) |ts_sec| try sections.decodeTypes(a, ts_sec.body) else null;
+        inst.export_types = try buildExportTypes(a, module, exports.items, imports_decoded, if (inst.export_src_types) |*t| t else null);
         // EH cross-module tag exports (10.E-xmodule-tags): tag exports
         // (kind 0x04) are dropped from exports_storage (c_api ExternKind
         // lacks a tag variant), so scan the export section directly for
@@ -1670,17 +1670,32 @@ fn checkImportTypeMatches(
             const want_ft = types.items[want_tidx];
             switch (binding.func.source) {
                 .cross_module => |cm| {
-                    // Wasm 3.0 §4.5.10 — the PROVIDED func type must be a
-                    // SUBTYPE of the declared import type (func subtyping,
-                    // §3.3.5.1), not exact-equal. cyc192 (D-198 .30/.48/.50):
-                    // a cross-module module imports the same name under
-                    // multiple subtype-related sigs. Monotonic-safe vs the
-                    // prior exact `eql` — only widens acceptance, so the
-                    // green multi-mem + EH cross-module imports (all eql) are
-                    // unaffected.
+                    // #387 — with the exporter's `Types` in hand, the rule is
+                    // the facade linker's (ADR-0127 PHASE C): the exporter's
+                    // type-def IS the declared one (`canonicalEqualCross`) or
+                    // declares it as a supertype (`superReachesCross`), each
+                    // index read in its own module's space. `source_signature`
+                    // is not consulted here — a `(ref $t)` in it means what
+                    // `$t` means in the EXPORTER, which `types` cannot say.
+                    if (cm.source_types) |src_types| {
+                        const def_ok = sections.canonicalEqualCross(&types, want_tidx, src_types, cm.source_typeidx) or
+                            sections.superReachesCross(src_types, cm.source_typeidx, &types, want_tidx);
+                        if (!def_ok) return error.ImportTypeMismatch;
+                        return;
+                    }
+                    // No retained exporter types: Wasm 3.0 §4.5.10 — the
+                    // PROVIDED func type must be a SUBTYPE of the declared
+                    // import type (func subtyping, §3.3.5.1), not exact-equal.
+                    // cyc192 (D-198 .30/.48/.50): a cross-module module imports
+                    // the same name under multiple subtype-related sigs. Read
+                    // in ONE type space (the importer's) — sound only while
+                    // both signatures are structural. The facade linker runs
+                    // this same compare plus its own cross-space check before
+                    // handing the binding here.
                     if (!validator.funcTypeImportCompatible(want_ft, cm.source_signature, &types)) {
                         return error.ImportTypeMismatch;
                     }
+                    if (types.finals[want_tidx] and !cm.source_final) return error.ImportTypeMismatch;
                 },
                 .wasi => {
                     // WASI binding-side guarantees the lookup

--- a/test/c_api_conformance/cross_module_by_extern.c
+++ b/test/c_api_conformance/cross_module_by_extern.c
@@ -1,0 +1,244 @@
+/* zwasm v2 — C-API conformance: a cross-module import binds to the extern
+ * the embedder passed, not to whichever export shares the import's field name.
+ *
+ * wasm-c-api's import vector is positional: `imports.data[i]` is the entity
+ * for import `i`, and the field name is the importer's business alone. Before
+ * #386 the binder re-resolved the source by looking the FIELD NAME up among
+ * the exporter's exports, with two consequences, both pinned here:
+ *
+ *   alias — the exporter has no export by that name: instantiation failed
+ *           (NULL) although a matching extern was passed;
+ *   decoy — the exporter exports a DIFFERENT entity under that name: the
+ *           import bound the decoy (the interpreter returned its value, the
+ *           JIT's bridge thunk jumped to its body), or its descriptor was
+ *           checked in the passed entity's stead.
+ *
+ * Funcs run on `auto`, `jit` and `interp`. Tables, memories and globals run
+ * with the exporter on `interp` and the importer on `auto` and `interp`: the
+ * JIT satisfies no non-func import today and reaches for the exporter's
+ * interpreter runtime, so a JIT-backed exporter cannot lend those kinds.
+ * Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (func (export "original") (result i32) (i32.const 42))
+ *         (func (export "renamed") (result i32) (i32.const 7))) */
+static const uint8_t kExporterFuncs[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00, 0x00, 0x07, 0x16, 0x02, 0x08,
+    0x6f, 0x72, 0x69, 0x67, 0x69, 0x6e, 0x61, 0x6c, 0x00, 0x00, 0x07, 0x72,
+    0x65, 0x6e, 0x61, 0x6d, 0x65, 0x64, 0x00, 0x01, 0x0a, 0x0b, 0x02, 0x04,
+    0x00, 0x41, 0x2a, 0x0b, 0x04, 0x00, 0x41, 0x07, 0x0b,
+};
+
+/* (module (import "x" "nope" (func (result i32)))
+ *         (func (export "call") (result i32) (call 0))) */
+static const uint8_t kImporterFuncAlias[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x0a, 0x01, 0x01, 0x78, 0x04, 0x6e, 0x6f, 0x70,
+    0x65, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x63,
+    0x61, 0x6c, 0x6c, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00,
+    0x0b,
+};
+
+/* (module (import "x" "renamed" (func (result i32)))
+ *         (func (export "call") (result i32) (call 0))) */
+static const uint8_t kImporterFuncDecoy[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x0d, 0x01, 0x01, 0x78, 0x07, 0x72, 0x65, 0x6e,
+    0x61, 0x6d, 0x65, 0x64, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x07, 0x08,
+    0x01, 0x04, 0x63, 0x61, 0x6c, 0x6c, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04,
+    0x00, 0x10, 0x00, 0x0b,
+};
+
+/* (module (table (export "tab_decoy") 2 funcref) (table (export "tab_orig") 3 funcref)
+ *         (memory (export "mem_decoy") 2) (memory (export "mem_orig") 1)
+ *         (global (export "g_decoy") i32 (i32.const 7)) (global (export "g_orig") i32 (i32.const 42))) */
+static const uint8_t kExporterEntities[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x04, 0x07, 0x02, 0x70,
+    0x00, 0x02, 0x70, 0x00, 0x03, 0x05, 0x05, 0x02, 0x00, 0x02, 0x00, 0x01,
+    0x06, 0x0b, 0x02, 0x7f, 0x00, 0x41, 0x07, 0x0b, 0x7f, 0x00, 0x41, 0x2a,
+    0x0b, 0x07, 0x42, 0x06, 0x09, 0x74, 0x61, 0x62, 0x5f, 0x64, 0x65, 0x63,
+    0x6f, 0x79, 0x01, 0x00, 0x08, 0x74, 0x61, 0x62, 0x5f, 0x6f, 0x72, 0x69,
+    0x67, 0x01, 0x01, 0x09, 0x6d, 0x65, 0x6d, 0x5f, 0x64, 0x65, 0x63, 0x6f,
+    0x79, 0x02, 0x00, 0x08, 0x6d, 0x65, 0x6d, 0x5f, 0x6f, 0x72, 0x69, 0x67,
+    0x02, 0x01, 0x07, 0x67, 0x5f, 0x64, 0x65, 0x63, 0x6f, 0x79, 0x03, 0x00,
+    0x06, 0x67, 0x5f, 0x6f, 0x72, 0x69, 0x67, 0x03, 0x01,
+};
+
+/* (module (import "x" "nope_t" (table 3 funcref)) (import "x" "nope_m" (memory 1))
+ *         (import "x" "nope_g" (global i32))
+ *         (func (export "tsize") (result i32) (table.size 0))
+ *         (func (export "msize") (result i32) (memory.size))
+ *         (func (export "gget") (result i32) (global.get 0))) */
+static const uint8_t kImporterEntitiesAlias[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x26, 0x03, 0x01, 0x78, 0x06, 0x6e, 0x6f, 0x70,
+    0x65, 0x5f, 0x74, 0x01, 0x70, 0x00, 0x03, 0x01, 0x78, 0x06, 0x6e, 0x6f,
+    0x70, 0x65, 0x5f, 0x6d, 0x02, 0x00, 0x01, 0x01, 0x78, 0x06, 0x6e, 0x6f,
+    0x70, 0x65, 0x5f, 0x67, 0x03, 0x7f, 0x00, 0x03, 0x04, 0x03, 0x00, 0x00,
+    0x00, 0x07, 0x18, 0x03, 0x05, 0x74, 0x73, 0x69, 0x7a, 0x65, 0x00, 0x00,
+    0x05, 0x6d, 0x73, 0x69, 0x7a, 0x65, 0x00, 0x01, 0x04, 0x67, 0x67, 0x65,
+    0x74, 0x00, 0x02, 0x0a, 0x11, 0x03, 0x05, 0x00, 0xfc, 0x10, 0x00, 0x0b,
+    0x04, 0x00, 0x3f, 0x00, 0x0b, 0x04, 0x00, 0x23, 0x00, 0x0b,
+};
+
+/* Same as the alias importer, importing "tab_decoy" / "mem_decoy" / "g_decoy". */
+static const uint8_t kImporterEntitiesDecoy[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x05, 0x01, 0x60,
+    0x00, 0x01, 0x7f, 0x02, 0x2d, 0x03, 0x01, 0x78, 0x09, 0x74, 0x61, 0x62,
+    0x5f, 0x64, 0x65, 0x63, 0x6f, 0x79, 0x01, 0x70, 0x00, 0x03, 0x01, 0x78,
+    0x09, 0x6d, 0x65, 0x6d, 0x5f, 0x64, 0x65, 0x63, 0x6f, 0x79, 0x02, 0x00,
+    0x01, 0x01, 0x78, 0x07, 0x67, 0x5f, 0x64, 0x65, 0x63, 0x6f, 0x79, 0x03,
+    0x7f, 0x00, 0x03, 0x04, 0x03, 0x00, 0x00, 0x00, 0x07, 0x18, 0x03, 0x05,
+    0x74, 0x73, 0x69, 0x7a, 0x65, 0x00, 0x00, 0x05, 0x6d, 0x73, 0x69, 0x7a,
+    0x65, 0x00, 0x01, 0x04, 0x67, 0x67, 0x65, 0x74, 0x00, 0x02, 0x0a, 0x11,
+    0x03, 0x05, 0x00, 0xfc, 0x10, 0x00, 0x0b, 0x04, 0x00, 0x3f, 0x00, 0x0b,
+    0x04, 0x00, 0x23, 0x00, 0x0b,
+};
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+typedef struct {
+    wasm_module_t* module;
+    wasm_instance_t* instance;
+    wasm_extern_vec_t exports;
+} link_t;
+
+static int link_up(wasm_store_t* store, uint8_t engine, const char* who, const char* label,
+                   const uint8_t* wasm, size_t len, wasm_extern_vec_t* imports, link_t* out) {
+    wasm_byte_vec_t binary = { len, (wasm_byte_t*) wasm };
+    out->module = wasm_module_new(store, &binary);
+    if (!out->module) { fprintf(stderr, "[%s] %s failed to parse\n", who, label); return 1; }
+    wasm_trap_t* trap = NULL;
+    out->instance = zwasm_instance_new_ex(store, out->module, imports, &trap, engine);
+    if (trap) wasm_trap_delete(trap);
+    if (!out->instance) { fprintf(stderr, "[%s] %s failed to instantiate\n", who, label); return 1; }
+    wasm_instance_exports(out->instance, &out->exports);
+    return 0;
+}
+
+static void unlink_all(link_t* l) {
+    if (l->exports.data) wasm_extern_vec_delete(&l->exports);
+    l->exports.data = NULL;
+    if (l->instance) wasm_instance_delete(l->instance);
+    l->instance = NULL;
+    if (l->module) wasm_module_delete(l->module);
+    l->module = NULL;
+}
+
+/* Call export `i` of `l` (no args, one i32 result) and compare. */
+static int expect_i32(const char* who, const char* label, link_t* l, size_t i, int32_t want) {
+    if (l->exports.size <= i || !l->exports.data[i] ||
+        wasm_extern_kind(l->exports.data[i]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] %s: export %zu is not a func\n", who, label, i);
+        return 1;
+    }
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(l->exports.data[i]), &no_args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] %s: export %zu trapped\n", who, label, i);
+        wasm_trap_delete(trap);
+        return 1;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != want) {
+        fprintf(stderr, "[%s] %s: export %zu returned kind=%d value=%d, want %d\n",
+                who, label, i, (int) results[0].kind, (int) results[0].of.i32, (int) want);
+        return 1;
+    }
+    return 0;
+}
+
+/* The exporter's "original" (export 0) satisfies an import whose field name
+ * is either absent from the exporter (alias) or names its "renamed" decoy. */
+static int funcs_on(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    link_t x = { 0 }, alias = { 0 }, decoy = { 0 };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    if (link_up(store, engine, who, "func exporter", kExporterFuncs, sizeof(kExporterFuncs), &no_imports, &x) != 0) goto cleanup;
+    if (x.exports.size != 2) { fprintf(stderr, "[%s] func exporter exposed %zu externs\n", who, x.exports.size); goto cleanup; }
+
+    wasm_extern_t* externs[1] = { x.exports.data[0] }; /* "original" */
+    wasm_extern_vec_t imports = { 1, externs };
+    if (link_up(store, engine, who, "func importer (alias)", kImporterFuncAlias, sizeof(kImporterFuncAlias), &imports, &alias) != 0) goto cleanup;
+    if (expect_i32(who, "alias", &alias, 0, 42) != 0) goto cleanup;
+    if (link_up(store, engine, who, "func importer (decoy)", kImporterFuncDecoy, sizeof(kImporterFuncDecoy), &imports, &decoy) != 0) goto cleanup;
+    if (expect_i32(who, "decoy", &decoy, 0, 42) != 0) goto cleanup;
+    rc = 0;
+
+cleanup:
+    unlink_all(&decoy);
+    unlink_all(&alias);
+    unlink_all(&x);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+/* The exporter's `*_orig` table / memory / global (exports 1, 3, 5) satisfy
+ * imports whose field names are absent (alias) or name the `*_decoy` siblings.
+ * The decoys differ in what the importer can observe: the decoy table is too
+ * small for the import's `(table 3 funcref)`, the decoy memory has two pages
+ * where the original has one, the decoy global holds 7. */
+static int entities_on(uint8_t importer_engine) {
+    int rc = 1;
+    const char* who = engine_name(importer_engine);
+    link_t x = { 0 }, alias = { 0 }, decoy = { 0 };
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    if (link_up(store, ZWASM_ENGINE_INTERP, who, "entity exporter", kExporterEntities, sizeof(kExporterEntities), &no_imports, &x) != 0) goto cleanup;
+    if (x.exports.size != 6) { fprintf(stderr, "[%s] entity exporter exposed %zu externs\n", who, x.exports.size); goto cleanup; }
+
+    wasm_extern_t* externs[3] = { x.exports.data[1], x.exports.data[3], x.exports.data[5] };
+    wasm_extern_vec_t imports = { 3, externs };
+    static const char* const labels[3] = { "table size", "memory size", "global value" };
+    static const int32_t wants[3] = { 3, 1, 42 };
+    if (link_up(store, importer_engine, who, "entity importer (alias)", kImporterEntitiesAlias, sizeof(kImporterEntitiesAlias), &imports, &alias) != 0) goto cleanup;
+    for (size_t i = 0; i < 3; i++) if (expect_i32(who, labels[i], &alias, i, wants[i]) != 0) goto cleanup;
+    if (link_up(store, importer_engine, who, "entity importer (decoy)", kImporterEntitiesDecoy, sizeof(kImporterEntitiesDecoy), &imports, &decoy) != 0) goto cleanup;
+    for (size_t i = 0; i < 3; i++) if (expect_i32(who, labels[i], &decoy, i, wants[i]) != 0) goto cleanup;
+    rc = 0;
+
+cleanup:
+    unlink_all(&decoy);
+    unlink_all(&alias);
+    unlink_all(&x);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    static const uint8_t func_engines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
+    static const uint8_t entity_engines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_INTERP };
+    for (size_t i = 0; i < sizeof(func_engines) / sizeof(func_engines[0]); i++) {
+        if (funcs_on(func_engines[i]) != 0) return 1;
+    }
+    for (size_t i = 0; i < sizeof(entity_engines) / sizeof(entity_engines[0]); i++) {
+        if (entities_on(entity_engines[i]) != 0) return 1;
+    }
+    return 0;
+}

--- a/test/c_api_conformance/cross_module_type_space.c
+++ b/test/c_api_conformance/cross_module_type_space.c
@@ -1,0 +1,162 @@
+/* zwasm v2 — C-API conformance: a cross-module func import's type is compared
+ * across both modules' type spaces.
+ *
+ * A signature that names a type INDEX — `(ref $cb)` — means what `$cb` means
+ * in the module the signature came from. Before #387 the binder read the
+ * exporter's signature in the IMPORTER's type space: here the exporter's
+ * `(ref 1)` would be read as the importer's type 1, the wrong type, so a link
+ * that is valid by Wasm 3.0 §4.5.10 failed (NULL) on both engines. The
+ * exporter's types are now retained, and the two type-definitions are compared
+ * canonically (`canonicalEqualCross` / `superReachesCross`).
+ *
+ * `ok` puts `$cb` at index 1 in the exporter and index 0 in the importer; the
+ * definitions are equal, so the import links and the exporter's `apply` calls
+ * back into the importer's `dbl` through the typed reference: 21 * 2. `bad`
+ * declares `$cb` with an i64 parameter, so the definitions differ and
+ * instantiation must fail (NULL, no trap — #353's surface). Both run on `auto`,
+ * `jit` and `interp`. Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (type $pad (func (param i64)))
+ *         (type $cb (func (param i32) (result i32)))
+ *         (type $take (func (param (ref $cb)) (result i32)))
+ *         (func (export "apply") (type $take) (call_ref $cb (i32.const 21) (local.get 0)))) */
+static const uint8_t kExporter[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x10, 0x03, 0x60,
+    0x01, 0x7e, 0x00, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x64, 0x01,
+    0x01, 0x7f, 0x03, 0x02, 0x01, 0x02, 0x07, 0x09, 0x01, 0x05, 0x61, 0x70,
+    0x70, 0x6c, 0x79, 0x00, 0x00, 0x0a, 0x0a, 0x01, 0x08, 0x00, 0x41, 0x15,
+    0x20, 0x00, 0x14, 0x01, 0x0b,
+};
+
+/* (module (type $cb (func (param i32) (result i32)))
+ *         (type $take (func (param (ref $cb)) (result i32)))
+ *         (import "t" "apply" (func $apply (type $take)))
+ *         (func $dbl (type $cb) (i32.mul (local.get 0) (i32.const 2)))
+ *         (elem declare func $dbl)
+ *         (func (export "test") (result i32) (call $apply (ref.func $dbl)))) */
+static const uint8_t kImporterOk[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x10, 0x03, 0x60,
+    0x01, 0x7f, 0x01, 0x7f, 0x60, 0x01, 0x64, 0x00, 0x01, 0x7f, 0x60, 0x00,
+    0x01, 0x7f, 0x02, 0x0b, 0x01, 0x01, 0x74, 0x05, 0x61, 0x70, 0x70, 0x6c,
+    0x79, 0x00, 0x01, 0x03, 0x03, 0x02, 0x00, 0x02, 0x07, 0x08, 0x01, 0x04,
+    0x74, 0x65, 0x73, 0x74, 0x00, 0x02, 0x09, 0x05, 0x01, 0x03, 0x00, 0x01,
+    0x01, 0x0a, 0x10, 0x02, 0x07, 0x00, 0x20, 0x00, 0x41, 0x02, 0x6c, 0x0b,
+    0x06, 0x00, 0xd2, 0x01, 0x10, 0x00, 0x0b,
+};
+
+/* As `ok`, with (type $cb (func (param i64) (result i32))) and a constant `test` body. */
+static const uint8_t kImporterBad[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x10, 0x03, 0x60,
+    0x01, 0x7e, 0x01, 0x7f, 0x60, 0x01, 0x64, 0x00, 0x01, 0x7f, 0x60, 0x00,
+    0x01, 0x7f, 0x02, 0x0b, 0x01, 0x01, 0x74, 0x05, 0x61, 0x70, 0x70, 0x6c,
+    0x79, 0x00, 0x01, 0x03, 0x02, 0x01, 0x02, 0x07, 0x08, 0x01, 0x04, 0x74,
+    0x65, 0x73, 0x74, 0x00, 0x01, 0x0a, 0x06, 0x01, 0x04, 0x00, 0x41, 0x00,
+    0x0b,
+};
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+static int type_space_on(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    wasm_module_t* exporter = NULL; wasm_instance_t* exporter_inst = NULL;
+    wasm_extern_vec_t exporter_exports = { 0, NULL };
+    wasm_module_t* ok = NULL; wasm_instance_t* ok_inst = NULL;
+    wasm_extern_vec_t ok_exports = { 0, NULL };
+    wasm_module_t* bad = NULL;
+    wasm_trap_t* trap = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t exporter_bin = { sizeof(kExporter), (wasm_byte_t*) kExporter };
+    exporter = wasm_module_new(store, &exporter_bin);
+    if (!exporter) { fprintf(stderr, "[%s] exporter failed to parse\n", who); goto cleanup; }
+    wasm_extern_vec_t no_imports = { 0, NULL };
+    exporter_inst = zwasm_instance_new_ex(store, exporter, &no_imports, &trap, engine);
+    if (trap) { wasm_trap_delete(trap); trap = NULL; }
+    if (!exporter_inst) { fprintf(stderr, "[%s] exporter failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(exporter_inst, &exporter_exports);
+    if (exporter_exports.size != 1 || !exporter_exports.data[0]) {
+        fprintf(stderr, "[%s] exporter exposed %zu externs\n", who, exporter_exports.size);
+        goto cleanup;
+    }
+    wasm_extern_t* externs[1] = { exporter_exports.data[0] };
+    wasm_extern_vec_t imports = { 1, externs };
+
+    /* ok: equal definitions at different indices link, and the call goes through. */
+    wasm_byte_vec_t ok_bin = { sizeof(kImporterOk), (wasm_byte_t*) kImporterOk };
+    ok = wasm_module_new(store, &ok_bin);
+    if (!ok) { fprintf(stderr, "[%s] ok importer failed to parse\n", who); goto cleanup; }
+    ok_inst = zwasm_instance_new_ex(store, ok, &imports, &trap, engine);
+    if (trap) { wasm_trap_delete(trap); trap = NULL; }
+    if (!ok_inst) { fprintf(stderr, "[%s] ok importer failed to instantiate\n", who); goto cleanup; }
+    wasm_instance_exports(ok_inst, &ok_exports);
+    if (ok_exports.size != 1 || wasm_extern_kind(ok_exports.data[0]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] ok importer is missing its `test` export\n", who);
+        goto cleanup;
+    }
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t res = { 1, results };
+    trap = wasm_func_call(wasm_extern_as_func(ok_exports.data[0]), &no_args, &res);
+    if (trap) { fprintf(stderr, "[%s] the typed-reference call trapped\n", who); goto cleanup; }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] expected 42 through the typed reference, got kind=%d value=%d\n",
+                who, (int) results[0].kind, (int) results[0].of.i32);
+        goto cleanup;
+    }
+
+    /* bad: differing definitions do not link. */
+    wasm_byte_vec_t bad_bin = { sizeof(kImporterBad), (wasm_byte_t*) kImporterBad };
+    bad = wasm_module_new(store, &bad_bin);
+    if (!bad) { fprintf(stderr, "[%s] bad importer failed to parse\n", who); goto cleanup; }
+    wasm_instance_t* bad_inst = zwasm_instance_new_ex(store, bad, &imports, &trap, engine);
+    if (bad_inst) {
+        fprintf(stderr, "[%s] bad importer instantiated against a differing type definition\n", who);
+        wasm_instance_delete(bad_inst);
+        goto cleanup;
+    }
+    if (trap) {
+        fprintf(stderr, "[%s] bad importer produced a trap where NULL alone was expected\n", who);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    if (trap) wasm_trap_delete(trap);
+    if (ok_exports.data) wasm_extern_vec_delete(&ok_exports);
+    if (ok_inst) wasm_instance_delete(ok_inst);
+    if (ok) wasm_module_delete(ok);
+    if (bad) wasm_module_delete(bad);
+    if (exporter_exports.data) wasm_extern_vec_delete(&exporter_exports);
+    if (exporter_inst) wasm_instance_delete(exporter_inst);
+    if (exporter) wasm_module_delete(exporter);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (type_space_on(kEngines[i]) != 0) return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
One root, two symptoms (the 09-03 comments on both): the C API binder
re-derived the source from the importer's view instead of keeping what the
exporter supplied. The native facade already keeps it and gets both right.

- **Entity by index, not by field name** (#386). `buildBindings` binds the
  entity the extern carries (`Func.func_idx`, `Extern.{table,memory,global}_idx`)
  for all four kinds, and the JIT arm resolves `JitInstance.funcTarget(idx)`.
  The memory arm also stops aliasing `memories[0]`.
- **Types across both spaces** (#387). `instantiateJit` retains the exporter's
  type section as the interp path already did; the binding carries it, and
  `checkImportTypeMatches` / `crossModuleJitTarget` compare type-definitions
  with `canonicalEqualCross || superReachesCross`. The same-space structural
  compare stays as the fallback when no section is retained.
- `buildExportTypes` now takes the retained `Types`: its `sig`s aliased a
  throwaway copy it deinit'ed, which an arena parent reclaims — the retained
  section overwrote it on the JIT path. The interp path re-decoded the same
  bytes into the same place, so it never showed.
- The JIT guard narrows to struct / array types. A typed function reference
  links and calls on every engine (measured below); what stays unverified is
  run-time identity of a GC value across instances, stated at the guard.

Before / after, `zig build test-c-api-conformance` at 84917edcf vs this branch:

| case | before | after |
|---|---|---|
| `cross_module_by_extern.c` — `"original"` extern for `(import "x" "nope")` | NULL on `auto` (first case; `jit` / `interp` and the decoy / table / memory / global cases unreached) | 42 on all three; decoys unbound |
| `cross_module_type_space.c` — `(ref $cb)` at index 1 vs 0 | NULL on `auto` | links and returns 42 on all three; the differing def is NULL, no trap |

Public prose: `include/` and `docs/reference/` grep clean for the diff's
identifiers and for "by name". CHANGELOG `[Unreleased]` carries one Fixed line.

Closes #386
Closes #387
