### PR TITLE
capi(interp): a re-exported import binds to what the re-exporter bound, so a chain reaches its definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ### Fixed
 
+- **On the interpreter, a re-exported import binds to what the re-exporter
+  bound, so a chain reaches its definition** (#427). The binder pointed the
+  importer at the re-exporter's own import slot — a placeholder whose body is
+  `unreachable` — so in a chain A→B→C, C linked and its call trapped. It now
+  folds at link time as the JIT has since #388: C's binding names A's runtime
+  directly, or copies a re-exported host callback's binding, and A stays
+  parked on the store until `wasm_store_delete` however B and C are deleted.
 - **A cross-module import through the C API binds to the extern the embedder
   passed, and its type is compared across both modules' type spaces** (#386,
   #387). The binder re-resolved the source by the import's field name — an

--- a/build.zig
+++ b/build.zig
@@ -1449,6 +1449,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/gc_heap_cap_trap.c", .name = "gc_heap_cap_trap" }, // #361 GC heap cap is OUT_OF_MEMORY
         .{ .src = "test/c_api_conformance/cross_module_func.c", .name = "cross_module_func" }, // #360 cross-module func import on every engine
         .{ .src = "test/c_api_conformance/cross_module_reexport.c", .name = "cross_module_reexport" }, // #388 a re-exported import links, and the chain outlives A
+        .{ .src = "test/c_api_conformance/cross_module_reexport_host.c", .name = "cross_module_reexport_host" }, // #427 a re-exported host callback is reached through the chain
         .{ .src = "test/c_api_conformance/cross_module_abi.c", .name = "cross_module_abi" }, // #390 / #413 overflow args, MEMORY-class results and the arm64 cohort cross the bridge
         .{ .src = "test/c_api_conformance/cross_module_by_extern.c", .name = "cross_module_by_extern" }, // #386 an import binds to the extern passed, not to the export sharing its field name
         .{ .src = "test/c_api_conformance/cross_module_type_space.c", .name = "cross_module_type_space" }, // #387 a func import's type-def is compared across both type spaces

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -608,6 +608,26 @@ fn lookupSourceExportType(
     return error.ImportTypeMismatch;
 }
 
+/// #427 — the `HostCall` an interp runtime bound for func `idx` when `idx`
+/// is one of its imports (`host_calls` is null past them); null for a defined
+/// func or a runtime without imports.
+fn importHostCall(rt: *const runtime.Runtime, idx: u32) ?runtime.HostCall {
+    if (idx >= rt.host_calls.len) return null;
+    return rt.host_calls[idx];
+}
+
+/// A `cross_module.thunk` binding whose `CallCtx` (on the importer's arena)
+/// names `rt`'s func `funcidx` as the callee.
+fn crossModuleHostCall(arena_alloc: std.mem.Allocator, rt: *runtime.Runtime, funcidx: u32) !runtime.HostCall {
+    const ctx_ptr = try arena_alloc.create(cross_module.CallCtx);
+    ctx_ptr.* = .{
+        .source_rt = rt,
+        .source_funcidx = funcidx,
+        .dispatch_table = dispatchTable(),
+    };
+    return .{ .fn_ptr = cross_module.thunk, .ctx = @ptrCast(ctx_ptr) };
+}
+
 /// Pre-resolve all imports declared in `bytes` into Zone-1
 /// native `ImportBinding`s. Returns null when the module has no
 /// imports. Allocates the binding slice + cross-module CallCtx
@@ -731,11 +751,38 @@ fn buildBindings(
                     .func => |sft| sft,
                     else => return error.ImportTypeMismatch,
                 };
-                const ctx_ptr = try arena_alloc.create(cross_module.CallCtx);
-                ctx_ptr.* = .{
-                    .source_rt = source_rt,
-                    .source_funcidx = source_funcidx,
-                    .dispatch_table = dispatchTable(),
+                // #427 — the extern may name one of the exporter's own
+                // IMPORTS (a re-export), and that func slot holds only the
+                // `unreachable` placeholder `instantiate.zig` builds: bind to
+                // what the exporter bound. A cross-module thunk folds to its
+                // target, so this binding names the DEFINING runtime. Any
+                // other `HostCall` (an embedder callback, a WASI thunk) is
+                // copied as it stands and runs on this importer's runtime —
+                // what a `call_indirect` through the exporter's slot already
+                // does (`mvp.zig` callIndirectOp).
+                //
+                // Retention: naming the definer is the dependency the
+                // re-exporter's own binding already carries, and
+                // `parkAsZombie` above is what meets it — an interp runtime is
+                // never freed before its store. `cross_module_reexport.c`
+                // deletes A and B before calling C.
+                var target_rt = source_rt;
+                var target_funcidx = source_funcidx;
+                const host_call: runtime.HostCall = blk: {
+                    const hc = importHostCall(source_rt, source_funcidx) orelse
+                        break :blk try crossModuleHostCall(arena_alloc, source_rt, source_funcidx);
+                    // #439 — an embedder callback's ctx is the payload its
+                    // `wasm_func_t` owns and `wasm_func_delete` frees; the copy
+                    // holds what the re-exporter's binding already held.
+                    if (hc.fn_ptr != cross_module.thunk) break :blk hc;
+                    const inner: *const cross_module.CallCtx = @ptrCast(@alignCast(hc.ctx));
+                    target_rt = inner.source_rt;
+                    target_funcidx = inner.source_funcidx;
+                    // Every link folds, so the exporter's target is already a
+                    // definition (or a host call): one hop, never a walk.
+                    const inner_hc = importHostCall(target_rt, target_funcidx);
+                    std.debug.assert(inner_hc == null or inner_hc.?.fn_ptr != cross_module.thunk);
+                    break :blk try crossModuleHostCall(arena_alloc, target_rt, target_funcidx);
                 };
                 // #387 — hand the exporter's own type section to the type
                 // check, so the two signatures are compared across both type
@@ -745,14 +792,17 @@ fn buildBindings(
                 // runtime the binding also names, so both outlive the importer
                 // together (the #382 park). `source_types` points into the
                 // exporter's handle and is read at instantiation only.
+                //
+                // #440 — these type fields stay the re-exporter's declaration
+                // while the target above is now the definition. The compare is
+                // one-directional (the definition is a subtype of what the
+                // re-exporter declared), so it can miss a link, never accept a
+                // bad one.
                 bindings[idx] = .{ .func = .{
-                    .host_call = .{
-                        .fn_ptr = cross_module.thunk,
-                        .ctx = @ptrCast(ctx_ptr),
-                    },
+                    .host_call = host_call,
                     .source = .{ .cross_module = .{
-                        .source_runtime = source_rt,
-                        .source_funcidx = source_funcidx,
+                        .source_runtime = target_rt,
+                        .source_funcidx = target_funcidx,
                         .source_signature = sft.sig,
                         .source_types = if (source_inst.export_src_types) |*t| t else null,
                         .source_typeidx = sft.typeidx,
@@ -4172,6 +4222,105 @@ test "wasm 2.0 cross-module funcref via wasm_instance_new: B's main dispatches i
     try testing.expect(trap == null);
     try testing.expectEqual(ValKind.i32, results_data[0].kind);
     try testing.expectEqual(@as(i32, 42), results_data[0].of.i32);
+}
+
+// (module (import "x" "get" (func (result i32))) (export "get" (func 0)))
+// #427 fixture — imports one () -> (i32) func and re-exports it under the
+// name the chain tests read. The import's module/field names are not
+// consulted by the binder (#386), so one module serves every link.
+const cross_module_reexport_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7f, // type: () -> (i32)
+    0x02, 0x09, 0x01, 0x01, 0x78, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, // import "x" "get" func typeidx=0
+    0x07, 0x07, 0x01, 0x03, 0x67, 0x65, 0x74, 0x00, 0x00, // export "get" -> func 0 (the import)
+};
+
+/// #427 test helper — instantiate `m` on `engine`, its single import bound
+/// to `source`'s first export. The source's export vector is released
+/// before returning, so the new instance's binding is the only reference
+/// left into `source`.
+fn instantiateImportingFirstExport(s: *Store, m: *const Module, source: *Instance, engine: EngineKind) ?*Instance {
+    var exports: ExternVec = .{ .size = 0, .data = null };
+    wasm_instance_exports(source, &exports);
+    defer wasm_extern_vec_delete(&exports);
+    const ext = (exports.data orelse return null)[0] orelse return null;
+    var imports_arr: [1]?*Extern = .{ext};
+    var imports_vec: ExternVec = .{ .size = imports_arr.len, .data = &imports_arr };
+    return instanceNewWithEngine(s, m, @ptrCast(&imports_vec), null, engine);
+}
+
+test "#427 a chain of re-exports folds at every link: D's binding names A's runtime, and the call reaches A after A, B and C are gone" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+
+    var bytes_a = cross_module_a_wasm;
+    const bv_a: ByteVec = .{ .size = bytes_a.len, .data = &bytes_a };
+    const m_a = wasm_module_new(s, &bv_a) orelse return error.ModuleAAllocFailed;
+    defer wasm_module_delete(m_a);
+    var bytes_r = cross_module_reexport_wasm;
+    const bv_r: ByteVec = .{ .size = bytes_r.len, .data = &bytes_r };
+    const m_r = wasm_module_new(s, &bv_r) orelse return error.ModuleRAllocFailed;
+    defer wasm_module_delete(m_r);
+    var bytes_d = cross_module_b_wasm;
+    const bv_d: ByteVec = .{ .size = bytes_d.len, .data = &bytes_d };
+    const m_d = wasm_module_new(s, &bv_d) orelse return error.ModuleDAllocFailed;
+    defer wasm_module_delete(m_d);
+
+    // A defines; B and C re-export; D imports and calls.
+    const inst_a = instanceNewWithEngine(s, m_a, null, null, .interp) orelse return error.InstanceAAllocFailed;
+    const inst_b = instantiateImportingFirstExport(s, m_r, inst_a, .interp) orelse return error.InstanceBAllocFailed;
+    const inst_c = instantiateImportingFirstExport(s, m_r, inst_b, .interp) orelse return error.InstanceCAllocFailed;
+    const inst_d = instantiateImportingFirstExport(s, m_d, inst_c, .interp) orelse return error.InstanceDAllocFailed;
+    defer wasm_instance_delete(inst_d);
+
+    // The fold, link by link: each importer's entity for its import names A's
+    // runtime and A's func 0 — never the re-exporter's placeholder.
+    const rt_a = inst_a.runtime orelse return error.RuntimeANull;
+    for ([_]*Instance{ inst_b, inst_c, inst_d }) |importer| {
+        const rt = importer.runtime orelse return error.RuntimeNull;
+        try testing.expect(rt.func_entities[0].runtime == rt_a);
+        try testing.expectEqual(@as(u32, 0), rt.func_entities[0].func_idx);
+    }
+
+    var exports_d: ExternVec = .{ .size = 0, .data = null };
+    wasm_instance_exports(inst_d, &exports_d);
+    defer wasm_extern_vec_delete(&exports_d);
+    const main_d = wasm_extern_as_func(exports_d.data.?[0]) orelse return error.MainFuncNull;
+
+    // Every earlier link goes before the call (the park keeps A).
+    wasm_instance_delete(inst_a);
+    wasm_instance_delete(inst_b);
+    wasm_instance_delete(inst_c);
+
+    var rd: [1]Val = undefined;
+    var rv: ValVec = .{ .size = 1, .data = &rd };
+    const av: ValVec = .{ .size = 0, .data = null };
+    const trap = wasm_func_call(main_d, &av, &rv);
+    try testing.expect(trap == null);
+    try testing.expectEqual(@as(i32, 42), rd[0].of.i32);
+}
+
+test "#427 an interp importer of a JIT-backed source is still declined: NULL (D4, unchanged)" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+
+    var bytes_a = cross_module_a_wasm;
+    const bv_a: ByteVec = .{ .size = bytes_a.len, .data = &bytes_a };
+    const m_a = wasm_module_new(s, &bv_a) orelse return error.ModuleAAllocFailed;
+    defer wasm_module_delete(m_a);
+    var bytes_b = cross_module_b_wasm;
+    const bv_b: ByteVec = .{ .size = bytes_b.len, .data = &bytes_b };
+    const m_b = wasm_module_new(s, &bv_b) orelse return error.ModuleBAllocFailed;
+    defer wasm_module_delete(m_b);
+
+    const inst_a = instanceNewWithEngine(s, m_a, null, null, .jit) orelse return error.InstanceAAllocFailed;
+    defer wasm_instance_delete(inst_a);
+    try testing.expect(inst_a.runtime == null);
+    try testing.expect(instantiateImportingFirstExport(s, m_b, inst_a, .interp) == null);
 }
 
 test "wasm 2.0 cross-module v128 global via wasm_instance_new: D-170 close" {

--- a/test/c_api_conformance/cross_module_reexport.c
+++ b/test/c_api_conformance/cross_module_reexport.c
@@ -8,21 +8,20 @@
  *
  * C's import is satisfied with B's export extern, which is A's function
  * re-exported. Before #388 a JIT-backed B answered "not a defined function"
- * and C failed to instantiate; the interpreter has always bound this.
+ * and C failed to instantiate; before #427 an interp-backed B bound C's
+ * import to B's own func index 0 — B's import placeholder (body:
+ * `unreachable`, the backstop `instantiate.zig` describes) — so C linked and
+ * the chained call trapped there.
  *
  * Between instantiating C and calling it, A's instance and module are
- * deleted, then B's. C's bridge thunk names A's runtime and entry point
- * (ADR-0228: B hands out what it resolved, so the thunk enters A directly),
- * and nothing counts that reference — A must stay alive until the store
- * goes. `wasm_instance_delete` parks every JIT instance on the store and
+ * deleted, then B's. On both engines C's thunk names A's runtime and entry
+ * point (ADR-0228 / #427: B hands out what it resolved, so the thunk enters A
+ * directly), and nothing counts that reference — A must stay alive until the
+ * store goes. `wasm_instance_delete` parks every instance on the store and
  * `wasm_module_delete` defers a borrowed module's bytes, so it does. If a
  * refcount ever replaced the park, this is the test that would notice.
  *
- * Run on `auto` and `jit`. The interpreter is left out: its binder points
- * C's import at B's runtime and B's func index 0, which is B's import
- * placeholder (body: `unreachable`, the backstop `instantiate.zig` describes),
- * so the chained call traps there today — the same missing fold, in the other
- * engine (#427). Exits 0 on success.
+ * Run on every engine. Exits 0 on success.
  */
 
 #include <stdio.h>
@@ -61,7 +60,7 @@ static const uint8_t kCWasm[] = {
     0x0a, 0x06, 0x01, 0x04, 0x00, 0x10, 0x00, 0x0b,             /* body: call 0 */
 };
 
-static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT };
+static const uint8_t kEngines[] = { ZWASM_ENGINE_AUTO, ZWASM_ENGINE_JIT, ZWASM_ENGINE_INTERP };
 
 static const char* engine_name(uint8_t kind) {
     switch (kind) {

--- a/test/c_api_conformance/cross_module_reexport_host.c
+++ b/test/c_api_conformance/cross_module_reexport_host.c
@@ -1,0 +1,159 @@
+/* zwasm v2 — C-API conformance: a re-exported HOST callback links across the
+ * chain and is reached by the importer's call (#427).
+ *
+ *   h: a `wasm_func_new` callback (i32) -> (i32), returns arg + 1
+ *   B: (module (import "h" "f" (func $f (param i32) (result i32))) (export "f" (func $f)))
+ *   C: (module (import "b" "f" (func $f (param i32) (result i32)))
+ *             (func (export "test") (param i32) (result i32) (local.get 0) (call $f)))
+ *
+ * C's import is satisfied with B's export extern, which is the host callback
+ * re-exported. The binder copies the callback binding B holds into C, so
+ * C's `call` runs the callback on C's own operand stack — the same route a
+ * `call_indirect` through B's slot takes. B is deleted before C is called;
+ * the callback handle stays, as it must (nothing counts its takers).
+ *
+ * Run on `interp` only. On `auto` the re-exporter compiles — a module whose
+ * only func is a host-callback import has nothing the JIT declines — so B is
+ * JIT-backed and has no interpreter runtime for C's binder to read, and the
+ * JIT's own target lookup has no entry address for an import slot a host
+ * callback fills. C links on neither engine there. That is the JIT-side hole
+ * (#388's) plus the unchanged rule that an interp importer cannot bind a
+ * JIT-backed source; measured on `main` at 8c6e19cb4, untouched by #427.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (import "h" "f" (func (param i32) (result i32))) (export "f" (func 0))) */
+static const uint8_t kBWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,             /* type (i32)->(i32) */
+    0x02, 0x07, 0x01, 0x01, 0x68, 0x01, 0x66, 0x00, 0x00,       /* import h.f */
+    0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,                   /* export "f" -> 0 (the import) */
+};
+
+/* (module (import "b" "f" (func (param i32) (result i32)))
+ *         (func (export "test") (param i32) (result i32) (local.get 0) (call 0))) */
+static const uint8_t kCWasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f,             /* type (i32)->(i32) */
+    0x02, 0x07, 0x01, 0x01, 0x62, 0x01, 0x66, 0x00, 0x00,       /* import b.f */
+    0x03, 0x02, 0x01, 0x00,                                     /* func[1]: type 0 */
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x65, 0x73, 0x74, 0x00, 0x01, /* export "test" -> 1 */
+    0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0x10, 0x00, 0x0b, /* local.get 0; call 0 */
+};
+
+static const uint8_t kEngines[] = { ZWASM_ENGINE_INTERP };
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+        case ZWASM_ENGINE_JIT: return "jit";
+        case ZWASM_ENGINE_INTERP: return "interp";
+        default: return "auto";
+    }
+}
+
+static wasm_trap_t* add_one(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
+    results->data[0].kind = WASM_I32;
+    results->data[0].of.i32 = args->data[0].of.i32 + 1;
+    return NULL;
+}
+
+typedef struct {
+    wasm_module_t* module;
+    wasm_instance_t* instance;
+    wasm_extern_vec_t exports;
+} link_t;
+
+static int link_up(wasm_store_t* store, uint8_t engine, const char* who, const char* label,
+                   const uint8_t* wasm, size_t len, wasm_extern_vec_t* imports, link_t* out) {
+    wasm_byte_vec_t binary = { len, (wasm_byte_t*) wasm };
+    out->module = wasm_module_new(store, &binary);
+    if (!out->module) { fprintf(stderr, "[%s] %s failed to parse\n", who, label); return 1; }
+    wasm_trap_t* trap = NULL;
+    out->instance = zwasm_instance_new_ex(store, out->module, imports, &trap, engine);
+    if (trap) wasm_trap_delete(trap);
+    if (!out->instance) { fprintf(stderr, "[%s] %s failed to instantiate\n", who, label); return 1; }
+    wasm_instance_exports(out->instance, &out->exports);
+    if (out->exports.size < 1 || !out->exports.data[0]) {
+        fprintf(stderr, "[%s] %s exposed nothing\n", who, label);
+        return 1;
+    }
+    return 0;
+}
+
+static void unlink_all(link_t* l) {
+    if (l->exports.data) wasm_extern_vec_delete(&l->exports);
+    l->exports.data = NULL;
+    if (l->instance) wasm_instance_delete(l->instance);
+    l->instance = NULL;
+    if (l->module) wasm_module_delete(l->module);
+    l->module = NULL;
+}
+
+static int chain_on(uint8_t engine) {
+    int rc = 1;
+    const char* who = engine_name(engine);
+    link_t b = { 0 }, c = { 0 };
+    wasm_func_t* host_fn = NULL;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_functype_t* ft = wasm_functype_new_1_1(wasm_valtype_new(WASM_I32), wasm_valtype_new(WASM_I32));
+    host_fn = wasm_func_new(store, ft, add_one);
+    wasm_functype_delete(ft);
+    if (!host_fn) { fprintf(stderr, "[%s] wasm_func_new failed\n", who); goto cleanup; }
+
+    wasm_extern_t* b_externs[1] = { wasm_func_as_extern(host_fn) };
+    wasm_extern_vec_t b_imports = { 1, b_externs };
+    if (link_up(store, engine, who, "B (re-exporting the host callback)", kBWasm, sizeof(kBWasm), &b_imports, &b) != 0) goto cleanup;
+
+    wasm_extern_t* c_externs[1] = { b.exports.data[0] };
+    wasm_extern_vec_t c_imports = { 1, c_externs };
+    if (link_up(store, engine, who, "C (importing B's re-export)", kCWasm, sizeof(kCWasm), &c_imports, &c) != 0) goto cleanup;
+    if (wasm_extern_kind(c.exports.data[0]) != WASM_EXTERN_FUNC) {
+        fprintf(stderr, "[%s] C is missing its `test` export\n", who);
+        goto cleanup;
+    }
+
+    /* The re-exporter goes before the call; the callback handle stays. */
+    unlink_all(&b);
+
+    wasm_val_t args_data[1] = { { WASM_I32, { 41 } } };
+    wasm_val_t results[1] = { { WASM_I32, { 0 } } };
+    wasm_val_vec_t args = { 1, args_data };
+    wasm_val_vec_t res = { 1, results };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(c.exports.data[0]), &args, &res);
+    if (trap) {
+        fprintf(stderr, "[%s] the chained call trapped after B was deleted\n", who);
+        wasm_trap_delete(trap);
+        goto cleanup;
+    }
+    if (results[0].kind != WASM_I32 || results[0].of.i32 != 42) {
+        fprintf(stderr, "[%s] expected the callback's 42 through B, got kind=%d value=%d\n",
+                who, (int) results[0].kind, (int) results[0].of.i32);
+        goto cleanup;
+    }
+    rc = 0;
+
+cleanup:
+    unlink_all(&c);
+    unlink_all(&b);
+    if (host_fn) wasm_func_delete(host_fn);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return rc;
+}
+
+int main(void) {
+    for (size_t i = 0; i < sizeof(kEngines) / sizeof(kEngines[0]); i++) {
+        if (chain_on(kEngines[i]) != 0) return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
`--engine interp` bound a re-exported import to the re-exporter's own
import slot — a placeholder whose body is `unreachable` — so in a chain
A→B→C, C linked and its call trapped there. The JIT folded this at link
time in #388; the interpreter now does the same in `buildBindings`.

A cross-module thunk resolves to the runtime and func index its `CallCtx`
names, so C's binding and its `FuncEntity` name A directly and no call
passes through B. Any other `HostCall` — an embedder callback, a WASI
thunk — is copied as it stands and runs on the importer's own runtime,
which is what a `call_indirect` through the exporter's slot already did.
Retention is the existing park: `wasm_instance_delete` never frees an
interp runtime, so A outlives B and C however they are deleted.

**Tests**

- `cross_module_reexport.c` runs `INTERP` again (it was excluded for this
  defect), so all three engines link the chain and call it after A and B
  are deleted.
- `cross_module_reexport_host.c` — new: the chain's root is a
  `wasm_func_new` callback, B re-exports it, C calls it after B is gone.
- Two Zig unit tests: a four-link chain (A→B→C→D) asserting every
  importer's entity names A, and a pin that an interp importer of a
  JIT-backed source still returns NULL.

**Measured, not fixed here.** On `auto`, a module whose only func is a
host-callback import compiles, so the re-exporter is JIT-backed: the
JIT's target lookup has no entry address for an import slot a host
callback fills, and the interpreter's binder has no runtime to read. That
chain links on no engine. Pre-existing on `main` at 8c6e19cb4 and
untouched by this PR; the new conformance test is `interp`-only and its
header records why.

Closes #427
