### PR TITLE
capi: a call shape the engine cannot marshal is ZWASM_TRAP_UNSUPPORTED, not a binding error (#431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ### Fixed
 
+- **A trap message ends with the NUL `wasm.h` declares, and its size says so**
+  (#441). `wasm_trap_message` copied the message bytes alone into a
+  `wasm_message_t` the header types as NUL-terminated, so a C host reading it
+  as a string ran past the allocation — measured at 42 bytes against a `size`
+  of 36. The vector now carries the NUL and counts it, the text being
+  `size - 1` bytes, and `wasm_trap_new` takes a host message either way so a
+  round trip keeps its length.
+
 - **A call shape the engine cannot marshal is `ZWASM_TRAP_UNSUPPORTED`, not
   `ZWASM_TRAP_BINDING_ERROR`** (#431). Calling a valid export with a mixed
   multi-value result — `(result i32 f32)`, a shape the JIT's wrapper thunks do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
   `size - 1` bytes, and `wasm_trap_new` takes a host message either way so a
   round trip keeps its length.
 
+- **A multi-value result is handed over whole or not at all** (#443). The C
+  API marshalled the JIT's results straight into the caller's buffer one at a
+  time, so a reference result that could not allocate its handle left the
+  handles minted before it stranded in a buffer the caller does not own once a
+  trap comes back. The elements are staged now, and the caller's buffer is
+  written only when every one is in hand.
+
 - **A call shape the engine cannot marshal is `ZWASM_TRAP_UNSUPPORTED`, not
   `ZWASM_TRAP_BINDING_ERROR`** (#431). Calling a valid export with a mixed
   multi-value result — `(result i32 f32)`, a shape the JIT's wrapper thunks do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ## [Unreleased]
 
+### Added
+
+- **`ZWASM_TRAP_UNSUPPORTED` (20)** — the trap kind for a call whose shape the
+  instance's engine has no implementation for. Appended, so the existing
+  `ZWASM_TRAP_*` values are unchanged.
+
 ### Changed
 
 - **`zwasm run` has one default-entry contract on every path** (#220,
@@ -26,6 +32,15 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
 
 ### Fixed
 
+- **A call shape the engine cannot marshal is `ZWASM_TRAP_UNSUPPORTED`, not
+  `ZWASM_TRAP_BINDING_ERROR`** (#431). Calling a valid export with a mixed
+  multi-value result — `(result i32 f32)`, a shape the JIT's wrapper thunks do
+  not cover — reported the embedder's binding as wrong, on the default engine
+  and on `--engine jit` alike, while `--engine interp` returned both values.
+  The kind now separates the two, and its message names the shape. The
+  interpreter still marshals every shape, and `zwasm run` prints the reason
+  instead of `binding_error`.
+
 - **On the interpreter, a re-exported import binds to what the re-exporter
   bound, so a chain reaches its definition** (#427). The binder pointed the
   importer at the re-exporter's own import slot — a placeholder whose body is
@@ -33,6 +48,7 @@ SemVer compatibility guarantees start at the first stable `v2.0.0` tag.
   folds at link time as the JIT has since #388: C's binding names A's runtime
   directly, or copies a re-exported host callback's binding, and A stays
   parked on the store until `wasm_store_delete` however B and C are deleted.
+
 - **A cross-module import through the C API binds to the extern the embedder
   passed, and its type is compared across both modules' type spaces** (#386,
   #387). The binder re-resolved the source by the import's field name — an

--- a/build.zig
+++ b/build.zig
@@ -1455,6 +1455,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/cross_module_type_space.c", .name = "cross_module_type_space" }, // #387 a func import's type-def is compared across both type spaces
         .{ .src = "test/c_api_conformance/instance_new_short_imports.c", .name = "instance_new_short_imports" }, // #392 a short import vector is NULL, not a read past it
         .{ .src = "test/c_api_conformance/auto_rejects_invalid.c", .name = "auto_rejects_invalid" }, // #233 AUTO and JIT return NULL with an INVALID_MODULE trap, AUTO does not retry
+        .{ .src = "test/c_api_conformance/trap_unsupported_shape.c", .name = "trap_unsupported_shape" }, // #431 a call shape the engine cannot marshal is UNSUPPORTED, not BINDING_ERROR
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/build.zig
+++ b/build.zig
@@ -1456,6 +1456,7 @@ pub fn build(b: *std.Build) void {
         .{ .src = "test/c_api_conformance/instance_new_short_imports.c", .name = "instance_new_short_imports" }, // #392 a short import vector is NULL, not a read past it
         .{ .src = "test/c_api_conformance/auto_rejects_invalid.c", .name = "auto_rejects_invalid" }, // #233 AUTO and JIT return NULL with an INVALID_MODULE trap, AUTO does not retry
         .{ .src = "test/c_api_conformance/trap_unsupported_shape.c", .name = "trap_unsupported_shape" }, // #431 a call shape the engine cannot marshal is UNSUPPORTED, not BINDING_ERROR
+        .{ .src = "test/c_api_conformance/trap_message_nul.c", .name = "trap_message_nul" }, // #441 a trap message is NUL-terminated and its size counts the NUL
         .{
             .src = "test/c_api_conformance/wasi_preopen.c",
             .name = "wasi_preopen",

--- a/docs/examples/c_host/hello.c
+++ b/docs/examples/c_host/hello.c
@@ -40,7 +40,11 @@ static void print_trap_and_delete(wasm_trap_t* trap) {
     if (!trap) return;
     wasm_message_t msg;
     wasm_trap_message(trap, &msg);
-    fprintf(stderr, "trap: %.*s\n", (int)msg.size, msg.data);
+    /* `wasm_message_t` is NUL-terminated and its size counts that NUL (#441),
+     * so the vector reads as a plain C string — but `wasm_trap_message` leaves
+     * it `{0, NULL}` when it cannot allocate the copy, and `%s` has no meaning
+     * for a null pointer. */
+    fprintf(stderr, "trap: %s\n", msg.data ? msg.data : "");
     wasm_byte_vec_delete(&msg);
     wasm_trap_delete(trap);
 }

--- a/docs/examples/rust_host/hello.rs
+++ b/docs/examples/rust_host/hello.rs
@@ -128,8 +128,11 @@ unsafe fn print_trap_and_delete(trap: *mut wasm_trap_t) {
     }
     let mut msg = wasm_byte_vec_t { size: 0, data: ptr::null_mut() };
     wasm_trap_message(trap, &mut msg);
-    if !msg.data.is_null() {
-        let bytes = std::slice::from_raw_parts(msg.data, msg.size);
+    // `wasm_trap_message` leaves the vector `{0, NULL}` when it cannot
+    // allocate, so both halves are checked before the length arithmetic below.
+    if !msg.data.is_null() && msg.size > 0 {
+        // `size` counts the terminating NUL (#441); drop it for the text.
+        let bytes = std::slice::from_raw_parts(msg.data, msg.size - 1);
         eprintln!("trap: {}", String::from_utf8_lossy(bytes));
     }
     wasm_byte_vec_delete(&mut msg);

--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -57,6 +57,14 @@ alone cannot separate a clean termination from a fault, and
 - trap **and** `false` — a genuine fault (unreachable, out of bounds, …).
   `wasm_trap_message` / `zwasm_trap_kind` describe it.
 
+**Reading a trap message.** `wasm_trap_message` fills a `wasm_message_t`, which
+upstream declares NUL-terminated (`include/wasm.h:393`) in the shape
+`wasm_name_new_from_string_nt` produces: the vector **carries the terminating
+NUL and `size` counts it**, so `data` reads as a C string and the text is
+`size - 1` bytes (#441). `wasm_trap_new` accepts a host message either way —
+with the NUL inside `size` or without — so a message that crosses the boundary
+in both directions keeps its length.
+
 The status is **per call** — each `wasm_func_call` into the Store clears it
 before running, so a `true` describes the call just made and never an earlier
 guest's (#341). Read it before calling into the Store again, or creating

--- a/docs/reference/c_api.md
+++ b/docs/reference/c_api.md
@@ -86,8 +86,10 @@ post-instantiate and re-armable mid-workload (v1's config-level
 instance: the JIT where it takes the module, the interpreter where the JIT
 *declines* it (an import it cannot satisfy, a body it cannot compile). A module
 the JIT judges *invalid* is not retried on the interpreter: `NULL`, with a
-`ZWASM_TRAP_INVALID_MODULE` trap whose message names the verdict (#233). To
-force the engine from C, use
+`ZWASM_TRAP_INVALID_MODULE` trap whose message names the verdict (#233). The
+fallback is at instantiation only — a decline reached at call time, where the
+instance is already JIT-backed, traps `ZWASM_TRAP_UNSUPPORTED` naming the shape
+(#431). To force the engine from C, use
 `zwasm_instance_new_ex(store, module, imports, trap_out, engine_kind)`
 with `ZWASM_ENGINE_AUTO` / `ZWASM_ENGINE_JIT` / `ZWASM_ENGINE_INTERP`.
 `zwasm_instance_get_func(instance, idx)` fetches an export function by index
@@ -99,7 +101,7 @@ with `ZWASM_ENGINE_AUTO` / `ZWASM_ENGINE_JIT` / `ZWASM_ENGINE_INTERP`.
 | `zwasm_instance_fuel_remaining(i, &out)`                            | remaining budget; returns `false` when unmetered                                                                                         |
 | `zwasm_instance_set_memory_pages_limit(i, p)` / `…_clear_…(i)`    | host ceiling below the declared max; `memory.grow` past it returns the spec `-1`                                                         |
 | `zwasm_instance_interrupt(i)` / `zwasm_instance_clear_interrupt(i)` | cooperative cancel/timeout from any thread; traps `interrupted` (kind 16) at the next poll                                               |
-| `zwasm_trap_kind(trap)`                                             | machine-readable trap kind beside wasm.h's message-only surface (`ZWASM_TRAP_INTERRUPTED`/`ZWASM_TRAP_OUT_OF_FUEL` macros); `-1` on NULL. Host-originated traps are separable from guest faults on every engine — `ZWASM_TRAP_WASI_EXIT` (18) for a `proc_exit`, `ZWASM_TRAP_BINDING_ERROR` (0) for a host callback's own trap (ADR-0218); `ZWASM_TRAP_INVALID_MODULE` (19) is the JIT's validity verdict at instantiation (#233) |
+| `zwasm_trap_kind(trap)`                                             | machine-readable trap kind beside wasm.h's message-only surface (`ZWASM_TRAP_INTERRUPTED`/`ZWASM_TRAP_OUT_OF_FUEL` macros); `-1` on NULL. Host-originated traps are separable from guest faults on every engine — `ZWASM_TRAP_WASI_EXIT` (18) for a `proc_exit`, `ZWASM_TRAP_BINDING_ERROR` (0) for a host callback's own trap (ADR-0218); `ZWASM_TRAP_INVALID_MODULE` (19) is the JIT's validity verdict at instantiation (#233); `ZWASM_TRAP_UNSUPPORTED` (20) is a call shape the instance's engine has no helper for, as against `BINDING_ERROR`'s wrong argument or result count (#431) |
 
 ## Not shipped (`zwasm.h` residuals)
 

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -113,6 +113,11 @@ WASM_API_EXTERN void zwasm_instance_clear_interrupt(wasm_instance_t*);
 #define ZWASM_TRAP_UNSUPPORTED 20
 WASM_API_EXTERN int32_t zwasm_trap_kind(const wasm_trap_t*);
 
+/* The message beside the kind: wasm.h's wasm_trap_message fills a
+ * wasm_message_t that carries its terminating NUL, with size counting it, so
+ * the vector reads as a C string and the text is size - 1 bytes. Symmetrically
+ * wasm_trap_new takes a host message with or without the NUL inside size. */
+
 /* ── Instance helpers ────────────────────────────────────────────────── */
 
 /* Resolve an instance + defined-function index into a fresh, owned func

--- a/include/zwasm.h
+++ b/include/zwasm.h
@@ -78,6 +78,10 @@ WASM_API_EXTERN void zwasm_instance_clear_interrupt(wasm_instance_t*);
 /* Machine-readable trap kind beside wasm.h's message-only surface; -1 on
  * NULL. Values mirror the `TrapKind` enum (src/api/trap_surface.zig), which is
  * append-only stable; a C host can switch on these without string-matching. */
+
+/* The embedder's binding is wrong: an argument or result count that is not the
+ * signature's, or a host callback's own trap. A shape the engine cannot call
+ * is ZWASM_TRAP_UNSUPPORTED. */
 #define ZWASM_TRAP_BINDING_ERROR 0
 #define ZWASM_TRAP_UNREACHABLE 1
 #define ZWASM_TRAP_DIV_BY_ZERO 2
@@ -103,6 +107,10 @@ WASM_API_EXTERN void zwasm_instance_clear_interrupt(wasm_instance_t*);
  * make yet): zwasm_instance_new_ex returns NULL with this trap on AUTO and JIT,
  * and AUTO does not retry on the interpreter. The message names the verdict. */
 #define ZWASM_TRAP_INVALID_MODULE 19
+/* The engine that owns this instance has no implementation for this call's
+ * shape. Not a guest trap and not a binding error; AUTO does not retry on the
+ * interpreter at call time. The message names the shape. */
+#define ZWASM_TRAP_UNSUPPORTED 20
 WASM_API_EXTERN int32_t zwasm_trap_kind(const wasm_trap_t*);
 
 /* ── Instance helpers ────────────────────────────────────────────────── */

--- a/src/api/extern_new.zig
+++ b/src/api/extern_new.zig
@@ -1209,7 +1209,8 @@ test "#315 wasm_func_call: the callback's own trap reaches the caller unconsumed
     var msg: vec.ByteVec = .{ .size = 0, .data = null };
     trap_surface.wasm_trap_message(trap, &msg);
     defer vec.wasm_byte_vec_delete(&msg);
-    try testing.expectEqualStrings("host said no", msg.data.?[0..msg.size]);
+    // #441 — `size` counts the NUL; the body is `size - 1`.
+    try testing.expectEqualStrings("host said no", msg.data.?[0 .. msg.size - 1]);
 }
 
 test "#315 wasm_func_call: an arity mismatch on a host func traps" {

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -3305,7 +3305,7 @@ test "#431: a mixed multi-value result the JIT cannot marshal is `unsupported`, 
         var msg: ByteVec = .{ .size = 0, .data = null };
         trap_surface.wasm_trap_message(trap, &msg);
         defer vec.wasm_byte_vec_delete(&msg);
-        const text = msg.data.?[0..msg.size];
+        const text = msg.data.?[0 .. msg.size - 1]; // #441 — `size` counts the NUL
         try testing.expect(std.mem.find(u8, text, "(i32 f32)") != null);
     }
 }

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -2683,8 +2683,17 @@ fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, all
         var rbuf: [16]runner.TypedResult = undefined;
         jit.invokeMultiIdx(func_idx, abuf[0..sig.params.len], rbuf[0..sig.results.len]) catch |err| return jitErrToTrap(err, sig, jit, alloc, store);
         if (results) |r| if (r.data) |dp| {
-            // Null only when a ref result's C handle could not be allocated.
-            for (0..sig.results.len) |idx| dp[idx] = typedResultToCVal(rbuf[idx], inst, alloc) orelse return allocTrap(alloc, store, .out_of_memory);
+            // #443 — a reference result mints an owned handle and the caller
+            // owns nothing when a trap comes back, so `dp` is written only
+            // once every element is in hand.
+            var staged: [16]Val = undefined;
+            for (0..sig.results.len) |idx| {
+                staged[idx] = typedResultToCVal(rbuf[idx], inst, alloc) orelse {
+                    releaseRefVals(staged[0..idx], alloc);
+                    return allocTrap(alloc, store, .out_of_memory);
+                };
+            }
+            @memcpy(dp[0..sig.results.len], staged[0..sig.results.len]);
         };
         return null;
     }
@@ -2695,7 +2704,8 @@ fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, all
     if (sig.results.len == 1 and std.meta.activeTag(sig.results[0]) == .ref) {
         const payload = jit.invokeRefIdx(func_idx, abuf[0..sig.params.len]) catch |err| return jitErrToTrap(err, sig, jit, alloc, store);
         if (results) |r| if (r.data) |dp| {
-            // Null only when the ref's C handle could not be allocated.
+            // Null only when the ref's C handle could not be allocated. No
+            // staging here (#443): one element has nothing minted before it.
             dp[0] = refResultToCVal(sig.results[0], payload, inst, alloc) orelse return allocTrap(alloc, store, .out_of_memory);
         };
         return null;
@@ -2747,6 +2757,17 @@ fn refResultToCVal(vt: zir.ValType, payload: u64, inst: *Instance, alloc: std.me
     const ref_handle = alloc.create(Ref) catch return null;
     ref_handle.* = .{ .instance = inst, .ref = payload };
     return .{ .kind = kind, .of = .{ .ref = ref_handle } };
+}
+
+/// #443 — release the owned `Ref` handles among `vals`, kind-guarded so a
+/// non-ref `of` member is never read as a pointer. Freed with the allocator
+/// that minted them rather than through `wasm_ref_delete`, which recovers the
+/// store's: create and destroy have to pair.
+fn releaseRefVals(vals: []const Val, alloc: std.mem.Allocator) void {
+    for (vals) |v| {
+        if (v.kind != .funcref and v.kind != .anyref) continue;
+        if (v.of.ref) |rp| alloc.destroy(@as(*Ref, @ptrCast(@alignCast(rp))));
+    }
 }
 
 /// Marshal a C `Val` to the JIT host-invoke u64 bit-carrier (i32/f32 in low 32).
@@ -3231,6 +3252,136 @@ test "wasm_func_call: arg-count mismatch returns Trap with message; both freed" 
     try testing.expect(msg.size > 0);
     vec.wasm_byte_vec_delete(&msg);
     trap_surface.wasm_trap_delete(trap);
+}
+
+// ============================================================
+// #443 — a multi-value result is handed over whole or not at all
+// ============================================================
+
+/// Fails exactly the `fail_at`-th allocation and lets every other one through.
+/// `std.testing.FailingAllocator` fails its index and everything after it, which
+/// would also swallow the out-of-memory trap the code under test builds to
+/// report the failure — leaving nothing to assert the kind on.
+const OneShotFailingAllocator = struct {
+    backing: std.mem.Allocator,
+    fail_at: usize,
+    seen: usize = 0,
+
+    fn allocator(self: *OneShotFailingAllocator) std.mem.Allocator {
+        return .{ .ptr = self, .vtable = &.{
+            .alloc = OneShotFailingAllocator.alloc,
+            .resize = OneShotFailingAllocator.resize,
+            .remap = OneShotFailingAllocator.remap,
+            .free = OneShotFailingAllocator.free,
+        } };
+    }
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *OneShotFailingAllocator = @ptrCast(@alignCast(ctx));
+        defer self.seen += 1;
+        if (self.seen == self.fail_at) return null;
+        return self.backing.rawAlloc(len, alignment, ra);
+    }
+    fn resize(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *OneShotFailingAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.rawResize(mem, alignment, new_len, ra);
+    }
+    fn remap(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *OneShotFailingAllocator = @ptrCast(@alignCast(ctx));
+        return self.backing.rawRemap(mem, alignment, new_len, ra);
+    }
+    fn free(ctx: *anyopaque, mem: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *OneShotFailingAllocator = @ptrCast(@alignCast(ctx));
+        self.backing.rawFree(mem, alignment, ra);
+    }
+};
+
+// (module (func $a) (elem declare func $a)
+//         (func (export "pair") (result funcref funcref) (ref.func $a) (ref.func $a)))
+// Two non-null reference results: the JIT thunks a two-GPR shape, and `.ref` is
+// GPR class, so this reaches the multi-value arm with two handles to mint.
+const two_funcref_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x09, 0x02, 0x60,
+    0x00, 0x00, 0x60, 0x00, 0x02, 0x70, 0x70, 0x03, 0x03, 0x02, 0x00, 0x01,
+    0x07, 0x08, 0x01, 0x04, 0x70, 0x61, 0x69, 0x72, 0x00, 0x01, 0x09, 0x05,
+    0x01, 0x03, 0x00, 0x01, 0x00, 0x0a, 0x0b, 0x02, 0x02, 0x00, 0x0b, 0x06,
+    0x00, 0xd2, 0x00, 0xd2, 0x00, 0x0b,
+};
+
+/// A `.jit` instance over `two_funcref_wasm`, with its JIT handle. The caller
+/// deletes the instance; `store` outlives it.
+fn twoFuncrefJitInstance(s: *Store, bytes: *[two_funcref_wasm.len]u8) !struct { inst: *Instance, jit: *runner.JitInstance } {
+    const bv: ByteVec = .{ .size = bytes.len, .data = bytes };
+    const m = wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer wasm_module_delete(m);
+    const i = instanceNewWithEngine(s, m, null, null, .jit) orelse return error.InstanceAllocFailed;
+    errdefer wasm_instance_delete(i);
+    // Without this a JIT that fell back to the interpreter would make the
+    // assertions below vacuous — the interp arm is a different marshaller.
+    try testing.expect(i.jit != null);
+    return .{ .inst = i, .jit = jitOf(i).? };
+}
+
+test "#443: two reference results both reach the caller, and both are its to delete" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+    var bytes = two_funcref_wasm;
+    const h = try twoFuncrefJitInstance(s, &bytes);
+    defer wasm_instance_delete(h.inst);
+    const alloc = storeAllocator(s).?;
+
+    var rdata: [2]Val = undefined;
+    var results: ValVec = .{ .size = 2, .data = &rdata };
+    const args: ValVec = .{ .size = 0, .data = null };
+    try testing.expect(wasmFuncCallJit(h.jit, h.inst, s, alloc, 1, &args, &results) == null);
+    for (rdata) |v| {
+        try testing.expectEqual(ValKind.funcref, v.kind);
+        try testing.expect(v.of.ref != null);
+        wasm_ref_delete(@ptrCast(@alignCast(v.of.ref.?)));
+    }
+}
+
+test "#443: a result the marshaller cannot finish writes nothing and strands no handle" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+    var bytes = two_funcref_wasm;
+    const h = try twoFuncrefJitInstance(s, &bytes);
+    defer wasm_instance_delete(h.inst);
+
+    // The call's own allocations, in order: handle 0, handle 1, then the trap's
+    // message and the trap. Failing index 1 breaks the loop with exactly one
+    // handle already minted — the case the defect strands.
+    var one_shot: OneShotFailingAllocator = .{ .backing = testing.allocator, .fail_at = 1 };
+    const alloc = one_shot.allocator();
+
+    // A sentinel the marshaller must not overwrite: a trap means the caller was
+    // handed nothing, so its buffer is still its own.
+    const sentinel: Val = .{ .kind = .i32, .of = .{ .i32 = 0x5A5A5A5A } };
+    var rdata: [2]Val = .{ sentinel, sentinel };
+    var results: ValVec = .{ .size = 2, .data = &rdata };
+    const args: ValVec = .{ .size = 0, .data = null };
+
+    const trap = wasmFuncCallJit(h.jit, h.inst, s, alloc, 1, &args, &results) orelse return error.CallDidNotTrap;
+    // Released through `alloc`, not `wasm_trap_delete`: the trap was built with
+    // the allocator passed in, while `wasm_trap_delete` recovers the store's.
+    // The two are the same object in production — this test is the one caller
+    // that hands `wasmFuncCallJit` an allocator of its own.
+    defer {
+        if (trap.message_ptr) |mp| alloc.free(mp[0..trap.message_len]);
+        alloc.destroy(trap);
+    }
+    try testing.expectEqual(TrapKind.out_of_memory, trap.kind);
+    // Nothing handed over.
+    for (rdata) |v| {
+        try testing.expectEqual(ValKind.i32, v.kind);
+        try testing.expectEqual(@as(i32, 0x5A5A5A5A), v.of.i32);
+    }
+    // And nothing stranded: `testing.allocator` reports the first handle at the
+    // end of this test if the loop returned without releasing it.
 }
 
 // ============================================================

--- a/src/api/instance.zig
+++ b/src/api/instance.zig
@@ -1257,7 +1257,9 @@ fn instantiateJit(store: *Store, module: *const Module, builder_state: anytype, 
             // JIT is torn down.
             const reject: JitReject = if (err == error.UnsupportedEntrySignature) error.Declined else error.Final;
             if (reject == error.Final) {
-                if (trap_out) |to| to.* = jitErrToTrap(err, jit, alloc, store);
+                // No shape to name: the start is `[] -> []`, and the one
+                // decline it can raise is already `Declined` above (#431).
+                if (trap_out) |to| to.* = allocTrap(alloc, store, jitErrKind(err, jit.owned.rt.trap_kind));
             }
             jit.deinit(alloc);
             alloc.destroy(jit);
@@ -2652,10 +2654,13 @@ pub fn jitOf(inst: *Instance) ?*runner.JitInstance {
     return @ptrCast(@alignCast(jp));
 }
 
-/// ADR-0200 — `wasm_func_call` JIT arm. Resolve func_idx→export name, get the
-/// sig, marshal `Val[]` args → u64, run via `JitInstance.invoke`/`invokeMulti`,
-/// marshal results back. Scalar args+results only (i32/i64/f32/f64); ref/v128
-/// or an uncovered shape → `binding_error` trap (mirrors the Zig facade arm).
+/// ADR-0200 — `wasm_func_call` JIT arm. Resolve func_idx → sig, marshal `Val[]`
+/// args → u64, run via `JitInstance.invokeIdx` / `invokeRefIdx` /
+/// `invokeMultiIdx`, marshal results back. The guards below are the embedder's
+/// binding (`binding_error`); the shapes the engine's entry helpers do not
+/// cover — over 16 params or results, a v128 result, a multi-value shape with
+/// no wrapper thunk — are `unsupported` (#431), named in the message. This is
+/// the one place that list is written; the interpreter arm marshals them all.
 fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, alloc: std.mem.Allocator, func_idx: u32, args: ?*const ValVec, results: ?*ValVec) ?*Trap {
     // D-496/D-498 — dispatch by func_idx, NOT export name: a funcref recovered from
     // a table or `ref.func` (wasm_ref_as_func) need not be exported, so the prior
@@ -2666,7 +2671,8 @@ fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, all
     const results_size = if (results) |r| r.size else 0;
     if (args_size != sig.params.len) return allocTrap(alloc, store, .binding_error);
     if (results_size != sig.results.len) return allocTrap(alloc, store, .binding_error);
-    if (sig.params.len > 16 or sig.results.len > 16) return allocTrap(alloc, store, .binding_error);
+    // The marshalling buffers below hold 16 slots: the engine's limit.
+    if (sig.params.len > 16 or sig.results.len > 16) return unsupportedShapeTrap(alloc, store, sig);
 
     var abuf: [16]u64 = undefined;
     if (args) |a| if (a.data) |dp| {
@@ -2675,9 +2681,10 @@ fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, all
 
     if (sig.results.len > 1) {
         var rbuf: [16]runner.TypedResult = undefined;
-        jit.invokeMultiIdx(func_idx, abuf[0..sig.params.len], rbuf[0..sig.results.len]) catch |err| return jitErrToTrap(err, jit, alloc, store);
+        jit.invokeMultiIdx(func_idx, abuf[0..sig.params.len], rbuf[0..sig.results.len]) catch |err| return jitErrToTrap(err, sig, jit, alloc, store);
         if (results) |r| if (r.data) |dp| {
-            for (0..sig.results.len) |idx| dp[idx] = typedResultToCVal(rbuf[idx], inst, alloc) orelse return allocTrap(alloc, store, .binding_error);
+            // Null only when a ref result's C handle could not be allocated.
+            for (0..sig.results.len) |idx| dp[idx] = typedResultToCVal(rbuf[idx], inst, alloc) orelse return allocTrap(alloc, store, .out_of_memory);
         };
         return null;
     }
@@ -2686,21 +2693,49 @@ fn wasmFuncCallJit(jit: *runner.JitInstance, inst: *Instance, store: *Store, all
     // (the scalar `invokeIdx` runs a ref-result func as void); marshal the raw
     // payload into an owned `*Ref` C handle.
     if (sig.results.len == 1 and std.meta.activeTag(sig.results[0]) == .ref) {
-        const payload = jit.invokeRefIdx(func_idx, abuf[0..sig.params.len]) catch |err| return jitErrToTrap(err, jit, alloc, store);
+        const payload = jit.invokeRefIdx(func_idx, abuf[0..sig.params.len]) catch |err| return jitErrToTrap(err, sig, jit, alloc, store);
         if (results) |r| if (r.data) |dp| {
-            dp[0] = refResultToCVal(sig.results[0], payload, inst, alloc) orelse return allocTrap(alloc, store, .binding_error);
+            // Null only when the ref's C handle could not be allocated.
+            dp[0] = refResultToCVal(sig.results[0], payload, inst, alloc) orelse return allocTrap(alloc, store, .out_of_memory);
         };
         return null;
     }
 
-    const got = jit.invokeIdx(func_idx, abuf[0..sig.params.len]) catch |err| return jitErrToTrap(err, jit, alloc, store);
+    const got = jit.invokeIdx(func_idx, abuf[0..sig.params.len]) catch |err| return jitErrToTrap(err, sig, jit, alloc, store);
     if (sig.results.len == 1) {
         if (results) |r| if (r.data) |dp| {
-            const bits = got orelse return allocTrap(alloc, store, .binding_error);
-            dp[0] = jitBitsToCVal(sig.results[0], bits) orelse return allocTrap(alloc, store, .binding_error);
+            // No value back for a one-result shape, or one the single-u64
+            // carrier cannot hold (v128).
+            const bits = got orelse return unsupportedShapeTrap(alloc, store, sig);
+            dp[0] = jitBitsToCVal(sig.results[0], bits) orelse return unsupportedShapeTrap(alloc, store, sig);
         };
     }
     return null;
+}
+
+/// #431 — an `unsupported` trap whose message names the declined shape, e.g.
+/// `no JIT entry helper for () -> (i32 f32)`. Falls back to the kind's fixed
+/// message when the shape does not fit the buffer.
+fn unsupportedShapeTrap(alloc: std.mem.Allocator, store: *Store, sig: zir.FuncType) ?*Trap {
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    const msg = writeShape(&w, sig) catch return allocTrap(alloc, store, .unsupported);
+    return trap_surface.allocTrapWithMessage(alloc, store, .unsupported, msg);
+}
+
+fn writeShape(w: *std.Io.Writer, sig: zir.FuncType) ![]const u8 {
+    try w.writeAll("no JIT entry helper for (");
+    for (sig.params, 0..) |p, i| {
+        if (i != 0) try w.writeByte(' ');
+        try w.writeAll(p.name());
+    }
+    try w.writeAll(") -> (");
+    for (sig.results, 0..) |r, i| {
+        if (i != 0) try w.writeByte(' ');
+        try w.writeAll(r.name());
+    }
+    try w.writeByte(')');
+    return w.buffered();
 }
 
 /// D-498 — wrap a raw JIT ref payload (u64; funcref = `*FuncEntity` ptr, externref
@@ -2726,7 +2761,7 @@ fn cValToJitBits(v: Val) u64 {
 }
 
 /// Decode a JIT scalar result u64 into a C `Val` by valtype; null for ref/v128
-/// (not retrievable via the single-u64 arm — surfaces as a binding_error trap).
+/// (not retrievable via the single-u64 arm — surfaces as an `unsupported` trap).
 fn jitBitsToCVal(vt: zir.ValType, bits: u64) ?Val {
     return switch (vt) {
         .i32 => .{ .kind = .i32, .of = .{ .i32 = @bitCast(@as(u32, @truncate(bits))) } },
@@ -2871,11 +2906,23 @@ fn verdictTrap(alloc: std.mem.Allocator, store: *Store, err: runner.Error) ?*Tra
     return trap_surface.allocTrapWithMessage(alloc, store, .invalid_module, msg);
 }
 
-fn jitErrToTrap(err: runner.Error, jit: *runner.JitInstance, alloc: std.mem.Allocator, store: *Store) ?*Trap {
+/// #431 — the kind for an error out of a post-instantiate JIT invoke. The
+/// `else` is safe because the three invoke paths raise nothing else once the
+/// module has compiled: `ExportNotFound` needs a func index past the signature
+/// table, which `funcSigByIdx` already refused, and the rest of `runner.Error`
+/// is compile-time names. The generic trap bucket reports `unreachable_` (D-292).
+fn jitErrKind(err: runner.Error, raw_trap_code: u32) TrapKind {
     return switch (err) {
-        error.Trap => allocTrap(alloc, store, trap_surface.jitTrapCode(jit.owned.rt.trap_kind) orelse .unreachable_),
-        else => allocTrap(alloc, store, .binding_error),
+        error.Trap => trap_surface.jitTrapCode(raw_trap_code) orelse .unreachable_,
+        error.UnsupportedEntrySignature => .unsupported,
+        else => .binding_error,
     };
+}
+
+fn jitErrToTrap(err: runner.Error, sig: zir.FuncType, jit: *runner.JitInstance, alloc: std.mem.Allocator, store: *Store) ?*Trap {
+    const kind = jitErrKind(err, jit.owned.rt.trap_kind);
+    if (kind == .unsupported) return unsupportedShapeTrap(alloc, store, sig);
+    return allocTrap(alloc, store, kind);
 }
 
 // ============================================================
@@ -3184,6 +3231,129 @@ test "wasm_func_call: arg-count mismatch returns Trap with message; both freed" 
     try testing.expect(msg.size > 0);
     vec.wasm_byte_vec_delete(&msg);
     trap_surface.wasm_trap_delete(trap);
+}
+
+// ============================================================
+// #431 — a shape the engine cannot call is its own kind
+// ============================================================
+
+// (module (func (export "pair") (result i32 f32) i32.const 1 f32.const 2)
+//         (func (export "id") (param i32) (result i32) local.get 0))
+// `pair` is the mixed multi-value shape the JIT's wrapper thunks do not cover
+// (2-int register-class and 3-int MEMORY-class only); `id` is the contrast —
+// a shape every engine calls, so a mis-bound call to it stays the embedder's.
+const mixed_multi_value_wasm = [_]u8{
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x0b, 0x02, 0x60, 0x00, 0x02, 0x7f, 0x7d,
+    0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x03, 0x02,
+    0x00, 0x01, 0x07, 0x0d, 0x02, 0x04, 0x70, 0x61,
+    0x69, 0x72, 0x00, 0x00, 0x02, 0x69, 0x64, 0x00,
+    0x01, 0x0a, 0x10, 0x02, 0x09, 0x00, 0x41, 0x01,
+    0x43, 0x00, 0x00, 0x00, 0x40, 0x0b, 0x04, 0x00,
+    0x20, 0x00, 0x0b,
+};
+
+/// Call export `idx` of `mixed_multi_value_wasm` on `engine` with `args`, and
+/// return the trap (caller deletes) or null. `results` is the caller's buffer,
+/// so a non-trapping call's values can be read back.
+fn callMixedExport(
+    s: *Store,
+    engine: EngineKind,
+    idx: u32,
+    args: *const ValVec,
+    results: *ValVec,
+) !?*Trap {
+    var bytes = mixed_multi_value_wasm;
+    const bv: ByteVec = .{ .size = bytes.len, .data = &bytes };
+    const m = wasm_module_new(s, &bv) orelse return error.ModuleAllocFailed;
+    defer wasm_module_delete(m);
+    const i = instanceNewWithEngine(s, m, null, null, engine) orelse return error.InstanceAllocFailed;
+    defer wasm_instance_delete(i);
+    // Without this a JIT that silently fell back to the interpreter would make
+    // the assertions below vacuous.
+    switch (engine) {
+        .jit => try testing.expect(i.jit != null),
+        .interp => try testing.expect(i.runtime != null),
+        // `.auto`'s backend is deliberately unpinned — which engine it picks is
+        // documented to change without an API break.
+        .auto => {},
+    }
+    const func = zwasm_instance_get_func(i, idx) orelse return error.FuncResolveFailed;
+    defer wasm_func_delete(func);
+    return wasm_func_call(func, args, results);
+}
+
+test "#431: a mixed multi-value result the JIT cannot marshal is `unsupported`, and the message names the shape" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+
+    // `.auto` is the default engine, and a call-time decline cannot fall back:
+    // the instance is already JIT-backed. So it answers as `.jit` does.
+    for ([_]EngineKind{ .jit, .auto }) |engine| {
+        var results_data: [2]Val = undefined;
+        var results: ValVec = .{ .size = 2, .data = &results_data };
+        const args: ValVec = .{ .size = 0, .data = null };
+        const trap = (try callMixedExport(s, engine, 0, &args, &results)) orelse return error.CallDidNotTrap;
+        defer trap_surface.wasm_trap_delete(trap);
+        // The defect: this was `binding_error`, which says the embedder bound
+        // the call wrong. It did not — the engine has no helper for the shape.
+        try testing.expectEqual(TrapKind.unsupported, trap.kind);
+        try testing.expect(trap.kind != .binding_error);
+
+        var msg: ByteVec = .{ .size = 0, .data = null };
+        trap_surface.wasm_trap_message(trap, &msg);
+        defer vec.wasm_byte_vec_delete(&msg);
+        const text = msg.data.?[0..msg.size];
+        try testing.expect(std.mem.find(u8, text, "(i32 f32)") != null);
+    }
+}
+
+test "#431: the interpreter marshals the same shape, so the decline is the engine's and not the module's" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+
+    var results_data: [2]Val = undefined;
+    var results: ValVec = .{ .size = 2, .data = &results_data };
+    const args: ValVec = .{ .size = 0, .data = null };
+    const trap = try callMixedExport(s, .interp, 0, &args, &results);
+    try testing.expect(trap == null);
+    try testing.expectEqual(ValKind.i32, results_data[0].kind);
+    try testing.expectEqual(@as(i32, 1), results_data[0].of.i32);
+    try testing.expectEqual(ValKind.f32, results_data[1].kind);
+    try testing.expectEqual(@as(f32, 2.0), results_data[1].of.f32);
+}
+
+test "#431: an argument count that is not the signature's stays `binding_error` on the JIT" {
+    const e = wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_engine_delete(e);
+    const s = wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_store_delete(s);
+
+    // `id` takes one i32 and the JIT calls its shape; passing none is the
+    // embedder's own error, and the new kind must not swallow it.
+    var results_data: [1]Val = undefined;
+    var results: ValVec = .{ .size = 1, .data = &results_data };
+    const args: ValVec = .{ .size = 0, .data = null };
+    const trap = (try callMixedExport(s, .jit, 1, &args, &results)) orelse return error.CallDidNotTrap;
+    defer trap_surface.wasm_trap_delete(trap);
+    try testing.expectEqual(TrapKind.binding_error, trap.kind);
+}
+
+test "#431: jitErrKind splits a guest fault, an engine decline and the embedder's binding" {
+    // A guest trap reads the runtime's recorded code (5 = the `unreachable`
+    // stub); an unrecorded one is the D-292 generic bucket.
+    try testing.expectEqual(TrapKind.unreachable_, jitErrKind(error.Trap, 5));
+    try testing.expectEqual(TrapKind.oob_memory, jitErrKind(error.Trap, 6));
+    try testing.expectEqual(TrapKind.unreachable_, jitErrKind(error.Trap, 0));
+    // The shape decline — the whole of #431.
+    try testing.expectEqual(TrapKind.unsupported, jitErrKind(error.UnsupportedEntrySignature, 0));
+    // Everything else is a compile-time name a post-instantiate invoke does not
+    // raise; it stays in the embedder bucket, as before.
+    try testing.expectEqual(TrapKind.binding_error, jitErrKind(error.ExportIsNotFunction, 0));
 }
 
 // Extern-vec null-arg coverage lives here alongside

--- a/src/api/trap_surface.zig
+++ b/src/api/trap_surface.zig
@@ -237,12 +237,20 @@ pub fn allocTrapWithMessage(alloc: std.mem.Allocator, store: ?*wasm_c_api.Store,
 /// to surface their own host-side errors as traps; the binding
 /// itself prefers `allocTrap` with a `TrapKind` so it can map
 /// runtime conditions to the spec-conformant strings.
+///
+/// #441 — the inbound half of the `wasm_message_t` convention. Upstream
+/// spells the same string two ways: `wasm_name_new_from_string` sizes it
+/// `strlen(s)` and `..._nt` sizes it `strlen(s) + 1` (`include/wasm.h:108-118`).
+/// A trailing NUL is dropped here so the stored `message_len` is the body
+/// either way, which is what makes the round-trip through `wasm_trap_message`
+/// length-preserving.
 pub export fn wasm_trap_new(s: ?*wasm_c_api.Store, message: ?*const wasm_c_api.ByteVec) callconv(.c) ?*Trap {
     const store = s orelse return null;
     const alloc = wasm_c_api.storeAllocator(store) orelse return null;
     const m = message orelse return null;
     const data_ptr = m.data orelse return null;
-    const buf = alloc.dupe(u8, data_ptr[0..m.size]) catch return null;
+    const body_len = if (m.size > 0 and data_ptr[m.size - 1] == 0) m.size - 1 else m.size;
+    const buf = alloc.dupe(u8, data_ptr[0..body_len]) catch return null;
     const t = alloc.create(Trap) catch {
         alloc.free(buf);
         return null;
@@ -286,6 +294,13 @@ pub export fn wasm_trap_delete(t: ?*Trap) callconv(.c) void {
 /// the caller and must be released via `wasm_byte_vec_delete`).
 /// Writes a zero-length vec if the trap has no message or
 /// allocation fails.
+///
+/// INVARIANT (#441): `out.size` COUNTS the terminating NUL, and
+/// `out.data[out.size - 1] == 0`. `wasm_message_t` is upstream's
+/// `_nt` shape (`include/wasm.h:393`), so a C host may read the
+/// vector as a C string; the body is `out.size - 1` bytes. The
+/// stored `Trap.message_len` is the body alone — this function and
+/// `wasm_trap_new` are the only two places the NUL exists.
 pub export fn wasm_trap_message(t: ?*const Trap, out: ?*wasm_c_api.ByteVec) callconv(.c) void {
     const out_ptr = out orelse return;
     out_ptr.* = .{ .size = 0, .data = null };
@@ -293,7 +308,9 @@ pub export fn wasm_trap_message(t: ?*const Trap, out: ?*wasm_c_api.ByteVec) call
     const store = handle.store orelse return;
     const alloc = wasm_c_api.storeAllocator(store) orelse return;
     const ptr = handle.message_ptr orelse return;
-    const copy = alloc.dupe(u8, ptr[0..handle.message_len]) catch return;
+    const copy = alloc.alloc(u8, handle.message_len + 1) catch return;
+    @memcpy(copy[0..handle.message_len], ptr[0..handle.message_len]);
+    copy[handle.message_len] = 0;
     out_ptr.* = .{ .size = copy.len, .data = copy.ptr };
 }
 
@@ -477,8 +494,37 @@ test "wasm_trap_new / message / delete: round-trip from caller-supplied message"
     var out: wasm_c_api.ByteVec = .{ .size = 0, .data = null };
     wasm_trap_message(trap, &out);
     defer wasm_c_api.wasm_byte_vec_delete(&out);
-    try testing.expectEqual(@as(usize, 12), out.size);
-    try testing.expectEqualStrings("host failure", out.data.?[0..out.size]);
+    // #441 — 12 body bytes plus the NUL `wasm_message_t` promises.
+    try testing.expectEqual(@as(usize, 13), out.size);
+    try testing.expectEqualStrings("host failure", out.data.?[0 .. out.size - 1]);
+    try testing.expectEqual(@as(u8, 0), out.data.?[out.size - 1]);
+}
+
+test "#441: the message round-trips at the same length whether the caller NUL-terminates or not" {
+    const e = wasm_c_api.wasm_engine_new() orelse return error.EngineAllocFailed;
+    defer wasm_c_api.wasm_engine_delete(e);
+    const s = wasm_c_api.wasm_store_new(e) orelse return error.StoreAllocFailed;
+    defer wasm_c_api.wasm_store_delete(s);
+
+    // `wasm_name_new_from_string` shape (body only) and `..._nt` (body + NUL).
+    // Both name the same message, so both must come back the same length —
+    // otherwise a message that crosses the boundary twice grows a NUL per trip.
+    var bare = "host failure".*;
+    var terminated = "host failure\x00".*;
+    const inputs = [_]wasm_c_api.ByteVec{
+        .{ .size = bare.len, .data = &bare },
+        .{ .size = terminated.len, .data = &terminated },
+    };
+    for (inputs) |in| {
+        const trap = wasm_trap_new(s, &in) orelse return error.TrapAllocFailed;
+        defer wasm_trap_delete(trap);
+        var out: wasm_c_api.ByteVec = .{ .size = 0, .data = null };
+        wasm_trap_message(trap, &out);
+        defer wasm_c_api.wasm_byte_vec_delete(&out);
+        try testing.expectEqual(@as(usize, 13), out.size);
+        try testing.expectEqualStrings("host failure", out.data.?[0 .. out.size - 1]);
+        try testing.expectEqual(@as(u8, 0), out.data.?[out.size - 1]);
+    }
 }
 
 test "jitTrapCode: precise codes map to interp-parity kinds; generic bucket is null (ADR-0164 A)" {

--- a/src/api/trap_surface.zig
+++ b/src/api/trap_surface.zig
@@ -76,6 +76,11 @@ pub const TrapKind = enum(u32) {
     // with this trap on AUTO and JIT alike, and AUTO does not retry on the
     // interpreter. The message names the verdict.
     invalid_module = 19,
+    // #431 — the engine that owns the instance has no entry helper for the
+    // call's shape. Not a guest fault and not `binding_error`, which is an
+    // argument or result count that is not the signature's; `.auto` cannot
+    // retry at call time. Which shapes — `wasmFuncCallJit` in `api/instance.zig`.
+    unsupported = 20,
 };
 
 /// `wasm_trap_t` — runtime trap surface. Carries the trap kind +
@@ -123,6 +128,7 @@ pub fn trapMessageFor(kind: TrapKind) []const u8 {
         .out_of_fuel => "all fuel consumed",
         .wasi_exit => "wasi proc_exit",
         .invalid_module => "invalid module",
+        .unsupported => "unsupported call shape",
     };
 }
 

--- a/src/zwasm/instance.zig
+++ b/src/zwasm/instance.zig
@@ -536,6 +536,9 @@ fn jitTrapToError(code: u32) Instance.InvokeError {
         // #233 — an instantiation verdict, never a call-time code: `jitTrapCode`
         // does not mint it, so a call cannot reach this arm.
         .invalid_module => unreachable,
+        // #431 — the C call arm's classification of `UnsupportedEntrySignature`
+        // (`mapJitErr` above maps the error itself); `jitTrapCode` never mints it.
+        .unsupported => unreachable,
     };
 }
 

--- a/test/c_api_conformance/auto_rejects_invalid.c
+++ b/test/c_api_conformance/auto_rejects_invalid.c
@@ -55,6 +55,8 @@ static int probe(wasm_store_t* store, const uint8_t* bytes, size_t len, uint8_t 
     {
         wasm_message_t msg;
         wasm_trap_message(trap, &msg);
+        /* Read as a C string: `wasm_message_t` carries its NUL and counts it in
+         * `size` (#441), so `strstr` stops inside the allocation. */
         int named = msg.data && strstr(msg.data, reason) != NULL;
         if (!named) fprintf(stderr, "%s: trap message \"%s\" does not name %s\n", label, msg.data ? msg.data : "", reason);
         wasm_byte_vec_delete(&msg);

--- a/test/c_api_conformance/host_func_direct_call.c
+++ b/test/c_api_conformance/host_func_direct_call.c
@@ -116,7 +116,9 @@ int main(void) {
     if (!trap) { fputs("refusing host callback reported success\n", stderr); goto cleanup; }
     wasm_byte_vec_t msg = { 0, NULL };
     wasm_trap_message(trap, &msg);
-    int msg_ok = msg.data && msg.size == sizeof(kRefusal) - 1 &&
+    /* `size` counts the terminating NUL (#441), so it matches sizeof on the
+     * string literal, and the compare covers the NUL too. */
+    int msg_ok = msg.data && msg.size == sizeof(kRefusal) &&
                  memcmp(msg.data, kRefusal, msg.size) == 0;
     if (msg.data) wasm_byte_vec_delete(&msg);
     wasm_trap_delete(trap);

--- a/test/c_api_conformance/trap.c
+++ b/test/c_api_conformance/trap.c
@@ -2,7 +2,8 @@
  *
  * Validates the trap surface through the real C ABI: a guest `unreachable`
  * surfaces as a non-null `wasm_trap_t*` from `wasm_func_call`, and
- * `wasm_trap_message` yields a (NUL-terminated) message.
+ * `wasm_trap_message` yields a NUL-terminated message whose size counts
+ * that NUL (#441).
  *
  *   (module (func (export "boom") unreachable))
  *
@@ -53,8 +54,8 @@ int main(void) {
 
     wasm_message_t msg;
     wasm_trap_message(trap, &msg);
-    printf("zwasm c_api_conformance/trap: trapped, message=\"%.*s\"\n",
-           (int) msg.size, msg.data ? msg.data : "");
+    printf("zwasm c_api_conformance/trap: trapped, message=\"%s\"\n",
+           msg.data ? msg.data : "");
     /* a non-null trap with a readable (possibly empty) message = pass */
     rc = 0;
     wasm_byte_vec_delete(&msg);

--- a/test/c_api_conformance/trap_message_nul.c
+++ b/test/c_api_conformance/trap_message_nul.c
@@ -1,0 +1,133 @@
+/* zwasm v2 — C-API conformance: a trap message is NUL-terminated and its size
+ * counts the NUL (issue #441).
+ *
+ * `include/wasm.h:393` types the out-parameter as
+ * `typedef wasm_name_t wasm_message_t;  // null terminated`. Upstream spells
+ * the same string two ways — `wasm_name_new_from_string` sizes it `strlen(s)`,
+ * `wasm_name_new_from_string_nt` sizes it `strlen(s) + 1` — and
+ * `wasm_message_t` is the `_nt` shape. So `size` includes the NUL and a C host
+ * may read the vector with `strstr` / `printf("%s")` without running off the
+ * allocation.
+ *
+ * Two probes:
+ *   1. A guest trap's message: `strlen(data) == size - 1` and `data[size-1]`
+ *      is 0. Before #441 this read `strlen=42` against `size=36`.
+ *   2. Round-trip through `wasm_trap_new`: a host hands its message in both
+ *      shapes (body only, and body + NUL) and gets the same size back, so a
+ *      message crossing the boundary twice does not grow a NUL per trip.
+ *
+ * Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+/* (module (func (export "boom") unreachable)) */
+static const uint8_t kGuest[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+    0x03, 0x02, 0x01, 0x00,
+    0x07, 0x08, 0x01, 0x04, 0x62, 0x6f, 0x6f, 0x6d, 0x00, 0x00,
+    0x0a, 0x05, 0x01, 0x03, 0x00, 0x00, 0x0b,
+};
+
+/* Asserts the contract on one message vector; consumes it. */
+static int check(wasm_message_t* msg, const char* what) {
+    if (!msg->data || msg->size == 0) {
+        fprintf(stderr, "%s: empty message vector\n", what);
+        return 0;
+    }
+    if (msg->data[msg->size - 1] != '\0') {
+        fprintf(stderr, "%s: last byte is %d, not the NUL wasm.h declares\n",
+                what, (int) (unsigned char) msg->data[msg->size - 1]);
+        return 0;
+    }
+    size_t len = strlen(msg->data);
+    if (len != msg->size - 1) {
+        fprintf(stderr, "%s: strlen %zu != size - 1 (%zu) — the string runs past the vector\n",
+                what, len, msg->size - 1);
+        return 0;
+    }
+    printf("trap_message_nul: %s -> size=%zu strlen=%zu \"%s\"\n", what, msg->size, len, msg->data);
+    return 1;
+}
+
+/* A guest `unreachable`: the message zwasm itself produced. */
+static int probe_guest_trap(wasm_store_t* store) {
+    int ok = 0;
+    wasm_module_t* module = NULL;
+    wasm_instance_t* instance = NULL;
+    wasm_extern_vec_t exports = { 0, NULL };
+
+    wasm_byte_vec_t binary = { sizeof(kGuest), (wasm_byte_t*) kGuest };
+    module = wasm_module_new(store, &binary);
+    if (!module) { fputs("wasm_module_new failed\n", stderr); goto cleanup; }
+    wasm_extern_vec_t imports = { 0, NULL };
+    instance = wasm_instance_new(store, module, &imports, NULL);
+    if (!instance) { fputs("instantiate failed\n", stderr); goto cleanup; }
+    wasm_instance_exports(instance, &exports);
+    if (exports.size < 1) { fputs("missing export\n", stderr); goto cleanup; }
+
+    wasm_val_vec_t no_args = { 0, NULL };
+    wasm_val_vec_t no_res = { 0, NULL };
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(exports.data[0]), &no_args, &no_res);
+    if (!trap) { fputs("boom did not trap\n", stderr); goto cleanup; }
+    wasm_message_t msg;
+    wasm_trap_message(trap, &msg);
+    ok = check(&msg, "guest trap");
+    wasm_byte_vec_delete(&msg);
+    wasm_trap_delete(trap);
+
+cleanup:
+    wasm_extern_vec_delete(&exports);
+    if (instance) wasm_instance_delete(instance);
+    if (module) wasm_module_delete(module);
+    return ok;
+}
+
+/* A host message in, the same message out — at the same length either way.
+ * `nt` selects the `wasm_name_new_from_string_nt` shape (NUL inside size). */
+static int probe_round_trip(wasm_store_t* store, int nt, const char* what) {
+    static const char kText[] = "host said no";
+    wasm_byte_vec_t in = { nt ? sizeof(kText) : sizeof(kText) - 1, (wasm_byte_t*) kText };
+    wasm_trap_t* trap = wasm_trap_new(store, &in);
+    if (!trap) { fprintf(stderr, "%s: wasm_trap_new failed\n", what); return 0; }
+
+    wasm_message_t msg;
+    wasm_trap_message(trap, &msg);
+    int ok = check(&msg, what);
+    if (ok && msg.size != sizeof(kText)) {
+        fprintf(stderr, "%s: size %zu != %zu — the round trip changed the length\n",
+                what, msg.size, sizeof(kText));
+        ok = 0;
+    }
+    if (ok && strcmp(msg.data, kText) != 0) {
+        fprintf(stderr, "%s: message came back as \"%s\"\n", what, msg.data);
+        ok = 0;
+    }
+    wasm_byte_vec_delete(&msg);
+    wasm_trap_delete(trap);
+    return ok;
+}
+
+int main(void) {
+    int rc = 1;
+    wasm_engine_t* engine = wasm_engine_new();
+    wasm_store_t* store = engine ? wasm_store_new(engine) : NULL;
+    if (!engine || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    int ok = 1;
+    ok &= probe_guest_trap(store);
+    ok &= probe_round_trip(store, 0, "round trip, body only");
+    ok &= probe_round_trip(store, 1, "round trip, body + NUL");
+    if (ok) rc = 0;
+
+cleanup:
+    if (store) wasm_store_delete(store);
+    if (engine) wasm_engine_delete(engine);
+    return rc;
+}

--- a/test/c_api_conformance/trap_unsupported_shape.c
+++ b/test/c_api_conformance/trap_unsupported_shape.c
@@ -1,0 +1,180 @@
+/* zwasm v2 — C-API conformance: a call shape the engine cannot marshal traps
+ * ZWASM_TRAP_UNSUPPORTED, not ZWASM_TRAP_BINDING_ERROR (issue #431).
+ *
+ *   (module
+ *     (func (export "pair") (result i32 f32) i32.const 1 f32.const 2)
+ *     (func (export "id") (param i32) (result i32) local.get 0))
+ *
+ * `pair` returns a mixed multi-value: the JIT emits wrapper thunks for the
+ * 2-int register-class and 3-int MEMORY-class shapes only, so it has no entry
+ * helper for this one. The binding is right and the module is valid — the
+ * engine simply cannot make the call, which is its own kind. The message names
+ * the shape.
+ *
+ * Four probes:
+ *   JIT    `pair` -> UNSUPPORTED, message naming "(i32 f32)"
+ *   AUTO   `pair` -> UNSUPPORTED — a decline at call time cannot fall back,
+ *                    the instance is already JIT-backed (ADR-0229 covers the
+ *                    instantiation-time decline, not this one)
+ *   INTERP `pair` -> no trap, 1 and 2.0 — the decline is the engine's, not the
+ *                    module's
+ *   JIT    `id` with no argument -> BINDING_ERROR, unchanged: an argument count
+ *                    that is not the signature's is still the embedder's own
+ *
+ * Exits 0 on success.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <wasm.h>
+#include <zwasm.h>
+
+static const uint8_t kGuest[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x01, 0x0b, 0x02, 0x60, 0x00, 0x02, 0x7f, 0x7d, /* type 0: () -> (i32 f32) */
+    0x60, 0x01, 0x7f, 0x01, 0x7f, /* type 1: (i32) -> (i32) */
+    0x03, 0x03, 0x02, 0x00, 0x01, /* func 0: type 0, func 1: type 1 */
+    0x07, 0x0d, 0x02, 0x04, 0x70, 0x61, 0x69, 0x72, 0x00, 0x00,
+    0x02, 0x69, 0x64, 0x00, 0x01, /* export "pair" -> 0, "id" -> 1 */
+    0x0a, 0x10, 0x02,
+    0x09, 0x00, 0x41, 0x01, 0x43, 0x00, 0x00, 0x00, 0x40, 0x0b, /* i32.const 1; f32.const 2 */
+    0x04, 0x00, 0x20, 0x00, 0x0b, /* local.get 0 */
+};
+
+static const char* engine_name(uint8_t kind) {
+    switch (kind) {
+    case ZWASM_ENGINE_AUTO: return "auto";
+    case ZWASM_ENGINE_JIT: return "jit";
+    case ZWASM_ENGINE_INTERP: return "interp";
+    default: return "?";
+    }
+}
+
+/* Instantiate on `engine` and call export `idx` with `args`. Writes the trap
+ * kind to *kind_out (-1 when the call did not trap) and the trap's message to
+ * `msg_out` (empty when there was none). Returns 1 on success. */
+static int call_export(uint8_t engine, size_t idx, wasm_val_vec_t* args, wasm_val_vec_t* results,
+                       int32_t* kind_out, char* msg_out, size_t msg_cap) {
+    int ok = 0;
+    wasm_engine_t* eng = wasm_engine_new();
+    wasm_store_t* store = eng ? wasm_store_new(eng) : NULL;
+    wasm_module_t* module = NULL;
+    wasm_instance_t* instance = NULL;
+    wasm_extern_vec_t exports = { 0, NULL };
+    if (!eng || !store) { fputs("engine/store new failed\n", stderr); goto cleanup; }
+
+    wasm_byte_vec_t binary = { sizeof(kGuest), (wasm_byte_t*) kGuest };
+    module = wasm_module_new(store, &binary);
+    if (!module) { fputs("wasm_module_new failed\n", stderr); goto cleanup; }
+
+    wasm_extern_vec_t imports = { 0, NULL };
+    wasm_trap_t* itrap = NULL;
+    instance = zwasm_instance_new_ex(store, module, &imports, &itrap, engine);
+    if (itrap) wasm_trap_delete(itrap);
+    if (!instance) { fprintf(stderr, "[%s] instantiate failed\n", engine_name(engine)); goto cleanup; }
+
+    wasm_instance_exports(instance, &exports);
+    if (exports.size < 2) { fputs("missing exports\n", stderr); goto cleanup; }
+
+    msg_out[0] = '\0';
+    wasm_trap_t* trap = wasm_func_call(wasm_extern_as_func(exports.data[idx]), args, results);
+    if (!trap) {
+        *kind_out = -1;
+    } else {
+        *kind_out = zwasm_trap_kind(trap);
+        wasm_message_t msg;
+        wasm_trap_message(trap, &msg);
+        /* Copied by size, not read as a C string: zwasm's `wasm_trap_message`
+         * returns exactly the message bytes, where `wasm.h` declares
+         * `wasm_message_t` NUL-terminated (#441). */
+        if (msg.data) {
+            size_t n = msg.size < msg_cap - 1 ? msg.size : msg_cap - 1;
+            memcpy(msg_out, msg.data, n);
+            msg_out[n] = '\0';
+        }
+        wasm_byte_vec_delete(&msg);
+        wasm_trap_delete(trap);
+    }
+    ok = 1;
+
+cleanup:
+    wasm_extern_vec_delete(&exports);
+    if (instance) wasm_instance_delete(instance);
+    if (module) wasm_module_delete(module);
+    if (store) wasm_store_delete(store);
+    if (eng) wasm_engine_delete(eng);
+    return ok;
+}
+
+/* `pair` on an engine that has no helper for its shape. */
+static int probe_declines(uint8_t engine) {
+    wasm_val_t rdata[2];
+    wasm_val_vec_t args = { 0, NULL };
+    wasm_val_vec_t results = { 2, rdata };
+    int32_t kind = -2;
+    char msg[256];
+    if (!call_export(engine, 0, &args, &results, &kind, msg, sizeof(msg))) return 0;
+
+    if (kind != ZWASM_TRAP_UNSUPPORTED) {
+        fprintf(stderr, "[%s] pair: kind=%d, want UNSUPPORTED (%d)%s\n", engine_name(engine),
+                (int) kind, ZWASM_TRAP_UNSUPPORTED,
+                kind == ZWASM_TRAP_BINDING_ERROR ? " — the binding is right, the engine has no helper" : "");
+        return 0;
+    }
+    if (strstr(msg, "(i32 f32)") == NULL) {
+        fprintf(stderr, "[%s] pair: message \"%s\" does not name the shape\n", engine_name(engine), msg);
+        return 0;
+    }
+    printf("trap_unsupported_shape: [%s] pair -> UNSUPPORTED (%s)\n", engine_name(engine), msg);
+    return 1;
+}
+
+/* `pair` on the interpreter: both values come back. */
+static int probe_runs(void) {
+    wasm_val_t rdata[2];
+    wasm_val_vec_t args = { 0, NULL };
+    wasm_val_vec_t results = { 2, rdata };
+    int32_t kind = -2;
+    char msg[256];
+    if (!call_export(ZWASM_ENGINE_INTERP, 0, &args, &results, &kind, msg, sizeof(msg))) return 0;
+
+    if (kind != -1) { fprintf(stderr, "[interp] pair trapped with kind %d\n", (int) kind); return 0; }
+    if (rdata[0].kind != WASM_I32 || rdata[0].of.i32 != 1 ||
+        rdata[1].kind != WASM_F32 || rdata[1].of.f32 != 2.0f) {
+        fprintf(stderr, "[interp] pair returned (%d, %f), want (1, 2.0)\n", (int) rdata[0].of.i32, (double) rdata[1].of.f32);
+        return 0;
+    }
+    printf("trap_unsupported_shape: [interp] pair -> 1, 2.0\n");
+    return 1;
+}
+
+/* `id` called with no argument: the embedder's own error, on the same engine
+ * that declines `pair`. The contrast is the point — one kind must not absorb
+ * the other. */
+static int probe_binding_error(void) {
+    wasm_val_t rdata[1];
+    wasm_val_vec_t args = { 0, NULL };
+    wasm_val_vec_t results = { 1, rdata };
+    int32_t kind = -2;
+    char msg[256];
+    if (!call_export(ZWASM_ENGINE_JIT, 1, &args, &results, &kind, msg, sizeof(msg))) return 0;
+
+    if (kind != ZWASM_TRAP_BINDING_ERROR) {
+        fprintf(stderr, "[jit] id with no argument: kind=%d, want BINDING_ERROR (%d)\n",
+                (int) kind, ZWASM_TRAP_BINDING_ERROR);
+        return 0;
+    }
+    printf("trap_unsupported_shape: [jit] id with no argument -> BINDING_ERROR\n");
+    return 1;
+}
+
+int main(void) {
+    int ok = 1;
+    ok &= probe_declines(ZWASM_ENGINE_JIT);
+    ok &= probe_declines(ZWASM_ENGINE_AUTO);
+    ok &= probe_runs();
+    ok &= probe_binding_error();
+    return ok ? 0 : 1;
+}

--- a/test/c_api_conformance/trap_unsupported_shape.c
+++ b/test/c_api_conformance/trap_unsupported_shape.c
@@ -86,11 +86,12 @@ static int call_export(uint8_t engine, size_t idx, wasm_val_vec_t* args, wasm_va
         *kind_out = zwasm_trap_kind(trap);
         wasm_message_t msg;
         wasm_trap_message(trap, &msg);
-        /* Copied by size, not read as a C string: zwasm's `wasm_trap_message`
-         * returns exactly the message bytes, where `wasm.h` declares
-         * `wasm_message_t` NUL-terminated (#441). */
-        if (msg.data) {
-            size_t n = msg.size < msg_cap - 1 ? msg.size : msg_cap - 1;
+        /* Copied by size rather than read as a C string. `wasm_message_t`
+         * carries its NUL and counts it in `size` (#441), so `size - 1` is the
+         * body; bounding the copy keeps this test independent of that. */
+        if (msg.data && msg.size > 0) {
+            size_t body = msg.size - 1;
+            size_t n = body < msg_cap - 1 ? body : msg_cap - 1;
             memcpy(msg_out, msg.data, n);
             msg_out[n] = '\0';
         }

--- a/test/runners/default_entry_runner.zig
+++ b/test/runners/default_entry_runner.zig
@@ -86,9 +86,11 @@ const rows = [_]Row{
     Row.same("start_section_trap", .{ .exit = 1, .stderr = .{ .contains = "unreachable" } }),
     Row.same("start_section_main_param", .{ .exit = 1, .stderr = .{ .contains = "unreachable" } }),
     // C4 — a shape the JIT cannot call is refused with the reason, not run as
-    // instantiate-only exit 0. `--engine interp` runs it; on `auto` the
-    // JIT-backed instance declines at call time instead — #431's answer,
-    // pinned as it is today.
+    // instantiate-only exit 0. `--engine interp` runs it. On `auto` the call
+    // reaches a JIT-backed instance and cannot fall back, so the decline traps
+    // `unsupported` naming the shape (#431). Only `main_multi_f32` gets there —
+    // the other two return a lone ref result, which the C API's JIT arm does
+    // call (`invokeRefIdx`).
     .{
         .fixture = "main_ref",
         .auto = .{ .exit = 0, .stdout = "null\n" },
@@ -105,7 +107,7 @@ const rows = [_]Row{
     },
     .{
         .fixture = "main_multi_f32",
-        .auto = .{ .exit = 1, .stderr = .{ .contains = "zwasm: trap kind=binding_error" } },
+        .auto = .{ .exit = 1, .stderr = .{ .contains = "zwasm: trap kind=unsupported msg=no JIT entry helper for () -> (i32 f32)" } },
         .interp = .{ .exit = 0, .stdout = "1\n2\n" },
         .jit = jit_cannot_call,
         .cwasm = jit_cannot_call,

--- a/test/runners/fixtures/default_entry/main_multi_f32.wat
+++ b/test/runners/fixtures/default_entry/main_multi_f32.wat
@@ -1,4 +1,5 @@
 ;; `main () -> (i32 f32)`: the interpreter prints both; the JIT has no
 ;; thunk for a mixed multi-value shape, so `--engine jit` / `.cwasm` refuse it
-;; (#220 C4). The default engine declines at call time instead — #431.
+;; (#220 C4). The default engine reaches the same shape at call time, where
+;; there is no falling back, and traps `unsupported` naming it (#431).
 (module (func (export "main") (result i32 f32) i32.const 1 f32.const 2))

--- a/test/runners/wast_runtime_runner.zig
+++ b/test/runners/wast_runtime_runner.zig
@@ -994,6 +994,7 @@ fn trapKindName(k: wasm_c_api.TrapKind) []const u8 {
         // mismatch message, where naming the kind beats naming nothing.
         .wasi_exit => "WasiExit",
         .invalid_module => "InvalidModule", // #233 — an instantiation verdict, not a call-time trap
+        .unsupported => "UnsupportedCallShape", // #431 — the engine declined the call's shape, it did not fault
     };
 }
 


### PR DESCRIPTION
Closes #431. Closes #441. Closes #443.

Three commits, all on what an embedder sees when a call fails: the *kind* it
gets back, the *message* beside it, and what its result buffer holds. #441's text says it should not be
folded here because it would widen the acceptance set — on reading it again
that is wrong. The acceptance-set rule is about which inputs are accepted, and
a terminating NUL changes an output's representation; no module is accepted or
refused differently. Same file, same public surface, and this PR already adds
a path that returns a trap, so they are more honest together.

## 1. The kind (#431)

### The defect

`wasm_func_call` on a valid export with a mixed multi-value result —
`(func (export "pair") (result i32 f32) …)` — returned
`ZWASM_TRAP_BINDING_ERROR`, which says the embedder bound the call wrong. It
did not: the module is valid, the vectors match the signature, and
`--engine interp` returns both values. The JIT emits wrapper thunks for the
2-int register-class and 3-int MEMORY-class shapes only, so `invokeMultiIdx`
declines with `UnsupportedEntrySignature` — and `jitErrToTrap` flattened every
non-`Trap` error into one kind.

Under ADR-0229 a capability decline at *instantiation* falls back to the
interpreter. This decline arrives at *call* time, where the instance is already
JIT-backed and there is nothing to fall back to, so it has to name itself.

### The change

`ZWASM_TRAP_UNSUPPORTED = 20`, appended after `ZWASM_TRAP_INVALID_MODULE`, so
no existing `ZWASM_TRAP_*` value moves. `scripts/check_trap_abi_sync.sh` now
matches 21 constants.

Each exit of the JIT call arm is classified by what actually went wrong:

| Site | Kind | Why |
|---|---|---|
| no signature for the handle; an argument or result count that is not the signature's | `binding_error` | the embedder's own |
| more than 16 params or results; a v128 result; a multi-value shape with no thunk; `UnsupportedEntrySignature` out of any invoke path | `unsupported` | the engine's coverage |
| a ref result whose C handle could not be allocated | `out_of_memory` | neither of the above, and it was `binding_error` before |
| `error.Trap` | the runtime's recorded kind | the guest's own fault, unchanged |

`jitErrKind` is that table as a function, so the split is testable without a
guest. The message names the declined shape:
`no JIT entry helper for () -> (i32 f32)`.

**The interpreter has no site to reclassify** (#431's D4). Its call-time errors
are `runtime.Trap` members plus the host-originated pair, all already mapped by
`mapInterpTrap`; the shape declines it could raise (`UnsupportedConstExpr`) are
instantiation-time. The Zig facade already told the two apart, as
`UnsupportedEngineSignature`.

## 2. The message (#441)

`wasm_trap_message` copied the message bytes alone into a `wasm_message_t`,
which `include/wasm.h:393` types NUL-terminated. Reading it the way the header
describes ran off the allocation — measured `strlen` 42 against a `size` of 36,
the trailing bytes being Zig's Debug poison and, in a release build, whatever
the allocator held.

**`size` includes the NUL**, the shape `wasm_name_new_from_string_nt` produces
(`include/wasm.h:108-118`), so the text is `size - 1` bytes. Upstream spells the
same string both ways on purpose, which is why the choice had to be made and
then stated where the vector is produced.

Only the two boundary functions know about the NUL. `wasm_trap_message` appends
it; `wasm_trap_new` drops a trailing NUL from the caller's vector, so it takes
a host message in either shape; `Trap.message_len` stays the body, and every
internal producer is untouched. That is what makes a message crossing the
boundary in both directions keep its length, which #441 asked for.

The readers that took `size` for the body length move with it: two Zig tests,
the C and Rust host examples, and `host_func_direct_call.c`. `auto_rejects_invalid.c`
already read the vector as a C string and is now correct rather than lucky; a
comment there says so.

## 3. The result buffer (#443)

The JIT arm marshalled results straight into the caller's `wasm_val_vec_t`,
one element at a time. A reference result mints an owned `Ref`, so an element
that could not allocate one returned an out-of-memory trap with the handles
minted before it already written into a buffer the caller does not own once a
trap comes back. Nothing would ever free them.

The elements are staged in a local array — `sig.results.len <= 16` is already
guaranteed above, so no extra allocation — and copied over only when every one
is in hand. That makes "a trap means the caller was handed nothing" true rather
than nearly true. The release is kind-guarded, so a non-reference `of` member
is never read as a pointer, and it frees with the allocator that minted the
handles rather than through `wasm_ref_delete`, which recovers the store's.

Swept by the minting functions rather than by the shape of the loop
(`git grep 'typedResultToCVal(\|refResultToCVal(\|allocRefHandle(' src/api`),
which finds three call sites. The single-reference arm has nothing minted
ahead of its one element; a comment there says so. The interpreter's
`marshalValOut` never returns early — on a failed allocation it yields a null
reference in place of the value, so it strands nothing, though that is a
different question about the same OOM path.

## Not in this PR

- **Widening the thunks so the shape returns values.** A mixed multi-result
  thunk arms neither the signal handler nor the stack limit (#302), so adding
  shapes widens reachability into that gap. Belongs with #302.
- **The CLI's `(binding_error)` label** on `--engine jit` is
  `diagnostic.Kind`, a different enum, and #433 pinned that line's wording. Its
  message already names the reason.

## Tests

- `test/c_api_conformance/trap_unsupported_shape.c` — JIT and AUTO trap
  `UNSUPPORTED` with the shape in the message; INTERP returns 1 and 2.0; the
  same JIT instance still answers `BINDING_ERROR` for a wrong argument count, so
  neither kind absorbs the other.
- Four unit tests in `src/api/instance.zig`, including the `jitErrKind` table.
  Verified red before the fix: both assert `.unsupported`, both found
  `.binding_error`.
- `test-cli-default-entry`'s `main_multi_f32` row now pins
  `zwasm: trap kind=unsupported msg=no JIT entry helper for () -> (i32 f32)`
  where it pinned `binding_error`. The `--engine jit` and `.cwasm` lanes are
  unchanged (#433).
- `test/c_api_conformance/trap_message_nul.c` — a guest trap's message has
  `strlen == size - 1` and a NUL at `size - 1`, and a host message round-trips
  at one length from both input shapes. Verified red: reverting
  `wasm_trap_message` fails it and two older conformance cases with it.
- A `trap_surface.zig` unit test walks the same round trip.
- Two unit tests for #443 over a `(result funcref funcref)` export on the JIT.
  The failure one uses a one-shot failing allocator — `std.testing.FailingAllocator`
  fails everything from its index onward, which would also swallow the trap
  being asserted on — and checks the kind, that a sentinel in the caller's
  buffer survives, and, through `testing.allocator`, that no handle is
  stranded. Verified red: without the staging it reports both
  `expected .i32, found .funcref` and a leaked allocation.

Public prose was grepped by both diffs' identifiers per the working agreement.
`docs/reference/c_api.md` gains the kind in its table, a clause saying the
interpreter fallback is at instantiation only, and the message contract;
`include/zwasm.h` states the same contract beside `zwasm_trap_kind`.
`include/wasm.h` is untouched — it is the upstream copy, and it already said
NUL-terminated.

Local on x86_64-linux: `scripts/gate_commit.sh` full, `zig build test-all`,
`test-c-api-conformance`, `test-cli-default-entry`, `check_trap_abi_sync`.

## Review notes

**Does `size` count the NUL?** Yes, and wasmtime agrees. Its `wasm_trap_message`
(`crates/c-api/src/trap.rs`) builds the body, then `buffer.push(0)` before
handing the vector out, so the NUL is inside the size it reports. That is the
same choice made here, arrived at independently from upstream's `_nt` helper.

**A partial multi-value reference result leaks its earlier handles on OOM.**
Confirmed with a failing allocator, filed as #443, and fixed in the third
commit. Not introduced here — before #431 the same line returned
`binding_error` and stranded the same handles.

**`jitErrKind`'s `else` needs to stay in sync.** A new invoke-time capability
error would silently land in `binding_error`. There is no cheap compile-time
guard: all three invoke paths declare the whole `runner.Error` union, so an
exhaustive walk would have to classify every compile-time-only name, the way
`engine_verdict_test.zig` does for #233's verdict/decline split. That is a
design change, not a drive-by; the docstring states the invariant the `else`
rests on in the meantime.

**The Windows leg's failure is the known ReleaseSafe-lane flake, not this
change.** `test runner failed to respond` on a binary whose six tests are pure
predicate checks (28 ms locally, and they never reach the trap surface). The
same signature, same step and same `16/18 steps succeeded` appeared on
2026-09-11 in runs 34600205332 (`develop/default-entry-one-policy`) and
34611661684 (the merge queue for #433) — and the failing binary differs between
occurrences, so it is the lane, not a test. #433 went green on a re-run.
